### PR TITLE
fix: java cadence client does not serialize SideEffects

### DIFF
--- a/client/routes/execution/event-details.vue
+++ b/client/routes/execution/event-details.vue
@@ -4,11 +4,19 @@ import eventCompactTransforms from './summarize-events'
 const eventFullTransforms = {
   MarkerRecorded: d => {
     if (d.markerName === 'SideEffect') {
-      return {
-        sideEffectID: d.details[0],
-        data:  JSON.tryParse(atob(d.details[1])) || d.details[1],
-        decisionTaskCompletedEventId: d.decisionTaskCompletedEventId
-      }
+        if (Array.isArray(d.details)) {
+            return {
+                sideEffectID: d.details[0],
+                data: JSON.tryParse(atob(d.details[1])) || d.details[1],
+                decisionTaskCompletedEventId: d.decisionTaskCompletedEventId
+            }
+        }
+        else { // Java client
+            return {
+                data: d.details,
+                decisionTaskCompletedEventId: d.decisionTaskCompletedEventId
+            }
+        }
     }
     return d
   }

--- a/client/routes/execution/summarize-events.js
+++ b/client/routes/execution/summarize-events.js
@@ -96,9 +96,16 @@ export default {
       }
     }
     if (d.markerName === 'SideEffect') {
-      return {
-        'Side Effect ID': details[0],
-        data:  JSON.tryParse(atob(details[1])) || details[1]
+      if (Array.isArray(details)) {
+        return {
+          'Side Effect ID': details[0],
+          data: JSON.tryParse(atob(details[1])) || details[1]
+        }
+      }
+      else { // Java client
+        return {
+          data: details
+        }
       }
     }
 


### PR DESCRIPTION
The java client just plainly sets details to the SideEffect value, instead of serializing it and adding it to an array. This fix checks if details is an array, if not just returns the value.
Without this fix, history overview is broken for java workflows with sideeffects