### PR TITLE
Support list workflows with SQL like query

### DIFF
--- a/client/routes/Workflows.vue
+++ b/client/routes/Workflows.vue
@@ -1,7 +1,7 @@
 <template>
   <section :class="{ workflows: true, loading }">
     <header class="filters">
-      <template v-if="filterMode === 'advance'">
+      <template v-if="filterMode === 'advanced'">
         <div class="field query-string">
           <input type="search" class="query-string"
             placeholder=" "
@@ -42,7 +42,7 @@
           :searchable="false"
         />
       </template>
-      <a class="toggle-filter" @click="toggleFilter">{{ filterMode === 'advance' ? 'basic' : 'advance' }}</a>
+      <a class="toggle-filter" @click="toggleFilter">{{ filterMode === 'advanced' ? 'basic' : 'advanced' }}</a>
     </header>
     <section class="results"
       v-infinite-scroll="nextPage"
@@ -233,11 +233,11 @@ export default pagedGrid({
       }
     },
     toggleFilter() {
-      if (this.filterMode === 'advance') {
+      if (this.filterMode === 'advanced') {
         this.filterMode = 'basic'
         this.$route.query.queryString = ''
       } else {
-        this.filterMode = 'advance'
+        this.filterMode = 'advanced'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "vue-router": "^3.0.1",
     "vue-select": "nathanboktae/vue-select#after2.4",
     "vue-split-panel": "^1.0.4",
+    "vue-style-loader": "^3.1.2",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.10.0"
   },
@@ -72,6 +73,7 @@
     "mocha": "^4.0.1",
     "mocha-chrome": "^1.1.0",
     "nathanboktae-browser-test-utils": "^0.1.0",
-    "supertest": "^3.0.0"
+    "supertest": "^3.0.0",
+    "webpack-hot-client": "^1.3.0"
   }
 }

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -160,6 +160,7 @@ module.exports = async function(ctx, next) {
   ctx.cadence = {
     openWorkflows: req('ListOpenWorkflowExecutions', 'list', withDomainPaging),
     closedWorkflows: req('ListClosedWorkflowExecutions', 'list', withDomainPaging),
+    listWorkflows: req('ListWorkflowExecutions', 'list', withDomainPaging),
     getHistory: req('GetWorkflowExecutionHistory', 'get', withDomainAndWorkflowExecution),
     exportHistory: req('GetWorkflowExecutionHistory', 'get', withDomainAndWorkflowExecution, cliTransform),
     describeWorkflow: req('DescribeWorkflowExecution', 'describe', withWorkflowExecution),

--- a/server/routes.js
+++ b/server/routes.js
@@ -39,6 +39,14 @@ async function listWorkflows(state, ctx) {
 router.get('/api/domain/:domain/workflows/open', listWorkflows.bind(null, 'open'))
 router.get('/api/domain/:domain/workflows/closed', listWorkflows.bind(null, 'closed'))
 
+router.get('/api/domain/:domain/workflows/list', async function (ctx) {
+  var q = ctx.query || {}
+  ctx.body = await ctx.cadence['listWorkflows']({
+    query: q.queryString || undefined,
+    nextPageToken: q.nextPageToken ? Buffer.from(q.nextPageToken, 'base64') : undefined
+  })
+})
+
 router.get('/api/domain/:domain/workflows/:workflowId/:runId/history', async function (ctx) {
   var q = ctx.query || {}
 


### PR DESCRIPTION
This PR add a button to list workflow page. 
![image](https://user-images.githubusercontent.com/1283368/62743322-d8afbd00-b9f6-11e9-8f19-d59fbfdd2558.png)

When click, it will switch to use advanced query mode, where you can put SQL like query
![image](https://user-images.githubusercontent.com/1283368/62743359-0d237900-b9f7-11e9-8360-6f0b698b106c.png)

This is supported by Cadence ListWorkflows API, which currently requires Cadence Server start with ElasticSearch. 




