### PR TITLE
Adjust height of history table spacer

### DIFF
--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -344,7 +344,7 @@ section.history
             width: 150px
         & + .spacer
           width 100%
-          height 38px
+          height 66px
     td, th
       &:first-child
         min-width 60px


### PR DESCRIPTION
The history results table uses a floating *thead*. The div spacer ensures that
*tbody* doesn't overlap but its height seems to be off since the Type dropdown
was introduced.

This commit updates the height of the spacer to avoid the visual glitch where
the first results cannot be seen properly.

### Before

The first row is hidden behind the floating header.

![image](https://user-images.githubusercontent.com/606459/69017208-58d0b180-095a-11ea-8db1-e9f9c25aea59.png)

### After

The first row can be seen.

![image](https://user-images.githubusercontent.com/606459/69017227-77cf4380-095a-11ea-91eb-e5ebd89e4452.png)
