### PR TITLE
API Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All options are optional.
 For example, here is how you would add a request count metric using `uber-statsd-client`:
 
 ```javascript
-var app = require('cadence-web/server/index')
+var app = require('cadence-web')
 var createStatsd = require('uber-statsd-client')
 var sdc = createStatsd({
     host: 'statsd.example.com'

--- a/README.md
+++ b/README.md
@@ -19,15 +19,49 @@ Set these environment variables if you need to change their defaults
 | CADENCE_TCHANNEL_PEERS    | Comma-delmited list of tchannel peers         | 127.0.0.1:7933    |
 | CADENCE_TCHANNEL_SERVICE  | Name of the cadence tchannel service to call  | cadence-frontend  |
 | CADENCE_WEB_PORT          | HTTP port to serve on                         | 8088              |
+| CADENCE_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI  |                   |
 
+### Running locally
 
-### Developing locally
-
-`cadence-web` uses all the standard [npm scripts](https://docs.npmjs.com/misc/scripts) to install dependencies, run the server, and run tests. Additionally to develop locally with webpack hot reloading and other conveniences, use
+`cadence-web` uses all the standard [npm scripts](https://docs.npmjs.com/misc/scripts) to install dependencies, run the server, and run tests. Additionally to run locally with webpack hot reloading and other conveniences, use
 
 ```
 npm run dev
 ```
+
+For development and contributing to `cadence-web`, please see the [contributing guide](https://github.com/uber/cadence-web/blob/master/CONTRIBUTING.md).
+
+### API
+
+If you need to extend `cadence-web` to add middleware to the server, you can install `cadence-web` as a dependecy, and it will export the [Koa](http://koajs.com/) web server that has not yet been started or configured. It includes an additional `init` function that will then compose the built-in middleware. This gives you an option to add middleware before or after you call `init` so it will add the middleware at the beginning or the end of the chain, respectively.
+
+#### `init(options)`
+
+All options are optional.
+
+`useWebpack`: If `true`, starts webpack and adds the middleware, otherwise if `false`, it assumes the UI bundle was already built and serves it statically. Defaults to `process.env.NODE_ENV === 'production'`.
+
+`logErrors`: If `true`, thrown errors are logged to `console.error`. Defaults to `true`.
+
+For example, here is how you would add a request count metric using `uber-statsd-client`:
+
+```javascript
+var app = require('cadence-web/server/index')
+var createStatsd = require('uber-statsd-client')
+var sdc = createStatsd({
+    host: 'statsd.example.com'
+})
+
+app.use(async function(ctx, next) {
+  sdc.increment('http.request')
+  await next()
+})
+.init()
+.listen(7000)
+```
+
+
+The [webpack](https://webpack.js.org/) configuration is also exported as `webpackConfig`, and can be modified before calling `init()`.
 
 ### Licence
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "licence": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development node server.js",
-    "start": "NODE_ENV=production node server.js",
+    "start": "npm run build && NODE_ENV=production node server.js",
     "test": "mocha server/test && mocha-chrome http://localhost:8088",
     "build": "webpack",
     "build-production": "NODE_ENV=production npm run build"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cadence-web",
   "version": "0.6.0",
   "description": "Cadence Web UI",
-  "main": "index.js",
+  "main": "server/index.js",
   "licence": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development node server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Cadence Web UI",
   "main": "index.js",
   "licence": "MIT",
@@ -19,12 +19,17 @@
   ],
   "author": "Nathan Black <nathanbl@uber.com>",
   "engines": {
-    "node": "8.9.0",
-    "npm": "5.5.1"
+    "node": "^8",
+    "npm": "^5"
   },
   "dependencies": {
+    "css-loader": "^0.28.7",
     "deepmerge": "^2.0.0",
+    "extract-text-webpack-plugin": "^3.0.1",
+    "file-loader": "^1.1.5",
     "friendly-querystring": "^0.2.0",
+    "html-webpack-plugin": "^2.30.1",
+    "html-webpack-template": "^6.1.0",
     "koa": "^2.3.0",
     "koa-better-error-handler": "^1.3.0",
     "koa-bodyparser": "^4.2.0",
@@ -33,33 +38,30 @@
     "koa-router": "^7.2.1",
     "koa-send": "^4.1.1",
     "koa-static": "^4.0.1",
+    "koa-webpack": "^2.0.3",
     "lodash-es": "^4.17.4",
     "long": "^3.2.0",
     "moment": "^2.19.1",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^3.0.1",
     "tchannel": "^3.9.11",
     "vue": "^2.5.2",
     "vue-async-computed": "^3.3.1",
     "vue-date-range": "^2.2.6",
     "vue-infinite-scroll": "^2.0.2",
+    "vue-loader": "^13.3.0",
     "vue-router": "^3.0.1",
-    "vue-select": "^2.3.0"
+    "vue-select": "^2.3.0",
+    "vue-template-compiler": "^2.5.2",
+    "webpack": "^3.10.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-dom": "^1.7.0",
-    "css-loader": "^0.28.7",
-    "extract-text-webpack-plugin": "^3.0.1",
     "fetch-mock": "^5.13.1",
-    "file-loader": "^1.1.5",
-    "html-webpack-plugin": "^2.30.1",
-    "koa-webpack": "^1.0.0",
     "mocha": "^4.0.1",
     "mocha-chrome": "^1.0.3",
     "nathanboktae-browser-test-utils": "^0.1.0",
-    "stylus": "^0.54.5",
-    "stylus-loader": "^3.0.1",
-    "supertest": "^3.0.0",
-    "vue-loader": "^13.3.0",
-    "vue-template-compiler": "^2.5.2"
+    "supertest": "^3.0.0"
   }
 }

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -41,7 +41,7 @@ before(function(done) {
   process.env.CADENCE_TCHANNEL_PEERS = '127.0.0.1:11343'
   tchanServer.listen(11343, '127.0.0.1', () => done())
 
-  global.app = require('../').init(true).listen()
+  global.app = require('../').init({ useWebpack: false, logErrors: false }).listen()
 })
 
 after(function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,7 @@ const
 module.exports = {
   devtool: 'source-map',
   entry: [
-    development && 'webpack-hot-middleware/client',
-    process.env.TEST_RUN ? './client/test/index' : './client/main'
+    path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
   ].filter(x => x),
   output: {
     path: path.join(__dirname, 'dist'),
@@ -23,12 +22,14 @@ module.exports = {
         NODE_ENV: '"production"'
       }
     }),
-    development && new webpack.HotModuleReplacementPlugin(),
     new ExtractTextPlugin({ filename: development ? 'cadence.css' : 'cadence.[hash].css', allChunks: true }),
     new HtmlWebpackPlugin({
       title: 'Cadence',
       filename: 'index.html',
-      favicon: 'favicon.ico'
+      favicon: 'favicon.ico',
+      template: require('html-webpack-template'),
+      lang: 'en-US',
+      scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
     })
   ].filter(x => x),
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
       title: 'Cadence',
       filename: 'index.html',
       favicon: 'favicon.ico',
+      inject: false,
       template: require('html-webpack-template'),
       lang: 'en-US',
       scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)


### PR DESCRIPTION
Allow usage of `cadence-web` to be extended with middleware on the server, and external scripts on the client for customization like Google Analytics script tags, custom logging middleware, authentication middleware, etc.