### PR TITLE
Add the ability to view a running workflow's stack trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 npm-debug.log
 dist/
+.vscode

--- a/client/App.vue
+++ b/client/App.vue
@@ -42,8 +42,8 @@ export default {
     <header class="top-bar">
       <a href="/" class="uber-icon"><h2>Cadence</h2></a>
       <nav v-if="$route.params.domain">
-        <router-link :to="{ name: 'workflows' }">Workflows</router-link>
-        <router-link :to="{ name: 'history' }">History</router-link>
+        <router-link class="workflows" :to="{ name: 'workflows' }">Workflows</router-link>
+        <router-link class="history" :to="{ name: 'history' }">History</router-link>
       </nav>
       <div class="domain" v-if="$route.params.domain" ref="domain">
         <span v-if="!editing" @click="edit">{{!editing && $route.params.domain}}</span>

--- a/client/App.vue
+++ b/client/App.vue
@@ -59,7 +59,7 @@ export default {
 
 <style lang="stylus">
 @import "https://d1a3f4spazzrp4.cloudfront.net/uber-fonts/4.0.0/superfine.css"
-@import "https://d1a3f4spazzrp4.cloudfront.net/uber-icons/3.13.0/uber-icons.css"
+@import "https://d1a3f4spazzrp4.cloudfront.net/uber-icons/3.14.0/uber-icons.css"
 @require "./styles/definitions"
 @require "./styles/reset"
 
@@ -67,6 +67,7 @@ global-reset()
 
 @import "./styles/base"
 @import "./styles/select"
+@import "./styles/modal"
 
 header.top-bar
   display flex

--- a/client/main.js
+++ b/client/main.js
@@ -3,9 +3,12 @@ import Router from 'vue-router'
 import infiniteScroll from 'vue-infinite-scroll'
 import vSelect from 'vue-select'
 import qs from 'friendly-querystring'
-import DateRangePicker from './widgets/date-range-picker.vue'
 import http from './http'
+
+import DateRangePicker from './widgets/date-range-picker.vue'
 import detailList from './widgets/detail-list.vue'
+import barLoader from './widgets/bar-loader.vue'
+
 import snapscroll from './directives/snapscroll'
 
 import App from './App.vue'
@@ -65,6 +68,7 @@ Vue.use(infiniteScroll)
 Vue.component('v-select', vSelect)
 Vue.component('date-range-picker', DateRangePicker)
 Vue.component('details-list', detailList)
+Vue.component('bar-loader', barLoader)
 Vue.directive('snapscroll', snapscroll)
 
 if (typeof mocha === 'undefined') {

--- a/client/main.js
+++ b/client/main.js
@@ -1,7 +1,8 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import infiniteScroll from 'vue-infinite-scroll'
-import vSelect from 'vue-select'
+import vueSelect from 'vue-select'
+import vueModal from 'vue-js-modal'
 import qs from 'friendly-querystring'
 import http from './http'
 
@@ -65,11 +66,13 @@ Vue.mixin({
 
 Vue.use(Router)
 Vue.use(infiniteScroll)
-Vue.component('v-select', vSelect)
+Vue.use(vueModal)
+Vue.component('v-select', vueSelect)
 Vue.component('date-range-picker', DateRangePicker)
 Vue.component('details-list', detailList)
 Vue.component('bar-loader', barLoader)
 Vue.directive('snapscroll', snapscroll)
+Vue.config.ignoredElements = ['loader']
 
 if (typeof mocha === 'undefined') {
   if (!document.querySelector('main')) {

--- a/client/routes/History.vue
+++ b/client/routes/History.vue
@@ -198,9 +198,10 @@ export default pagedGrid({
       downloadEl.style.display = 'none'
       document.body.appendChild(downloadEl)
 
-      downloadEl.click()
-
-      document.body.removeChild(downloadEl)
+      if (typeof Mocha === 'undefined') {
+        downloadEl.click()
+        document.body.removeChild(downloadEl)
+      }
     },
     viewStackTrace() {
       var domain = this.$route.params.domain, q = this.$route.query || {}

--- a/client/routes/History.vue
+++ b/client/routes/History.vue
@@ -17,16 +17,21 @@
           @input="debouncedSetQuery" />
           <label for="runId">Run ID</label>
       </div>
-      <a href="#" class="export" @click="exportResults">Export</a>
     </header>
-    <header class="actions">
-      <label for="workflowId">View Format</label>
-      <div class="view-formats">
-        <a href="#" class="compact" @click.prevent="setFormat('compact')" :class="format === 'compact' ? 'active' : ''">Compact</a>
-        <a href="#" class="grid" @click.prevent="setFormat('grid')" :class="format === 'grid' ? 'active' : ''">Grid</a>
-        <a href="#" class="json" @click.prevent="setFormat('json')" :class="format === 'json' ? 'active' : ''">JSON</a>
+    <header class="controls">
+      <div class="view-format">
+        <label for="format">View Format</label>
+        <div class="view-formats">
+          <a href="#" class="compact" @click.prevent="setFormat('compact')" :class="format === 'compact' ? 'active' : ''">Compact</a>
+          <a href="#" class="grid" @click.prevent="setFormat('grid')" :class="format === 'grid' ? 'active' : ''">Grid</a>
+          <a href="#" class="json" @click.prevent="setFormat('json')" :class="format === 'json' ? 'active' : ''">JSON</a>
+        </div>
+        <span class="is-running" :data-is-running="JSON.stringify(isWorkflowRunning)"><bar-loader /></span>
       </div>
-      <span class="is-running" :data-is-running="JSON.stringify(isWorkflowRunning)"><bar-loader /> Workflow </span>
+      <div class="actions">
+        <a href="#" class="stack-trace" @click="viewStackTrace" v-if="isWorkflowRunning">Stack Trace</a>
+        <a href="#" class="export" @click="exportResults">Export</a>
+      </div>
     </header>
     <section class="results"
       v-infinite-scroll="nextPage"
@@ -61,6 +66,16 @@
     </section>
     <span class="error" v-if="error">{{error}}</span>
     <span class="no-results" v-if="showNoResults">No Results</span>
+    <modal name="stack-trace">
+      <header>
+        <h2>Stack Trace</h2>
+        <span v-if="stackTraceTimestamp">as of {{stackTraceTimestamp.format('lll')}}</span>
+        <a href="#" class="close" @click="$modal.hide('stack-trace')"></a>
+      </header>
+
+      <pre v-if="typeof stackTrace === 'string'">{{stackTrace}}</pre>
+      <span class="error" v-if="stackTrace && stackTrace.message">{{JSON.stringify(stackTrace)}}</span>
+    </modal>
   </section>
 </template>
 
@@ -78,6 +93,8 @@ export default pagedGrid({
       nextPageToken: undefined,
       results: [],
       isWorkflowRunning: undefined,
+      stackTrace: undefined,
+      stackTraceTimestamp: undefined,
       get queryUrl() {
         var
           domain = vm.$route.params.domain,
@@ -91,13 +108,14 @@ export default pagedGrid({
   props: ['format'],
   created() {
     this.$watch(() => {
-      if (!this.nextPageToken) return this.queryUrl
+      if (!this.nextPageToken || !this.queryUrl) return this.queryUrl
       return this.queryUrl + '&nextPageToken=' + encodeURIComponent(this.nextPageToken)
     }, v => this.fetch(v), { immediate: true })
 
     this.$watch('queryUrl', (v, old) => {
       this.results = []
       this.nextPageToken = undefined
+      this.isWorkflowRunning = undefined
     })
   },
   computed: {
@@ -131,14 +149,17 @@ export default pagedGrid({
   },
   methods: {
     fetch(pagedQueryUrl) {
-      if (!pagedQueryUrl) return
-
       this.error = undefined
+      if (!pagedQueryUrl) {
+        this.loading = false
+        return
+      }
+
       this.loading = true
       this.pqu = pagedQueryUrl
       return this.$http(pagedQueryUrl).then(res => {
-        if (this._isDestroyed) return
-        if (res.nextPageToken && this.npt === res.nextPageToken && this.pqu === pagedQueryUrl) {
+        if (this._isDestroyed || this.pqu !== pagedQueryUrl) return
+        if (res.nextPageToken && this.npt === res.nextPageToken) {
           // nothing happened, and same query is still valid, so let's long pool again
           return this.fetch(pagedQueryUrl)
         }
@@ -159,6 +180,7 @@ export default pagedGrid({
         setImmediate(() => this.$emit('longpoll'))
         return this.results
       }).catch(e => {
+        if (this._isDestroyed || this.pqu !== pagedQueryUrl) return
         this.npt = undefined
         this.loading = false
         this.error = (e.json && e.json.message) || e.status || e.message
@@ -179,6 +201,14 @@ export default pagedGrid({
       downloadEl.click()
 
       document.body.removeChild(downloadEl)
+    },
+    viewStackTrace() {
+      var domain = this.$route.params.domain, q = this.$route.query || {}
+      this.$http.post(`/api/domain/${this.$route.params.domain}/workflows/${encodeURIComponent(q.workflowId)}/${encodeURIComponent(q.runId)}/query/__stack_trace`).then(({ queryResult }) => {
+        this.stackTrace = JSON.parse(atob(queryResult))
+        this.stackTraceTimestamp = moment()
+        this.$modal.show('stack-trace')
+      }).catch(e => this.stackTrace = new Error(e))
     },
     setFormat(format) {
       this.$router.replace({
@@ -203,12 +233,20 @@ export default pagedGrid({
 @require "../styles/definitions.styl"
 
 section.history
-  header
+  > header
     padding inline-spacing-large
+    flex-wrap wrap
     a
       action-button()
     .field
       flex 1 1 auto
+    &.controls
+      justify-content space-between
+      & > div
+        display flex
+        align-items center
+        & > *
+          margin inline-spacing-small
     .view-formats
       display flex
       a
@@ -220,21 +258,36 @@ section.history
 
   paged-grid()
 
-  &:not(.has-results) a.export
+  &:not(.has-results) header .actions
     display none
   &.loading.has-results
     &::after
       content none
 
+  a.export
+    icon-download()
+  a.stack-trace
+    icon-trips()
+
+  [data-modal="stack-trace"]
+    pre
+      padding inline-spacing-small
+      border 1px solid uber-black-60
+      background-color uber-white-20
+      flex 1 1 auto
+
   span.is-running
     &:not([data-is-running="true"]) loader.bar
       display none
-    &[data-is-running="true"]
-      &::after
-        content 'is executing...'
-    &[data-is-running="false"]
-      &::after
-        content 'finished'
+    &::after
+      vertical-align middle
+    @media (min-width: 900px)
+      &[data-is-running="true"]
+        &::after
+          content ' Workflow is executing...'
+      &[data-is-running="false"]
+        &::after
+          content ' Workflow finished'
 
   table
     td:nth-child(3)

--- a/client/styles/definitions.styl
+++ b/client/styles/definitions.styl
@@ -137,11 +137,25 @@ action-button(color = primary-color)
   font-weight 600
   color white
   background-color color
+  white-space nowrap
   &:hover:not([aria-disabled="true"])
     background-color darken(color, 20%)
   &[aria-disabled="true"]
     opacity 0.5
     cursor not-allowed
+
+icon(charcode)
+  &::before
+    font-family 'uber-icons'
+    content charcode
+    margin-right 0.2em
+
+icon-download()
+  icon('\ea21')
+icon-trips()
+  icon('\ea6d')
+icon-delete()
+  icon('\ea1e')
 
 paged-grid()
   .filters, span.error, span.no-results

--- a/client/styles/modal.styl
+++ b/client/styles/modal.styl
@@ -1,0 +1,30 @@
+@require "./definitions"
+
+body .v--modal-overlay
+  display flex
+  justify-content center
+  align-items center
+.v--modal-box.v--modal
+  top initial !important
+  left initial !important
+  width auto !important
+  height auto !important
+  max-width 95vw
+  padding layout-spacing-medium
+  display flex
+  flex-direction column
+  header
+    flex 0 0 auto
+    display flex
+    align-items center
+    margin-bottom layout-spacing-small
+    & > *
+      margin-right 0.2em
+  a.close
+    position absolute
+    color base-text-color
+    icon-delete()
+    vertical-align middle
+    right inline-spacing-medium
+    top layout-spacing-medium
+    padding 4px

--- a/client/test/history.test.js
+++ b/client/test/history.test.js
@@ -36,8 +36,9 @@ describe('History', function() {
     historyEl.querySelector('input[name="runId"]').value.should.be.empty
 
     historyEl.querySelector('section.results table').should.not.be.displayed
-    historyEl.textNodes('header.actions .view-formats a').should.deep.equal(['Compact', 'Grid', 'JSON'])
+    historyEl.textNodes('header.controls .view-formats a').should.deep.equal(['Compact', 'Grid', 'JSON'])
     historyEl.querySelector('.view-formats .compact').should.have.class('active')
+    historyEl.querySelector('header.controls').should.not.contain('a.stack-trace')
 
     await Promise.delay(100)
   })
@@ -73,6 +74,10 @@ describe('History', function() {
     resultsEl.should.not.have.descendant('.compact-view')
     scenario.location.should.equal('/domain/ci-test/history?workflowId=email-daily-summaries&runId=emailRun1&format=json')
   })
+
+  it('should reset state if workflow id and run id are cleared')
+  it('should allow a stack trace to be viewed for a running workflow')
+  it('should download the currently loaded history events as json when export is clicked')
 
   describe('Compact View', function() {
     it('should build a heiarchy of events', async function () {

--- a/client/test/history.test.js
+++ b/client/test/history.test.js
@@ -25,6 +25,25 @@ describe('History', function() {
     }))
   }
 
+  async function runningWfHistoryTest(mochaTest) {
+    var [testEl, scenario] = new Scenario(mochaTest)
+      .withDomain('ci-test')
+      .startingAt('/domain/ci-test/history?workflowId=long-running-op-2&runId=theRunId&format=grid')
+      .withHistory('long-running-op-2', 'theRunId', [{
+        timestamp: moment().toISOString(),
+        eventType: 'WorkflowExecutionStarted',
+        eventId: 1,
+        details: {
+          workflowType: {
+            name: 'long-running-op'
+          }
+        }
+      }].concat(generateActivityEvents(15)), true)
+      .go(true)
+
+    return [await testEl.waitUntilExists('section.history section.results'), scenario]
+  }
+
   it('should have empty inputs and not run a query if directly navigated to', async function () {
     var testEl = new Scenario(this.test)
       .withDomain('ci-test')
@@ -75,14 +94,59 @@ describe('History', function() {
     scenario.location.should.equal('/domain/ci-test/history?workflowId=email-daily-summaries&runId=emailRun1&format=json')
   })
 
-  it('should reset state if workflow id and run id are cleared')
-  it('should allow a stack trace to be viewed for a running workflow')
-  it('should download the currently loaded history events as json when export is clicked')
+  it('should reset state if workflow id and run id are cleared', async function() {
+    var [resultsEl, scenario] = await runningWfHistoryTest(this.test),
+        historyEl = scenario.vm.$el.querySelector('section.history')
+
+    historyEl.should.have.class('has-results').and.have.descendant('a.stack-trace')
+
+    scenario.vm.$el.querySelector('header.top-bar a.history').trigger('click')
+    await retry(() => scenario.location.should.equal('/domain/ci-test/history?'))
+
+    historyEl.should.not.have.class('has-results').and.not.have.descendant('a.stack-trace')
+    await Promise.delay(100)
+  })
+
+  it('should allow a stack trace to be viewed for a running workflow', async function () {
+    var [resultsEl, scenario] = await runningWfHistoryTest(this.test),
+        stackTrace = await scenario.vm.$el.waitUntilExists('section.history .controls a.stack-trace')
+
+    stackTrace.should.have.trimmed.text('Stack Trace')
+    scenario.api.post('/api/domain/ci-test/workflows/long-running-op-2/theRunId/query/__stack_trace', {
+      queryResult: btoa(JSON.stringify('goroutine 1:\n\tat foo.go:56'))
+    })
+    stackTrace.trigger('click')
+
+    var modal = await scenario.vm.$el.waitUntilExists('section.history [data-modal="stack-trace"]')
+    await retry(() => modal.should.have.descendant('header h2').and.have.trimmed.text('Stack Trace'))
+    modal.querySelector('header span').should.contain.text(`as of ${moment().format('ll')}`)
+    modal.querySelector('pre').should.have.text('goroutine 1:\n\tat foo.go:56')
+
+    modal.querySelector('a.close').trigger('click')
+    await retry(() => scenario.vm.$el.querySelector('section.history').should.not.contain('[data-modal="stack-trace"]'))
+  })
+
+  it('should download the currently loaded history events as json when export is clicked', async function () {
+    var [historyEl, scenario] = await historyTest(this.test),
+        exportEl = await scenario.vm.$el.waitUntilExists('section.history .controls a.export')
+
+    exportEl.trigger('click')
+    var downloadEl = document.body.querySelector('a[download]')
+    downloadEl.should.have.attr('download', 'email daily summaries - emailRun1.json')
+
+    var href = decodeURIComponent(downloadEl.getAttribute('href'))
+    var eventsJson = JSON.parse(decodeURIComponent(href).replace('data:text/plain;charset=utf-8,', ''))
+
+    eventsJson.length.should.equal(12)
+    eventsJson.map(e => e.eventType).slice(3,6).should.deep.equal([
+      'DecisionTaskCompleted', 'MarkerRecorded', 'ActivityTaskScheduled'
+    ])
+  })
 
   describe('Compact View', function() {
     it('should build a heiarchy of events', async function () {
       var [historyEl, scenario] = await historyTest(this.test)
-      await historyEl.waitUntilExists('.results tbody tr:nth-child(4)')
+      await historyEl.waitUntilExists('.compact-view > .event-node')
 
       historyEl.textNodes('.compact-view > .event-node > a[data-event-id]').should.deep.equal([
         'WorkflowExecutionStarted', 'DecisionTaskScheduled', 'DecisionTaskScheduled'
@@ -171,22 +235,7 @@ describe('History', function() {
 
 
     it('should request more pages only when the user scrolls to the bottom', async function () {
-      var [testEl, scenario] = new Scenario(this.test)
-        .withDomain('ci-test')
-        .startingAt('/domain/ci-test/history?workflowId=long-running-op-2&runId=theRunId&format=grid')
-        .withHistory('long-running-op-2', 'theRunId', [{
-          timestamp: moment().toISOString(),
-          eventType: 'WorkflowExecutionStarted',
-          eventId: 1,
-          details: {
-            workflowType: {
-              name: 'long-running-op'
-            }
-          }
-        }].concat(generateActivityEvents(15)), true)
-        .go(true)
-
-      var resultsEl = await testEl.waitUntilExists('section.history section.results')
+      var [resultsEl, scenario] = await runningWfHistoryTest(this.test)
       await retry(() => resultsEl.querySelectorAll('tbody tr').should.have.length(16))
 
       resultsEl.scrollTop = 100

--- a/client/test/history.test.js
+++ b/client/test/history.test.js
@@ -98,6 +98,7 @@ describe('History', function() {
     var [resultsEl, scenario] = await runningWfHistoryTest(this.test),
         historyEl = scenario.vm.$el.querySelector('section.history')
 
+    await historyEl.waitUntilExists('.results tbody tr:nth-child(4)')
     historyEl.should.have.class('has-results').and.have.descendant('a.stack-trace')
 
     scenario.vm.$el.querySelector('header.top-bar a.history').trigger('click')

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -114,7 +114,7 @@ Scenario.prototype.withHistory = function(workflowId, runId, events, hasMorePage
 
   const makeToken = () => btoa(JSON.stringify({ NextEventId: this.historyNpt[runId], IsWorkflowRunning: true }))
 
-  var url = `/api/domain/${this.domain}/workflows/history/${encodeURIComponent(workflowId)}/${encodeURIComponent(runId)}?waitForNewEvent=true`,
+  var url = `/api/domain/${this.domain}/workflows/${encodeURIComponent(workflowId)}/${encodeURIComponent(runId)}/history?waitForNewEvent=true`,
       response = Array.isArray(events) ? { history: { events } } : events
 
   if (this.historyNpt[runId]) {

--- a/client/widgets/bar-loader.vue
+++ b/client/widgets/bar-loader.vue
@@ -1,0 +1,38 @@
+<template>
+  <loader class="bar"><div></div><div></div><div></div></loader>
+</template>
+
+<script>
+export default {
+  name: 'bar-loader'
+}
+</script>
+
+<style lang="stylus">
+@require "../styles/definitions.styl"
+
+loader.bar
+  display inline-block
+  > div
+    display inline-block
+    vertical-align middle
+    border 1px solid uber-black-40
+    background-color uber-white-40
+    height 1em
+    width 0.3em
+    margin 0 1px
+    animation wave 2s infinite ease-in-out
+    &:nth-child(2)
+      animation-delay 200ms
+    &:nth-child(3)
+      animation-delay 400ms
+
+@keyframes wave
+  0%, 35%
+    opacity 0.5
+  50%
+    opacity 1
+    transform scale(1.2)
+  65%, 100%
+    opacity 0.5
+</style>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "vue": "^2.5.13",
     "vue-date-range": "^2.2.6",
     "vue-infinite-scroll": "^2.0.2",
+    "vue-js-modal": "^1.3.12",
     "vue-loader": "^13.3.0",
     "vue-router": "^3.0.1",
     "vue-select": "^2.3.0",

--- a/server/routes.js
+++ b/server/routes.js
@@ -34,14 +34,10 @@ async function listWorkflows(state, ctx) {
 router.get('/api/domain/:domain/workflows/open', listWorkflows.bind(null, 'open'))
 router.get('/api/domain/:domain/workflows/closed', listWorkflows.bind(null, 'closed'))
 
-router.get('/api/domain/:domain/workflows/history/:workflowId/:runId', async function (ctx) {
+router.get('/api/domain/:domain/workflows/:workflowId/:runId/history', async function (ctx) {
   var q = ctx.query || {}
 
   ctx.body = await ctx.cadence.getHistory({
-    execution: {
-      workflowId: ctx.params.workflowId,
-      runId: ctx.params.runId
-    },
     nextPageToken: q.nextPageToken ? Buffer.from(q.nextPageToken, 'base64') : undefined,
     waitForNewEvent: 'waitForNewEvent' in q ? true : undefined
   })
@@ -69,6 +65,14 @@ router.get('/api/domain/:domain/workflows/history/:workflowId/:runId', async fun
       }
     })
   }
+})
+
+router.post('/api/domain/:domain/workflows/:workflowId/:runId/query/:queryType', async function (ctx) {
+  ctx.body = await ctx.cadence.queryWorkflow({
+    query: {
+      queryType: ctx.params.queryType
+    }
+  })
 })
 
 router.get('/health', ctx => ctx.body = 'OK')

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -36,10 +36,13 @@ before(function(done) {
     }
   }
 
-  tchan.register(tchanServer, 'WorkflowService::ListOpenWorkflowExecutions', {}, handler)
-  tchan.register(tchanServer, 'WorkflowService::ListClosedWorkflowExecutions', {}, handler)
-  tchan.register(tchanServer, 'WorkflowService::GetWorkflowExecutionHistory', {}, handler)
-  tchan.register(tchanServer, 'WorkflowService::DescribeDomain', {}, handler)
+  [
+    'ListOpenWorkflowExecutions',
+    'ListClosedWorkflowExecutions',
+    'GetWorkflowExecutionHistory',
+    'DescribeDomain',
+    'QueryWorkflow'
+  ].forEach(endpoint => tchan.register(tchanServer, 'WorkflowService::' + endpoint, {}, handler))
 
   process.env.CADENCE_TCHANNEL_PEERS = '127.0.0.1:11343'
   tchanServer.listen(11343, '127.0.0.1', () => done())

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -43,27 +43,25 @@ wfHistoryThrift = [{
 }],
 
 wfHistoryJson = [{
-    eventId: 1,
-    timestamp: '2017-11-14T23:24:10.351Z',
-    eventType: 'WorkflowExecutionStarted',
-    details: wfHistoryThrift[0].workflowExecutionStartedEventAttributes
-  }, {
-    eventId: 2,
-    timestamp: '2017-11-14T23:24:10.351Z',
-    eventType: 'DecisionTaskScheduled',
-    details: wfHistoryThrift[1].decisionTaskScheduledEventAttributes
-  },
-  {
-    eventId: 3,
-    timestamp: '2017-11-14T23:24:27.531Z',
-    eventType: 'DecisionTaskStarted',
-    details: {
-      identity: 'box1@ci-task-queue',
-      requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
-      scheduledEventId: 2,
-    }
+  eventId: 1,
+  timestamp: '2017-11-14T23:24:10.351Z',
+  eventType: 'WorkflowExecutionStarted',
+  details: wfHistoryThrift[0].workflowExecutionStartedEventAttributes
+}, {
+  eventId: 2,
+  timestamp: '2017-11-14T23:24:10.351Z',
+  eventType: 'DecisionTaskScheduled',
+  details: wfHistoryThrift[1].decisionTaskScheduledEventAttributes
+}, {
+  eventId: 3,
+  timestamp: '2017-11-14T23:24:27.531Z',
+  eventType: 'DecisionTaskStarted',
+  details: {
+    identity: 'box1@ci-task-queue',
+    requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
+    scheduledEventId: 2,
   }
-]
+}]
 
 describe('Workflow History', function() {
   it('should forward the request to the cadence frontend with workflowId and runId', function() {
@@ -87,7 +85,7 @@ describe('Workflow History', function() {
     }
 
     return request(global.app)
-      .get('/api/domain/canary/workflows/history/ci%2Fdemo/run1')
+      .get('/api/domain/canary/workflows/ci%2Fdemo/run1/history')
       .expect(200)
       .expect('Content-Type', /json/)
   })
@@ -103,7 +101,7 @@ describe('Workflow History', function() {
     }
 
     return request(global.app)
-      .get('/api/domain/canary/workflows/history/ci%2Fdemo/run1?nextPageToken=cGFnZTI%3D')
+      .get('/api/domain/canary/workflows/ci%2Fdemo/run1/history?nextPageToken=cGFnZTI%3D')
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
@@ -119,11 +117,11 @@ describe('Workflow History', function() {
     }
 
     return request(global.app)
-      .get('/api/domain/canary/workflows/history/ci%2Fdemo/run1?waitForNewEvent=true')
+      .get('/api/domain/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent=true')
       .expect(200)
       .expect('Content-Type', /json/)
       .then(() =>  request(global.app)
-        .get('/api/domain/canary/workflows/history/ci%2Fdemo/run1?waitForNewEvent')
+        .get('/api/domain/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent')
         .expect(200)
       )
   })
@@ -134,9 +132,8 @@ describe('Workflow History', function() {
       nextPageToken: new Buffer('page2')
     })
 
-
     return request(global.app)
-      .get('/api/domain/canary/workflows/history/ci%2Fdemo/run1')
+      .get('/api/domain/canary/workflows/ci%2Fdemo/run1/history')
       .expect(200)
       .expect({
         history: { events: wfHistoryJson },

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -38,10 +38,10 @@ describe('Query Workflow', function() {
 
     return request(global.app)
       .post('/api/domain/canary/workflows/ci%2Fdemo/run1/query/state')
-      .expect(200)
+      .expect(400)
       .expect('Content-Type', /json/)
       .expect({
-        queryResult: Buffer.from('foobar').toString('base64')
+        message: 'that does not make sense'
       })
   })
 })

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -1,0 +1,47 @@
+const request = require('supertest')
+
+describe('Query Workflow', function() {
+  it('should forward the query to the workflow', async function () {
+    this.test.QueryWorkflow = ({ queryRequest }) => {
+      queryRequest.should.deep.equal({
+        domain: 'canary',
+        execution: {
+          workflowId: 'ci/demo',
+          runId: 'run1'
+        },
+        query: {
+          queryType: 'state',
+          queryArgs: null
+        }
+      })
+
+      return { queryResult: Buffer.from('foobar') }
+    }
+
+    return request(global.app)
+      .post('/api/domain/canary/workflows/ci%2Fdemo/run1/query/state')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect({
+        queryResult: Buffer.from('foobar').toString('base64')
+      })
+  })
+
+  it('should forward the body as the query input')
+
+  it('should turn bad requests into 400s', async function () {
+    this.test.QueryWorkflow = () => ({
+      ok: false,
+      body: { message: 'that does not make sense' },
+      typeName: 'badRequestError'
+    })
+
+    return request(global.app)
+      .post('/api/domain/canary/workflows/ci%2Fdemo/run1/query/state')
+      .expect(200)
+      .expect('Content-Type', /json/)
+      .expect({
+        queryResult: Buffer.from('foobar').toString('base64')
+      })
+  })
+})


### PR DESCRIPTION
Using `WorkflowService::QueryWorkflow`, show the user a stack trace for running workflows in the History page.

![image](https://user-images.githubusercontent.com/1989335/37619753-9dd681a0-2b77-11e8-9249-a1c22a3f73a8.png)
