### PR TITLE
Migration Webpack v3 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mocha": "^4.0.1",
     "mocha-chrome": "^1.1.0",
     "nathanboktae-browser-test-utils": "^0.1.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "mini-css-extract-plugin" : "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vue-select": "nathanboktae/vue-select#after2.4",
     "vue-split-panel": "^1.0.4",
     "vue-template-compiler": "^2.5.2",
-    "webpack": "^3.10.0"
+    "webpack": "^4.31.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,97 +8,92 @@ const
 	development = !['production', 'ci'].includes(process.env.NODE_ENV)
 
 module.exports = {
-		devtool: 'source-map',
-		entry: [
-			path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
-		].filter(x => x),
-		output: {
-			path: path.join(__dirname, 'dist'),
-			filename: 'cadence.[hash].js',
-			publicPath: '/'
-		},
-		plugins: [
-			!development && new webpack.DefinePlugin({
-				'process.env': {
-					NODE_ENV: '"production"'
-				}
-			}),
-			new MiniCssExtractPlugin({
-				filename: development ? 'cadence.css' : 'cadence.[hash].css',
-			}),
-			new HtmlWebpackPlugin({
-				title: 'Cadence',
-				filename: 'index.html',
-				favicon: 'favicon.ico',
-				inject: false,
-				template: require('html-webpack-template'),
-				lang: 'en-US',
-				scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
-			})
-		].filter(x => x),
-		module: {
-			rules: [{
-					test: /\.css$/,
-					use: [
-						{
-							test: /\.css$/,
-							use: [
-							  {
-								loader: MiniCssExtractPlugin.loader,
-								options: {
-								  hmr: development,
-								},
-							  },
-							  'css-loader',
-							],
-						  },
-					{
-						test: /\.vue?$/,
-						loader: 'vue-loader',
-						options: {
-							loaders: {
-								stylus: ExtractTextPlugin.extract({
-									use: extractStylus,
-									fallback: 'vue-style-loader'
-								}),
-							}
-						}
-					},
-					{
-						test: /\.svg$/,
-						use: [{
-							loader: 'html-loader',
-							options: {
-								minimize: true
-							}
-						}]
-					},
-					{
-						test: /\.(png|jpg|gif)$/,
-						loader: 'file-loader',
-						options: {
-							name: '[name].[ext]?[hash]'
-						}
-					},
-					{
-						test: /\.styl$/,
-						use: ExtractTextPlugin.extract({
-							use: extractStylus,
-							fallback: 'raw-loader'
-						}),
-						include: path.join(__dirname, 'src')
-					}]
-			},
-			resolve: {
-				extensions: ['.js', '.vue']
-			},
-			resolve: {
-				alias: {
-					'vue$': 'vue/dist/vue.esm.js'
-				}
-			},
-			devServer: {
-				historyApiFallback: true,
-				overlay: true
+	devtool: 'source-map',
+	entry: [
+		path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
+	].filter(x => x),
+	output: {
+		path: path.join(__dirname, 'dist'),
+		filename: 'cadence.[hash].js',
+		publicPath: '/'
+	},
+	plugins: [
+		!development && new webpack.DefinePlugin({
+			'process.env': {
+				NODE_ENV: '"production"'
 			}
+		}),
+		new MiniCssExtractPlugin({
+			filename: development ? 'cadence.css' : 'cadence.[hash].css',
+		}),
+		new HtmlWebpackPlugin({
+			title: 'Cadence',
+			filename: 'index.html',
+			favicon: 'favicon.ico',
+			inject: false,
+			template: require('html-webpack-template'),
+			lang: 'en-US',
+			scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
+		})
+	].filter(x => x),
+	module: {
+		rules: [{
+				test: /\.css$/,
+				use: [{
+						loader: MiniCssExtractPlugin.loader,
+						options: {
+							hmr: development,
+						},
+					},
+					'css-loader',
+				],
+			},
+			{
+				test: /\.vue?$/,
+				loader: 'vue-loader',
+				options: {
+					loaders: {
+						stylus: ExtractTextPlugin.extract({
+							use: extractStylus,
+							fallback: 'vue-style-loader'
+						}),
+					}
+				}
+			},
+			{
+				test: /\.svg$/,
+				use: [{
+					loader: 'html-loader',
+					options: {
+						minimize: true
+					}
+				}]
+			},
+			{
+				test: /\.(png|jpg|gif)$/,
+				loader: 'file-loader',
+				options: {
+					name: '[name].[ext]?[hash]'
+				}
+			},
+			{
+				test: /\.styl$/,
+				use: ExtractTextPlugin.extract({
+					use: extractStylus,
+					fallback: 'raw-loader'
+				}),
+				include: path.join(__dirname, 'src')
+			}
+		]
+	},
+	resolve: {
+		extensions: ['.js', '.vue'],
+		alias: {
+			'vue$': 'vue/dist/vue.esm.js'
 		}
+	},
+	devServer: {
+		historyApiFallback: true,
+		overlay: true
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,99 +1,99 @@
 const
-	path = require('path'),
-	webpack = require('webpack'),
-	ExtractTextPlugin = require('extract-text-webpack-plugin'),
-	HtmlWebpackPlugin = require('html-webpack-plugin'),
-	extractStylus = 'css-loader?sourceMap!stylus-loader',
-	MiniCssExtractPlugin = require('mini-css-extract-plugin'),
-	development = !['production', 'ci'].includes(process.env.NODE_ENV)
+  path = require('path'),
+  webpack = require('webpack'),
+  ExtractTextPlugin = require('extract-text-webpack-plugin'),
+  HtmlWebpackPlugin = require('html-webpack-plugin'),
+  extractStylus = 'css-loader?sourceMap!stylus-loader',
+  MiniCssExtractPlugin = require('mini-css-extract-plugin'),
+  development = !['production', 'ci'].includes(process.env.NODE_ENV)
 
 module.exports = {
-	devtool: 'source-map',
-	entry: [
-		path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
-	].filter(x => x),
-	output: {
-		path: path.join(__dirname, 'dist'),
-		filename: 'cadence.[hash].js',
-		publicPath: '/'
-	},
-	plugins: [
-		!development && new webpack.DefinePlugin({
-			'process.env': {
-				NODE_ENV: '"production"'
-			}
-		}),
-		new MiniCssExtractPlugin({
-			filename: development ? 'cadence.css' : 'cadence.[hash].css',
-		}),
-		new HtmlWebpackPlugin({
-			title: 'Cadence',
-			filename: 'index.html',
-			favicon: 'favicon.ico',
-			inject: false,
-			template: require('html-webpack-template'),
-			lang: 'en-US',
-			scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
-		})
-	].filter(x => x),
-	module: {
-		rules: [{
-				test: /\.css$/,
-				use: [{
-						loader: MiniCssExtractPlugin.loader,
-						options: {
-							hmr: development,
-						},
-					},
-					'css-loader',
-				],
-			},
-			{
-				test: /\.vue?$/,
-				loader: 'vue-loader',
-				options: {
-					loaders: {
-						stylus: ExtractTextPlugin.extract({
-							use: extractStylus,
-							fallback: 'vue-style-loader'
-						}),
-					}
-				}
-			},
-			{
-				test: /\.svg$/,
-				use: [{
-					loader: 'html-loader',
-					options: {
-						minimize: true
-					}
-				}]
-			},
-			{
-				test: /\.(png|jpg|gif)$/,
-				loader: 'file-loader',
-				options: {
-					name: '[name].[ext]?[hash]'
-				}
-			},
-			{
-				test: /\.styl$/,
-				use: ExtractTextPlugin.extract({
-					use: extractStylus,
-					fallback: 'raw-loader'
-				}),
-				include: path.join(__dirname, 'src')
-			}
-		]
-	},
-	resolve: {
-		extensions: ['.js', '.vue'],
-		alias: {
-			'vue$': 'vue/dist/vue.esm.js'
-		}
-	},
-	devServer: {
-		historyApiFallback: true,
-		overlay: true
-	}
+  devtool: 'source-map',
+  entry: [
+    path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
+  ].filter(x => x),
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'cadence.[hash].js',
+    publicPath: '/'
+  },
+  plugins: [
+    !development && new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
+    new MiniCssExtractPlugin({
+      filename: development ? 'cadence.css' : 'cadence.[hash].css',
+    }),
+    new HtmlWebpackPlugin({
+      title: 'Cadence',
+      filename: 'index.html',
+      favicon: 'favicon.ico',
+      inject: false,
+      template: require('html-webpack-template'),
+      lang: 'en-US',
+      scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
+    })
+  ].filter(x => x),
+  module: {
+    rules: [{
+        test: /\.css$/,
+        use: [{
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              hmr: development,
+            },
+          },
+          'css-loader',
+        ],
+      },
+      {
+        test: /\.vue?$/,
+        loader: 'vue-loader',
+        options: {
+          loaders: {
+            stylus: ExtractTextPlugin.extract({
+              use: extractStylus,
+              fallback: 'vue-style-loader'
+            }),
+          }
+        }
+      },
+      {
+        test: /\.svg$/,
+        use: [{
+          loader: 'html-loader',
+          options: {
+            minimize: true
+          }
+        }]
+      },
+      {
+        test: /\.(png|jpg|gif)$/,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]?[hash]'
+        }
+      },
+      {
+        test: /\.styl$/,
+        use: ExtractTextPlugin.extract({
+          use: extractStylus,
+          fallback: 'raw-loader'
+        }),
+        include: path.join(__dirname, 'src')
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.vue'],
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js'
+    }
+  },
+  devServer: {
+    historyApiFallback: true,
+    overlay: true
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const
   ExtractTextPlugin = require('extract-text-webpack-plugin'),
   HtmlWebpackPlugin = require('html-webpack-plugin'),
   extractStylus = 'css-loader?sourceMap!stylus-loader',
+  MiniCssExtractPlugin = require('mini-css-extract-plugin'),
   development = !['production', 'ci'].includes(process.env.NODE_ENV)
 
 module.exports = {
@@ -22,7 +23,9 @@ module.exports = {
         NODE_ENV: '"production"'
       }
     }),
-    new ExtractTextPlugin({ filename: development ? 'cadence.css' : 'cadence.[hash].css', allChunks: true }),
+      new MiniCssExtractPlugin({
+      filename: development ? 'cadence.css' : 'cadence.[hash].css',
+    }),
     new HtmlWebpackPlugin({
       title: 'Cadence',
       filename: 'index.html',
@@ -34,7 +37,19 @@ module.exports = {
     })
   ].filter(x => x),
   module: {
-    rules: [{
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {     
+              hmr: development,
+            },
+          },
+          'css-loader',
+      },
+      {
       test: /\.vue?$/,
       loader: 'vue-loader',
       options: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,95 +1,104 @@
 const
-  path = require('path'),
-  webpack = require('webpack'),
-  ExtractTextPlugin = require('extract-text-webpack-plugin'),
-  HtmlWebpackPlugin = require('html-webpack-plugin'),
-  extractStylus = 'css-loader?sourceMap!stylus-loader',
-  MiniCssExtractPlugin = require('mini-css-extract-plugin'),
-  development = !['production', 'ci'].includes(process.env.NODE_ENV)
+	path = require('path'),
+	webpack = require('webpack'),
+	ExtractTextPlugin = require('extract-text-webpack-plugin'),
+	HtmlWebpackPlugin = require('html-webpack-plugin'),
+	extractStylus = 'css-loader?sourceMap!stylus-loader',
+	MiniCssExtractPlugin = require('mini-css-extract-plugin'),
+	development = !['production', 'ci'].includes(process.env.NODE_ENV)
 
 module.exports = {
-  devtool: 'source-map',
-  entry: [
-    path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
-  ].filter(x => x),
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'cadence.[hash].js',
-    publicPath: '/'
-  },
-  plugins: [
-    !development && new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: '"production"'
-      }
-    }),
-      new MiniCssExtractPlugin({
-      filename: development ? 'cadence.css' : 'cadence.[hash].css',
-    }),
-    new HtmlWebpackPlugin({
-      title: 'Cadence',
-      filename: 'index.html',
-      favicon: 'favicon.ico',
-      inject: false,
-      template: require('html-webpack-template'),
-      lang: 'en-US',
-      scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
-    })
-  ].filter(x => x),
-  module: {
-    rules: [
-      {
-        test: /\.css$/,
-        use: [
-          {
-            loader: MiniCssExtractPlugin.loader,
-            options: {     
-              hmr: development,
-            },
-          },
-          'css-loader',
-      },
-      {
-      test: /\.vue?$/,
-      loader: 'vue-loader',
-      options: {
-        loaders: {
-          stylus: ExtractTextPlugin.extract({
-            use: extractStylus,
-            fallback: 'vue-style-loader'
-          }),
-        }
-      }
-    }, {
-      test: /\.svg$/,
-      use: [{
-        loader: 'html-loader',
-        options: {
-          minimize: true
-        }
-      }]
-    }, {
-      test: /\.(png|jpg|gif)$/,
-      loader: 'file-loader',
-      options: {
-        name: '[name].[ext]?[hash]'
-      }
-    }, {
-      test: /\.styl$/,
-      use: ExtractTextPlugin.extract({ use: extractStylus, fallback: 'raw-loader' }),
-      include: path.join(__dirname, 'src')
-    }]
-  },
-  resolve: {
-    extensions: ['.js', '.vue']
-  },
-  resolve: {
-    alias: {
-      'vue$': 'vue/dist/vue.esm.js'
-    }
-  },
-  devServer: {
-    historyApiFallback: true,
-    overlay: true
-  }
-}
+		devtool: 'source-map',
+		entry: [
+			path.join(__dirname, process.env.TEST_RUN ? 'client/test/index' : 'client/main')
+		].filter(x => x),
+		output: {
+			path: path.join(__dirname, 'dist'),
+			filename: 'cadence.[hash].js',
+			publicPath: '/'
+		},
+		plugins: [
+			!development && new webpack.DefinePlugin({
+				'process.env': {
+					NODE_ENV: '"production"'
+				}
+			}),
+			new MiniCssExtractPlugin({
+				filename: development ? 'cadence.css' : 'cadence.[hash].css',
+			}),
+			new HtmlWebpackPlugin({
+				title: 'Cadence',
+				filename: 'index.html',
+				favicon: 'favicon.ico',
+				inject: false,
+				template: require('html-webpack-template'),
+				lang: 'en-US',
+				scripts: (process.env.CADENCE_EXTERNAL_SCRIPTS || '').split(',').filter(x => x)
+			})
+		].filter(x => x),
+		module: {
+			rules: [{
+					test: /\.css$/,
+					use: [
+						{
+							test: /\.css$/,
+							use: [
+							  {
+								loader: MiniCssExtractPlugin.loader,
+								options: {
+								  hmr: development,
+								},
+							  },
+							  'css-loader',
+							],
+						  },
+					{
+						test: /\.vue?$/,
+						loader: 'vue-loader',
+						options: {
+							loaders: {
+								stylus: ExtractTextPlugin.extract({
+									use: extractStylus,
+									fallback: 'vue-style-loader'
+								}),
+							}
+						}
+					},
+					{
+						test: /\.svg$/,
+						use: [{
+							loader: 'html-loader',
+							options: {
+								minimize: true
+							}
+						}]
+					},
+					{
+						test: /\.(png|jpg|gif)$/,
+						loader: 'file-loader',
+						options: {
+							name: '[name].[ext]?[hash]'
+						}
+					},
+					{
+						test: /\.styl$/,
+						use: ExtractTextPlugin.extract({
+							use: extractStylus,
+							fallback: 'raw-loader'
+						}),
+						include: path.join(__dirname, 'src')
+					}]
+			},
+			resolve: {
+				extensions: ['.js', '.vue']
+			},
+			resolve: {
+				alias: {
+					'vue$': 'vue/dist/vue.esm.js'
+				}
+			},
+			devServer: {
+				historyApiFallback: true,
+				overlay: true
+			}
+		}


### PR DESCRIPTION
Migrated webpack v3 to v4
Added `mini-css-extract-plugin` for handling styling ( `.css` )
Pretty much thats it. Working on the `splitchunk` and `uglifyjs-webpack-plugin` optimizer