### PR TITLE
Fix child workflow navigation & compact display extra fields

### DIFF
--- a/client/routes/execution/helpers/get-event-details.js
+++ b/client/routes/execution/helpers/get-event-details.js
@@ -1,14 +1,15 @@
 import { getKeyValuePairs } from '../../../helpers';
 
 const getEventDetails = event => {
-  const { details, eventId, eventType } = event;
-  const kvps = getKeyValuePairs(details);
+  const { details, eventId, eventType, timeStampDisplay } = event;
+  const kvps = getKeyValuePairs({ ...details, eventId, timestamp: timeStampDisplay });
 
   return {
     ...details,
     eventId,
     eventType,
     kvps,
+    timestamp: timeStampDisplay,
   };
 };
 

--- a/client/routes/execution/helpers/get-event-details.js
+++ b/client/routes/execution/helpers/get-event-details.js
@@ -2,7 +2,7 @@ import { getKeyValuePairs } from '../../../helpers';
 
 const getEventDetails = event => {
   const { details, eventId, eventType, timeStampDisplay } = event;
-  const kvps = getKeyValuePairs({ ...details, eventId, timestamp: timeStampDisplay });
+  const kvps = getKeyValuePairs({ timestamp: timeStampDisplay, eventId, ...details });
 
   return {
     ...details,

--- a/client/routes/execution/helpers/get-event-details.js
+++ b/client/routes/execution/helpers/get-event-details.js
@@ -2,7 +2,11 @@ import { getKeyValuePairs } from '../../../helpers';
 
 const getEventDetails = event => {
   const { details, eventId, eventType, timeStampDisplay } = event;
-  const kvps = getKeyValuePairs({ timestamp: timeStampDisplay, eventId, ...details });
+  const kvps = getKeyValuePairs({
+    timestamp: timeStampDisplay,
+    eventId,
+    ...details,
+  });
 
   return {
     ...details,

--- a/client/routes/execution/helpers/get-history-events.js
+++ b/client/routes/execution/helpers/get-history-events.js
@@ -12,16 +12,10 @@ const getHistoryEvents = events => {
 
   return events
     .map(event => {
-      const details = getEventDetails(event);
-      const eventSummary = getEventSummary(event);
-      const eventFullDetails = getEventFullDetails(event);
       const timestamp = moment(event.timestamp);
 
       return {
         ...event,
-        details,
-        eventSummary,
-        eventFullDetails,
         timestamp,
       };
     })
@@ -33,6 +27,18 @@ const getHistoryEvents = events => {
         ...event,
         timeStampDisplay,
         timeElapsedDisplay,
+      };
+    })
+    .map(event => {
+      const details = getEventDetails(event);
+      const eventSummary = getEventSummary(event);
+      const eventFullDetails = getEventFullDetails(event);
+
+      return {
+        ...event,
+        details,
+        eventSummary,
+        eventFullDetails,
       };
     });
 };

--- a/client/routes/execution/index.vue
+++ b/client/routes/execution/index.vue
@@ -144,6 +144,7 @@ export default {
 
       if (!pagedQueryUrl) {
         this.history.loading = false;
+
         return;
       }
 

--- a/client/routes/execution/index.vue
+++ b/client/routes/execution/index.vue
@@ -86,9 +86,7 @@ export default {
     );
   },
   beforeDestroy() {
-    while (this.unwatch.length) {
-      this.unwatch.pop()();
-    }
+    this.clearWatches();
   },
   computed: {
     baseAPIURL() {
@@ -111,12 +109,41 @@ export default {
     },
   },
   methods: {
+    clearState() {
+      this.events = [];
+      this.isWorkflowRunning = undefined;
+      this.nextPageToken = undefined;
+      this.wfError = undefined;
+      this.wfLoading = true;
+      this.workflow = undefined;
+
+      this.history.error = undefined;
+      this.history.events = [];
+      this.history.loading = undefined;
+      this.history.timelineEvents = [];
+
+      this.summary.input = undefined;
+      this.summary.isWorkflowRunning = undefined;
+      this.summary.parentWorkflowRoute = undefined;
+      this.summary.result = undefined;
+      this.summary.wfStatus = undefined;
+      this.summary.workflow = undefined;
+    },
+    clearWatches() {
+      while (this.unwatch.length) {
+        this.unwatch.pop()();
+      }
+    },
+    clearQueryUrlWatch() {
+      while (this.unwatch.length > 1) {
+        this.unwatch.pop()();
+      }
+    },
     fetchHistoryPage(pagedQueryUrl) {
       this.history.error = undefined;
 
       if (!pagedQueryUrl) {
         this.history.loading = false;
-
         return;
       }
 
@@ -190,10 +217,9 @@ export default {
         });
     },
     onBaseApiUrlChange(baseAPIURL) {
-      this.events = [];
-      this.history.events = [];
-      this.history.timelineEvents = [];
-      this.nextPageToken = undefined;
+      this.clearQueryUrlWatch();
+      this.clearState();
+      this.wfLoading = true;
 
       return this.$http(baseAPIURL)
         .then(
@@ -214,10 +240,7 @@ export default {
       this.fetchHistoryPage(queryUrl);
     },
     setupQueryUrlWatch() {
-      while (this.unwatch.length > 1) {
-        this.unwatch.pop()();
-      }
-
+      this.clearQueryUrlWatch();
       this.unwatch.push(
         this.$watch('queryUrl', this.onQueryUrlChange, { immediate: true })
       );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.7.1-beta.0",
+  "version": "3.7.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.7.0",
+  "version": "3.7.1-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
This PR is to address navigating to a child workflow from a parent workflow.

What happened was on route change it would try to fire off 2 calls to `fetchHistoryPage` instead of just 1. This would result in the view duplicating the list items twice. Essentially what was happening is the query watcher would fire once instead of unsubscribing on base route change. This change now makes sure that it unsubscribes from the watch, then will resubscribe once it has the summary information.

The second change was to add back in information that was previously displaying on the compact view when opening the activity detail panel (timestamp & event id).

See github issue:
https://github.com/uber/cadence-web/issues/81

