### PR TITLE
Quick navigation to recent domains

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -1,47 +1,23 @@
 <script>
+import domainNav from './widgets/domain-navigate.vue'
+
 export default {
   data () {
     return {
       domain: '',
-      editing: false,
-      recentDomains: JSON.tryParse(localStorage.getItem('recent-domains')) || []
-    }
-  },
-  created() {
-    this.recordDomain(this.$route.params.domain)
-  },
-  watch: {
-    '$route'() {
-      this.recordDomain(this.$route.params.domain)
+      editing: false
     }
   },
   methods: {
-    changeDomain() {
-      this.$router.push({
-        path: `/domain/${this.domain}/workflows`,
-        query: this.$router.currentRoute.query
-      })
-      this.editing = false
-      this.recordDomain(this.domain)
-    },
-    recordDomain(domain) {
-      console.log(`recordDomain: ${domain}`)
-      if (domain) {
-        this.recentDomains = this.recentDomains.filter(d => d && d !== domain)
-        this.recentDomains.unshift(domain)
-        console.dir(this.recentDomains)
-        localStorage.setItem('recent-domains', JSON.stringify(this.recentDomains))
-      }
-    },
     clearEdit() {
       this.editing = false
     },
     edit() {
       this.editing = true
-      setTimeout(() => this.$refs.domain.focus(), 10)
+      setTimeout(() => this.$refs.domain.querySelector('input').focus(), 10)
     },
     globalClick(e) {
-      if (this.editing && !this.$refs.domaincontainer.contains(e.target)) {
+      if (this.editing && !this.$refs.domain.contains(e.target)) {
         this.clearEdit()
       }
 
@@ -54,6 +30,9 @@ export default {
         }
       }
     }
+  },
+  components: {
+    'domain-navigate': domainNav
   }
 }
 </script>
@@ -66,14 +45,11 @@ export default {
         <router-link :to="{ name: 'workflows' }">Workflows</router-link>
         <router-link :to="{ name: 'history' }">History</router-link>
       </nav>
-      <div class="domain" v-if="$route.params.domain" ref="domaincontainer">
+      <div class="domain" v-if="$route.params.domain" ref="domain">
         <span v-if="!editing" @click="edit">{{!editing && $route.params.domain}}</span>
-        <input type="text" name="domain" spellcheck="false" autocorrect="off"
-           v-if="editing"
-           v-model="domain"
-           ref="domain"
-           @keydown.enter="changeDomain"
-           @keydown.esc="clearEdit"
+        <domain-navigate v-if="editing"
+          @navigate="clearEdit"
+          @cacnel="clearEdit"
         />
       </div>
     </header>
@@ -131,6 +107,27 @@ header.top-bar
     input
       background-color alpha(white, 10%)
       color inverted-text-color
+    .validation
+      display none
+    ul.recent-domains
+      position absolute
+      top 100%
+      width 100%
+      left inline-spacing-medium
+      background-color uber-black
+      border 1px solid uber-black-80
+      z-index 5
+      h3
+        font-size 11px
+        text-transform uppercase
+        font-weight 500
+        padding 8px
+      a
+        line-height 2em
+        padding 0 inline-spacing-small
+        text-transform none
+      li:nth-child(2n)
+        background-color rgba(255,255,255,0.1)
     span
       cursor pointer
       transition smooth-transition

--- a/client/main.js
+++ b/client/main.js
@@ -44,6 +44,12 @@ Object.getPrototypeOf(router).replaceQueryParam = function(prop, val) {
   this.replace({ query: newQuery })
 }
 
+JSON.tryParse = function() {
+  try {
+    return JSON.parse.apply(this, arguments)
+  } catch (e) {}
+}
+
 Vue.mixin({
   created: function () {
     if (typeof Scenario === 'undefined') {

--- a/client/routes/History.vue
+++ b/client/routes/History.vue
@@ -106,9 +106,7 @@ export default pagedGrid({
       if (Array.isArray(this.results)) {
         this.results.forEach(r => {
           hash[r.eventId] = r
-          Object.defineProperty(r, 'children', {
-            value: []
-          })
+          r.children.length = 0
         })
 
         for (let r of this.results) {
@@ -143,6 +141,9 @@ export default pagedGrid({
         this.loading = false
         this.prevResults = (this.prevResults || []).concat(res.history.events.map(data => {
           data.timestamp = moment(data.timestamp)
+          Object.defineProperty(data, 'children', {
+            value: []
+          })
           return data
         }))
 

--- a/client/routes/Intro.vue
+++ b/client/routes/Intro.vue
@@ -9,29 +9,19 @@
     <a href="https://github.com/uber/cadence"
       target="_blank" rel="noopener noreferrer">Source code on GitHub</a>
     <p>Otherwise, provide your team's domain to get started</p>
-    <input type="text"
-      placeholder="cadence-canary"
-      v-model="domain"
-      @keydown.enter="goToDomain"
-    />
-    <ul class="recent-domains" v-if="$parent.recentDomains.length">
-      <h3>Recent Domains</h3>
-      <li v-for="domain in $parent.recentDomains">
-        <a :href="`/domain/${domain}/workflows`">{{domain}}</a>
-      </li>
-    </ul>
+    <domain-navigation type="text" placeholder="cadence-canary" />
   </section>
 </template>
 
 <script>
+import domainNav from '../widgets/domain-navigate.vue'
+
 export default {
   data() {
-    return { domain: '' }
+    return {}
   },
-  methods: {
-    goToDomain: function() {
-      this.$router.push(`/domain/${this.domain}/workflows`)
-    }
+  components: {
+    'domain-navigation': domainNav
   }
 }
 </script>
@@ -45,14 +35,17 @@ section.intro
   margin layout-spacing-large auto 0
   h1
     margin-bottom base-font-size
-  p, h3
+  p, h3, .domain-navigation
     margin 1em 0
   a
     line-height 2.5em
     &:nth-child(2n)
       background none
+  .domain-navigation
+    max-width 400px
+    input
+      margin 0
   .recent-domains
-    margin-top layout-spacing-large
     li
       padding 0 inline-spacing-medium
 </style>

--- a/client/routes/Intro.vue
+++ b/client/routes/Intro.vue
@@ -2,20 +2,24 @@
   <section class="intro">
     <h1>Welcome to Cadence!</h1>
     <p>If you are new to Cadence, here's some resources to get you started!</p>
-    <ul>
-      <li><a href="https://www.youtube.com/watch?v=-BuIkhlc-RM&amp;t=3s"
-        target="_blank" rel="noopener noreferrer">Introductory to Cadence Video</a></li>
-      <li><a href="https://github.com/samarabbas/cadence-samples"
-        target="_blank" rel="noopener noreferrer">Code Samples</a></li>
-      <li><a href="https://github.com/uber/cadence"
-        target="_blank" rel="noopener noreferrer">Source code on GitHub</a></li>
-    </ul>
+    <a href="https://www.youtube.com/watch?v=-BuIkhlc-RM&amp;t=3s"
+        target="_blank" rel="noopener noreferrer">Introductory to Cadence Video</a>
+    <a href="https://github.com/samarabbas/cadence-samples"
+      target="_blank" rel="noopener noreferrer">Code Samples</a>
+    <a href="https://github.com/uber/cadence"
+      target="_blank" rel="noopener noreferrer">Source code on GitHub</a>
     <p>Otherwise, provide your team's domain to get started</p>
     <input type="text"
       placeholder="cadence-canary"
       v-model="domain"
       @keydown.enter="goToDomain"
     />
+    <ul class="recent-domains" v-if="$parent.recentDomains.length">
+      <h3>Recent Domains</h3>
+      <li v-for="domain in $parent.recentDomains">
+        <a :href="`/domain/${domain}/workflows`">{{domain}}</a>
+      </li>
+    </ul>
   </section>
 </template>
 
@@ -41,10 +45,14 @@ section.intro
   margin layout-spacing-large auto 0
   h1
     margin-bottom base-font-size
-  > p, > ul
+  p, h3
     margin 1em 0
-  li
+  a
     line-height 2.5em
     &:nth-child(2n)
       background none
+  .recent-domains
+    margin-top layout-spacing-large
+    li
+      padding 0 inline-spacing-medium
 </style>

--- a/client/routes/event-node.vue
+++ b/client/routes/event-node.vue
@@ -46,12 +46,6 @@ export default {
       ])
     }
 
-    function bleck(l, n) {
-      console.log(new Array(l).fill('  ').join('') + n.eventId)
-      n.children.forEach(c => bleck(l + 2, c))
-    }
-    //bleck(0, this.node)
-
     return eventNode(this.node, true)
   }
 }

--- a/client/styles/select.styl
+++ b/client/styles/select.styl
@@ -15,6 +15,9 @@ main .v-select
   &.unsearchable input[type="search"]
     width 10px !important
 
+  .dropdown-toggle button.clear
+    display none
+
   ul.dropdown-menu
     max-height initial !important
     overflow auto

--- a/client/test/intro.test.js
+++ b/client/test/intro.test.js
@@ -19,13 +19,39 @@ describe('Intro', function() {
     headerBar.should.not.contain('nav').and.not.contain('div.domain')
   })
 
-  it('should go to the workflows of the domain requested when entered', async function() {
+  it('should validate the existance of domains as the user types', async function () {
     var [testEl, scenario] = new Scenario(this.test).go(),
-        domainInput = await testEl.waitUntilExists('.intro input')
+        domainNav = await testEl.waitUntilExists('.intro .domain-navigation'),
+        domainInput = domainNav.querySelector('input')
 
     domainInput.value.should.be.empty
+    domainNav.should.have.class('validation-unknown').and.not.have.class('.validation-valid')
+    domainNav.should.not.have.descendant('ul.recent-domains')
+
+    scenario.api.getOnce('/api/domain/ci-', 404)
+    domainInput.input('ci-')
+
+    await retry(() => domainNav.should.have.class('validation-invalid'))
+
+    await Promise.delay(50)
+
+    domainInput.trigger('keydown', { code: 13, keyCode: 13, key: 'Enter' })
+    await Promise.delay(50)
+
+    scenario.api.getOnce('/api/domain/ci-tests', 200)
     domainInput.input('ci-tests')
 
+    await retry(() => domainNav.should.have.class('validation-valid'))
+  })
+
+  it('should go to the workflows of the domain requested when entered', async function() {
+    var [testEl, scenario] = new Scenario(this.test).go(),
+        domainInput = await testEl.waitUntilExists('.intro .domain-navigation input')
+
+    scenario.api.getOnce('/api/domain/ci-tests', 200)
+    domainInput.input('ci-tests')
+
+    await testEl.waitUntilExists('.domain-navigation.validation-valid')
     scenario.withDomain('ci-tests').withWorkflows('open')
     domainInput.trigger('keydown', { code: 13, keyCode: 13, key: 'Enter' })
 
@@ -35,5 +61,21 @@ describe('Intro', function() {
     headerBar.should.have.descendant('nav')
     headerBar.should.have.descendant('div.domain').that.contains.text('ci-test')
     scenario.location.should.contain('/domain/ci-tests/workflows')
+    localStorage.getItem('recent-domains').should.equal('["ci-tests"]')
+  })
+
+  it('should show recent domains with links to them', async function () {
+    localStorage.setItem('recent-domains', JSON.stringify(['demo', 'ci-tests']))
+    var [testEl, scenario] = new Scenario(this.test).go(),
+        recentDomains = await testEl.waitUntilExists('.domain-navigation ul.recent-domains')
+
+    recentDomains.should.have.descendant('h3').with.trimmed.text('Recent Domains')
+    recentDomains.textNodes('li a').should.deep.equal(['demo', 'ci-tests'])
+
+    recentDomains.querySelectorAll('li a')[1].trigger('click')
+    scenario.withDomain('ci-tests').withWorkflows('open')
+
+    await testEl.waitUntilExists('section.workflows')
+    localStorage.getItem('recent-domains').should.equal('["ci-tests","demo"]')
   })
 })

--- a/client/widgets/domain-navigate.vue
+++ b/client/widgets/domain-navigate.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="domain-navigation" :class="'validation-' + validation">
+    <div class="input-wrapper">
+      <input type="text" name="domain" spellcheck="false" autocorrect="off"
+        ref="input"
+        v-bind:value="d"
+        :placeholder="$props.placeholder"
+        @input="onInput"
+        @keydown.enter="changeDomain"
+        @keydown.esc="onEsc"
+      />
+    </div>
+    <p :class="'validation validation-' + validation">{{validationMessage}}</p>
+    <ul class="recent-domains" v-if="recentDomains.length">
+      <h3>Recent Domains</h3>
+      <li v-for="domain in recentDomains">
+        <a :href="`/domain/${domain}/workflows`" :data-domain="domain" @click="goToRecentDomain">{{domain}}</a>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+import debounce from 'lodash-es/debounce'
+
+const validationMessages = {
+  valid: d => `${d} exists`,
+  invalid: d => `${d} does not exist`,
+  error: d => `An error occoured while querying for ${d}`,
+}
+
+export default {
+  props: ['domain', 'placeholder'],
+  data() {
+    return {
+      d: this.$props.domain,
+      validation: 'unknown',
+      validationRequest: undefined,
+      validationMessage: undefined,
+      recentDomains: JSON.tryParse(localStorage.getItem('recent-domains')) || []
+    }
+  },
+  created() {
+    if (this.$route && this.$route.params && this.$route.params.domain) {
+      this.recordDomain(this.$route.params.domain)
+    }
+  },
+  methods: {
+    recordDomain(domain) {
+      console.log(`recordDomain: ${domain}`)
+      if (domain) {
+        this.recentDomains = this.recentDomains.filter(d => d && d !== domain).slice(0, 9)
+        this.recentDomains.unshift(domain)
+        console.dir(this.recentDomains)
+        localStorage.setItem('recent-domains', JSON.stringify(this.recentDomains))
+      }
+    },
+    changeDomain() {
+      if (this.validation === 'valid') {
+        this.$router.push({
+          path: `/domain/${this.d}/workflows`,
+          query: this.$router.currentRoute.query
+        })
+        this.recordDomain(this.d)
+        this.$emit('navigate', this.d)
+      }
+    },
+    goToRecentDomain(e) {
+      this.d = e.target.getAttribute('data-domain')
+      this.validation = 'valid'
+      this.changeDomain()
+    },
+    checkValidity: debounce(function (x) {
+      const check = newDomain => {
+        this.validation = 'pending'
+        this.validationRequest = this.$http(`/api/domain/${newDomain}`).then(
+          () => 'valid',
+          res => res.status === 404 ? 'invalid' : 'error'
+        ).then(v => {
+          this.$emit('validate', this.d, v)
+          if (v in validationMessages) {
+            this.validationMessage = validationMessages[v](this.d)
+          }
+          if (this.d === newDomain || !this.d) {
+            this.validation = this.d ? v : 'unknown'
+            this.validationRequest = null
+          } else {
+            check.call(this, this.d)
+          }
+        })
+      }
+
+      if (!this.validationRequest && this.d) {
+        check(this.d)
+      }
+    }, 300),
+    onInput() {
+      this.d = this.$refs.input.value
+      this.checkValidity()
+    },
+    onEsc(e) {
+      this.$emit('cancel', e)
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@require "../styles/definitions.styl"
+
+validation(color, symbol)
+  input
+    border-color color
+    &:focus
+      outline color auto 2px
+  &::after
+    background-color color
+    content symbol
+
+.domain-navigation
+  display flex
+  flex-direction column
+  div.input-wrapper
+    display flex
+    position relative
+    flex 1 1 auto
+    input
+      flex 1 1 auto
+    &::after
+      position absolute
+      right 18px
+      font-size 11px
+      size = 16px
+      width size
+      height size
+      border-radius size
+      top "calc(50% - %s)" % (size/2)
+      color white
+      display flex
+      justify-content center
+      align-items center
+  &.validation-invalid .input-wrapper
+    validation(uber-orange, '✕')
+  &.validation-valid .input-wrapper
+    validation(uber-green, '✔')
+  &.validation-pending .input-wrapper::after
+    background none
+    border 2px solid uber-black-40
+    border-bottom-color transparent
+    animation spin 600ms linear infinite
+    content ' '
+  .validation-message
+    line-height 1.5em
+  ul
+    display block
+</style>

--- a/client/widgets/domain-navigate.vue
+++ b/client/widgets/domain-navigate.vue
@@ -47,11 +47,9 @@ export default {
   },
   methods: {
     recordDomain(domain) {
-      console.log(`recordDomain: ${domain}`)
       if (domain) {
         this.recentDomains = this.recentDomains.filter(d => d && d !== domain).slice(0, 9)
         this.recentDomains.unshift(domain)
-        console.dir(this.recentDomains)
         localStorage.setItem('recent-domains', JSON.stringify(this.recentDomains))
       }
     },

--- a/server/routes.js
+++ b/server/routes.js
@@ -5,6 +5,13 @@ const
   Long = require('long'),
   momentToLong = m => Long.fromValue(m.unix()).mul(1000000000)
 
+router.get('/api/domain/:domain', async function (ctx) {
+  const domainInfo = await ctx.cadence.describeDomain({ name: ctx.params.domain })
+  if (domainInfo) {
+    ctx.body = domainInfo.domainInfo
+  }
+})
+
 async function listWorkflows(state, ctx) {
   var q = ctx.query || {},
       startTime = moment(q.startTime || NaN),

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -29,6 +29,8 @@ before(function(done) {
     var body = currTest[mockName](body, req)
     if (body instanceof Error) {
       cb(body)
+    } else if (body && body.ok === false) {
+      cb(null, body)
     } else {
       cb(null, { ok: true, head, body })
     }
@@ -37,6 +39,7 @@ before(function(done) {
   tchan.register(tchanServer, 'WorkflowService::ListOpenWorkflowExecutions', {}, handler)
   tchan.register(tchanServer, 'WorkflowService::ListClosedWorkflowExecutions', {}, handler)
   tchan.register(tchanServer, 'WorkflowService::GetWorkflowExecutionHistory', {}, handler)
+  tchan.register(tchanServer, 'WorkflowService::DescribeDomain', {}, handler)
 
   process.env.CADENCE_TCHANNEL_PEERS = '127.0.0.1:11343'
   tchanServer.listen(11343, '127.0.0.1', () => done())

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -102,3 +102,40 @@ describe('Listing Workflows', function() {
       .expect(400)
   })
 })
+
+describe('Describe Domain', function() {
+  it('should describe the domain', async function () {
+    const domainInfo = {
+      name: 'test-domain',
+      status: 'REGISTERED',
+      description: 'ci test domain'
+    }
+
+    this.test.DescribeDomain = ({ describeRequest }) => {
+      describeRequest.name.should.equal('test-domain')
+      return { domainInfo }
+    }
+
+    return request(global.app)
+      .get('/api/domain/test-domain')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect(Object.assign({ ownerEmail: null }, domainInfo))
+  })
+
+  it('should return 404 if the domain is not found', async function () {
+    this.test.DescribeDomain = ({ describeRequest }) => ({
+      ok: false,
+      body: { message: `domain "${describeRequest.name}" does not exist`},
+      typeName: 'entityNotExistError'
+    })
+
+    return request(global.app)
+      .get('/api/domain/nonexistant')
+      .expect(404)
+      .expect('Content-Type', /json/)
+      .expect({
+        message: 'domain "nonexistant" does not exist'
+      })
+  })
+})


### PR DESCRIPTION
Keep track of the user's domains they have visited, and provide links to the most recent 10, in order of recency on the Intro page and the domain header navigation.

![image](https://user-images.githubusercontent.com/1989335/36916014-87b21cc2-1e07-11e8-8823-b874a2715282.png)

![image](https://user-images.githubusercontent.com/1989335/36916071-b6da2990-1e07-11e8-99ff-d16f321eb0f7.png)
