### PR TITLE
Specially handle line-delimited JSON buffers and transform them to JSON

### DIFF
--- a/client/routes/History.vue
+++ b/client/routes/History.vue
@@ -206,7 +206,7 @@ export default pagedGrid({
     viewStackTrace() {
       var domain = this.$route.params.domain, q = this.$route.query || {}
       this.$http.post(`/api/domain/${this.$route.params.domain}/workflows/${encodeURIComponent(q.workflowId)}/${encodeURIComponent(q.runId)}/query/__stack_trace`).then(({ queryResult }) => {
-        this.stackTrace = JSON.parse(atob(queryResult))
+        this.stackTrace = queryResult
         this.stackTraceTimestamp = moment()
         this.$modal.show('stack-trace')
       }).catch(e => this.stackTrace = new Error(e))

--- a/client/routes/History.vue
+++ b/client/routes/History.vue
@@ -293,12 +293,9 @@ section.history
   table
     td:nth-child(3)
       one-liner-ellipsis()
-  section.results pre
+  section.results pre.json
     margin layout-spacing-small
     padding layout-spacing-small
-    border 1px solid uber-black-60
-    background-color uber-white-40
-    overflow auto
   .compact-view
     padding layout-spacing-small
     & > .event-node

--- a/client/styles/base.styl
+++ b/client/styles/base.styl
@@ -108,6 +108,9 @@ pre, code
   font-weight 200
 pre
   overflow auto
+  border 1px solid uber-black-60
+  background-color uber-white-40
+  padding 6px
 
 area-loader
   display block

--- a/client/styles/modal.styl
+++ b/client/styles/modal.styl
@@ -10,6 +10,7 @@ body .v--modal-overlay
   width auto !important
   height auto !important
   max-width 95vw
+  max-height 95vh
   padding layout-spacing-medium
   display flex
   flex-direction column

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -104,7 +104,7 @@ export default {
           taskList: {
             name: 'ci-task-queue'
           },
-          input: btoa('12345\n"bob@example.com"\n"jane@somewhere.com"'),
+          input: [12345, ["bob@example.com", "jane@somewhere.com"]],
           scheduleToCloseTimeoutSeconds: 360,
           scheduleToStartTimeoutSeconds: 180,
           startToCloseTimeoutSeconds: 180,

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -52,7 +52,7 @@ export default {
           taskList: {
             name: 'ci-task-queue'
           },
-          input: btoa('839134\n{"Env":"prod"}'),
+          input:[839134, { env: "prod" }],
           executionStartToCloseTimeoutSeconds: 360,
           taskStartToCloseTimeoutSeconds: 180
         }

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -52,7 +52,7 @@ export default {
           taskList: {
             name: 'ci-task-queue'
           },
-          input: btoa('839134\n{Env:prod}'),
+          input: btoa('839134\n{"Env":"prod"}'),
           executionStartToCloseTimeoutSeconds: 360,
           taskStartToCloseTimeoutSeconds: 180
         }
@@ -104,7 +104,7 @@ export default {
           taskList: {
             name: 'ci-task-queue'
           },
-          input: btoa('12345\n{SliceVal:[bob@example.com,jane@somewhere.com]}'),
+          input: btoa('12345\n"bob@example.com"\n"jane@somewhere.com"'),
           scheduleToCloseTimeoutSeconds: 360,
           scheduleToStartTimeoutSeconds: 180,
           startToCloseTimeoutSeconds: 180,

--- a/client/test/history.test.js
+++ b/client/test/history.test.js
@@ -114,7 +114,7 @@ describe('History', function() {
 
     stackTrace.should.have.trimmed.text('Stack Trace')
     scenario.api.post('/api/domain/ci-test/workflows/long-running-op-2/theRunId/query/__stack_trace', {
-      queryResult: btoa(JSON.stringify('goroutine 1:\n\tat foo.go:56'))
+      queryResult: 'goroutine 1:\n\tat foo.go:56'
     })
     stackTrace.trigger('click')
 

--- a/client/test/history.test.js
+++ b/client/test/history.test.js
@@ -222,16 +222,18 @@ describe('History', function() {
       )
     })
 
-    it('should show details as flattened key-value pairs from parsed json', async function () {
+    it('should show details as flattened key-value pairs from parsed json, except for result and input', async function () {
       var [historyEl, scenario] = await historyTest(this.test),
-          startDetails = await historyEl.waitUntilExists('.results tbody tr:first-child td:nth-child(5)')
+          startDetails = await historyEl.waitUntilExists('.results tbody tr:first-child td:nth-child(5)'),
+          inputPreText = JSON.stringify(fixtures.history.emailRun1[0].details.input, null, 2)
 
       startDetails.textNodes('dl.details dt').should.deep.equal([
         'workflowType.name', 'taskList.name', 'input', 'executionStartToCloseTimeoutSeconds', 'taskStartToCloseTimeoutSeconds'
       ])
       startDetails.textNodes('dl.details dd').should.deep.equal([
-        'email-daily-summaries', 'ci-task-queue', '839134\n{Env:prod}', '360', '180'
+        'email-daily-summaries', 'ci-task-queue', inputPreText, '360', '180'
       ])
+      startDetails.textNodes('dl.details dd pre').should.deep.equal([inputPreText])
     })
 
 

--- a/client/test/index.js
+++ b/client/test/index.js
@@ -20,7 +20,8 @@ document.head.appendChild(mochaCss)
 var extraStyling = document.createElement('style')
 extraStyling.setAttribute('type', 'text/css')
 extraStyling.textContent = `
-#mocha li:nth-child(2n) {
+#mocha li:nth-child(2n),
+#mocha pre {
   background: none;
 }
 

--- a/client/widgets/detail-list.vue
+++ b/client/widgets/detail-list.vue
@@ -1,13 +1,6 @@
-<template>
-  <dl class="details">
-    <div v-for="kvp in kvps">
-      <dt>{{kvp.key}}</dt>
-      <dd>{{format(kvp.value)}}</dd>
-    </div>
-  </dl>
-</template>
-
 <script>
+const jsonKeys = ['result', 'input']
+
 export default {
   name: 'details-list',
   props: ['item'],
@@ -21,7 +14,7 @@ export default {
       function flatten(prefix, obj) {
         Object.entries(obj).forEach(([k, value]) => {
           var key = prefix ? `${prefix}.${k}` : k
-          if (value && typeof value === 'object') {
+          if (value && typeof value === 'object' && !jsonKeys.includes(key)) {
             flatten(key, value)
           } else if (value) {
             kvps.push({ key, value })
@@ -37,6 +30,14 @@ export default {
     format(val) {
       return val == null ? '' : (String(val) || '""')
     }
+  },
+  render(h) {
+    return h('dl', { class: 'details' }, this.kvps.map(kvp => h('div', null, [
+      h('dt', null, kvp.key),
+      h('dd', null, typeof kvp.value === 'object' ?
+        [h('pre', null, JSON.stringify(kvp.value, null, 2))] :
+        kvp.value)
+    ])))
   }
 }
 </script>

--- a/client/widgets/detail-list.vue
+++ b/client/widgets/detail-list.vue
@@ -8,14 +8,6 @@
 </template>
 
 <script>
-function decodeIfNeeded(s) {
-  try {
-    return atob(s)
-  } catch(e) {
-    return s
-  }
-}
-
 export default {
   name: 'details-list',
   props: ['item'],
@@ -31,9 +23,7 @@ export default {
           var key = prefix ? `${prefix}.${k}` : k
           if (value && typeof value === 'object') {
             flatten(key, value)
-          } else if (typeof value === 'string') {
-            kvps.push({ key, value: decodeIfNeeded(value) })
-          } else {
+          } else if (value) {
             kvps.push({ key, value })
           }
         })

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 var app = require('./server/index'),
-    port = port = Number(process.env.CADENCE_WEB_PORT) || 8088,
+    port = Number(process.env.CADENCE_WEB_PORT) || 8088,
     production = process.env.NODE_ENV === 'production'
 
 app.init().listen(port)

--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,8 @@ app.init = function(options) {
   .use(useWebpack ?
     koaWebpack({
       compiler,
-      dev: { stats: { colors: true } }
+      dev: { stats: { colors: true } },
+      hot: { port: process.env.TEST_RUN ? 8082 : 8081 }
     }) :
     require('koa-static')(staticRoot))
   .use(router.routes())

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -33,8 +33,8 @@ function transform(item) {
           item[subkey] = item[subkey][0]
         }
       } catch(e) {
-        item[subkey] = subvalue.toString('base64')
-        item[`${subkey}_utf8`] = stringval
+        item[`${subkey}_base64`] = subvalue.toString('base64')
+        item[subkey] = stringval
       }
     } else if (Array.isArray(subvalue)) {
       subvalue.forEach(transform)

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -20,6 +20,11 @@ function transform(item) {
         item[subkey] = m.toISOString()
       }
     } else if (Buffer.isBuffer(subvalue)) {
+      if (subkey === 'nextPageToken') {
+        item.nextPageToken = subvalue.toString('base64')
+        return
+      }
+
       let stringval = subvalue.toString('utf8')
       try {
         // most of Cadence's uses of buffer is just line-delimited JSON.
@@ -29,9 +34,7 @@ function transform(item) {
         }
       } catch(e) {
         item[subkey] = subvalue.toString('base64')
-        if (subkey !== 'nextPageToken') {
-          item[`${subkey}_utf8`] = stringval
-        }
+        item[`${subkey}_utf8`] = stringval
       }
     } else if (Array.isArray(subvalue)) {
       subvalue.forEach(transform)

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -15,7 +15,10 @@ wfHistoryThrift = [{
       kind: null
     },
     identity: null,
-    input: null,
+    input: Buffer.from(JSON.stringify({
+      emails: ['jane@example.com', 'bob@example.com'],
+      includeFooter: true
+    })),
     taskStartToCloseTimeoutSeconds: 30,
     executionStartToCloseTimeoutSeconds: 1080
   }
@@ -46,7 +49,12 @@ wfHistoryJson = [{
   eventId: 1,
   timestamp: '2017-11-14T23:24:10.351Z',
   eventType: 'WorkflowExecutionStarted',
-  details: wfHistoryThrift[0].workflowExecutionStartedEventAttributes
+  details: Object.assign({}, wfHistoryThrift[0].workflowExecutionStartedEventAttributes, {
+    input: {
+      emails: ['jane@example.com', 'bob@example.com'],
+      includeFooter: true
+    }
+  })
 }, {
   eventId: 2,
   timestamp: '2017-11-14T23:24:10.351Z',
@@ -126,7 +134,7 @@ describe('Workflow History', function() {
       )
   })
 
-  it('should transform Long numbers to JavaScript numbers, and Long dates to ISO date strings', function() {
+  it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => ({
       history: { events: wfHistoryThrift },
       nextPageToken: new Buffer('page2')

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -23,7 +23,8 @@ describe('Query Workflow', function() {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
-        queryResult: Buffer.from('foobar').toString('base64')
+        queryResult: Buffer.from('foobar').toString('base64'),
+        queryResult_utf8: 'foobar'
       })
   })
 

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -23,8 +23,8 @@ describe('Query Workflow', function() {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
-        queryResult: Buffer.from('foobar').toString('base64'),
-        queryResult_utf8: 'foobar'
+        queryResult: 'foobar',
+        queryResult_base64: Buffer.from('foobar').toString('base64')
       })
   })
 

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -30,7 +30,7 @@ describe('Listing Workflows', function() {
       should.not.exist(listRequest.typeFilter)
       return {
         executions: [demoExecThrift],
-        nextPageToken: new Buffer('opentoken')
+        nextPageToken: new Buffer('{"IsWorkflowRunning":true,NextEventId:37}')
       }
     }
 
@@ -40,7 +40,7 @@ describe('Listing Workflows', function() {
       .expect('Content-Type', /json/)
       .expect({
         executions: [demoExecJson],
-        nextPageToken: 'b3BlbnRva2Vu'
+        nextPageToken: 'eyJJc1dvcmtmbG93UnVubmluZyI6dHJ1ZSxOZXh0RXZlbnRJZDozN30='
       })
   })
 
@@ -53,7 +53,7 @@ describe('Listing Workflows', function() {
       should.not.exist(listRequest.typeFilter)
       return {
         executions: [demoExecThrift],
-        nextPageToken: new Buffer('closetoken')
+        nextPageToken: new Buffer('{"IsWorkflowRunning":false}')
       }
     }
 
@@ -63,7 +63,7 @@ describe('Listing Workflows', function() {
       .expect('Content-Type', /json/)
       .expect({
         executions: [demoExecJson],
-        nextPageToken: 'Y2xvc2V0b2tlbg=='
+        nextPageToken: 'eyJJc1dvcmtmbG93UnVubmluZyI6ZmFsc2V9'
       })
   })
 


### PR DESCRIPTION
Since Cadence often uses line-delimited JSON in binary fields like `result` and `input`, specially handle those cases on the server transform level. Also in the UI, handle `result` and `input` and render them in a pre tag to call them out.

![image](https://user-images.githubusercontent.com/1989335/38586767-ee46286c-3cd3-11e8-8f48-9f007ab80202.png)
