### PR TITLE
Increase maximum history count limit

### DIFF
--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -343,7 +343,11 @@ export default {
       this.scrollEventIntoView(eventId);
     },
     filteredEvents() {
-      if (!this.scrolledToEventOnInit && this.eventId !== undefined && this.filteredEventIdToIndex[this.eventId] !== undefined) {
+      if (
+        !this.scrolledToEventOnInit
+        && this.eventId !== undefined
+        && this.filteredEventIdToIndex[this.eventId] !== undefined
+      ) {
         this.scrolledToEventOnInit = true;
         setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
       }

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -158,6 +158,7 @@ export default {
     return {
       tsFormat: localStorage.getItem(`${this.$route.params.domain}:history-ts-col-format`) || 'elapsed',
       compactDetails: localStorage.getItem(`${this.$route.params.domain}:history-compact-details`) === 'true',
+      scrolledToEventOnInit: false,
       splitEnabled: false,
       eventType: "",
       eventTypes: [
@@ -256,7 +257,8 @@ export default {
   },
   methods: {
     setEventType(et){
-      this.eventType = et.value
+      this.eventType = et.value;
+      setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
     },
     setFormat(format) {
       this.$router.replace({
@@ -273,6 +275,7 @@ export default {
       this.compactDetails = compact;
       localStorage.setItem(`${this.$route.params.domain}:history-compact-details`, JSON.stringify(compact));
       scrollerGrid.forceUpdate();
+      setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
     },
     timeCol(ts, i) {
       if (i === -1) {
@@ -340,7 +343,10 @@ export default {
       this.scrollEventIntoView(eventId);
     },
     filteredEvents() {
-      this.scrollEventIntoView(this.eventId);
+      if (!this.scrolledToEventOnInit && this.eventId !== undefined && this.filteredEventIdToIndex[this.eventId] !== undefined) {
+        this.scrolledToEventOnInit = true;
+        setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
+      }
     },
   },
   components: {

--- a/client/routes/execution/index.vue
+++ b/client/routes/execution/index.vue
@@ -12,7 +12,7 @@
 
 <script>
 import moment from 'moment'
-const resultThreshold = 1000
+const resultThreshold = 200000;
 
 export default {
   data() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.5.3",
+  "version": "3.6.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.6.0-beta.0",
+  "version": "3.6.0-beta.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
Bumping to 200K history count which matches cadence server internal history count limit (see eng /docs/cadence/size_limits.html#history-count-limit).

Because the history table is now virtualized there should be little to no penalty in making this change. The only downside is the page bandwidth is now increased because of the increase of API calls made to fetch all of the history. The history page can be interacted with while the data is being fetched.