### PR TITLE
Feature/reverse history

### DIFF
--- a/client/routes/execution/helpers/index.js
+++ b/client/routes/execution/helpers/index.js
@@ -10,5 +10,6 @@ export { default as getTimeStampDisplay } from './get-time-stamp-display';
 export { eventFullTransforms } from './event-full-transforms';
 export { default as mapTimelineEvents } from './map-timeline-events';
 export { default as parentWorkflowLink } from './parent-workflow-link';
+export { default as sortComparatorNumeric } from './sort-comparator-numeric';
 export { summarizeEvents } from './summarize-events';
 export { default as workflowLink } from './workflow-link';

--- a/client/routes/execution/helpers/sort-comparator-numeric.js
+++ b/client/routes/execution/helpers/sort-comparator-numeric.js
@@ -1,0 +1,6 @@
+const sortComparatorNumeric = (key, ascending) => {
+  const sign = ascending ? -1 : 1;
+  return (eventA, eventB) => sign * (eventB[key] - eventA[key]);
+};
+
+export default sortComparatorNumeric;

--- a/client/routes/execution/helpers/sort-comparator-numeric.js
+++ b/client/routes/execution/helpers/sort-comparator-numeric.js
@@ -1,5 +1,6 @@
 const sortComparatorNumeric = (key, ascending) => {
   const sign = ascending ? -1 : 1;
+
   return (eventA, eventB) => sign * (eventB[key] - eventA[key]);
 };
 

--- a/client/routes/execution/helpers/sort-comparator-numeric.spec.js
+++ b/client/routes/execution/helpers/sort-comparator-numeric.spec.js
@@ -1,0 +1,58 @@
+import sortComparatorNumeric from './sort-comparator-numeric';
+
+const LIST_ASCENDING_ORDER = [
+  {
+    id: 1,
+  },
+  {
+    id: 2,
+  },
+  {
+    id: 3,
+  },
+];
+
+const LIST_DESCENDING_ORDER = [
+  {
+    id: 3,
+  },
+  {
+    id: 2,
+  },
+  {
+    id: 1,
+  },
+];
+
+describe('sortComparatorNumeric', () => {
+  const initList = () => {
+    return [
+      {
+        id: 3,
+      },
+      {
+        id: 1,
+      },
+      {
+        id: 2,
+      },
+    ];
+  };
+
+  describe('when key = id', () => {
+    describe('and ascending = true', () => {
+      it('should sort the list into ascending order.', () => {
+        const list = initList();
+        list.sort(sortComparatorNumeric('id', true));
+        expect(list).toEqual(LIST_ASCENDING_ORDER);
+      });
+    });
+    describe('and ascending = false', () => {
+      it('should sort the list into descending order.', () => {
+        const list = initList();
+        list.sort(sortComparatorNumeric('id', false));
+        expect(list).toEqual(LIST_DESCENDING_ORDER);
+      });
+    });
+  });
+});

--- a/client/routes/execution/helpers/sort-comparator-numeric.spec.js
+++ b/client/routes/execution/helpers/sort-comparator-numeric.spec.js
@@ -43,6 +43,7 @@ describe('sortComparatorNumeric', () => {
     describe('and ascending = true', () => {
       it('should sort the list into ascending order.', () => {
         const list = initList();
+
         list.sort(sortComparatorNumeric('id', true));
         expect(list).toEqual(LIST_ASCENDING_ORDER);
       });
@@ -50,6 +51,7 @@ describe('sortComparatorNumeric', () => {
     describe('and ascending = false', () => {
       it('should sort the list into descending order.', () => {
         const list = initList();
+
         list.sort(sortComparatorNumeric('id', false));
         expect(list).toEqual(LIST_DESCENDING_ORDER);
       });

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -79,7 +79,14 @@
             :class="{ compact: compactDetails }"
           >
             <div class="thead" ref="thead">
-              <div class="th col-id">ID</div>
+              <div class="th col-id">
+                <a
+                  class="icon icon_down-arrow"
+                  @click.prevent="toggleSortParam('ID')"
+                >
+                ID
+                </a>
+              </div>
               <div class="th col-type">
                 Type
                 <v-select
@@ -275,6 +282,7 @@ import eventDetails from './event-details.vue';
 export default {
   name: 'history',
   data() {
+    console.log('data:sortParam = ', JSON.tryParse(localStorage.getItem(`${this.domain}:history-sort-param`)));
     return {
       tsFormat:
         localStorage.getItem(`${this.domain}:history-ts-col-format`) ||
@@ -294,6 +302,7 @@ export default {
         { value: 'ChildWorkflow', label: 'ChildWorkflow' },
         { value: 'Workflow', label: 'Workflow' },
       ],
+      sortParam: JSON.tryParse(localStorage.getItem(`${this.domain}:history-sort-param`)) || { key: 'ID', ascending: true },
       splitSizeSet: [1, 99],
       splitSizeMinSet: [0, 0],
       unwatch: [],
@@ -358,6 +367,8 @@ export default {
         ...event,
         expanded: event.eventId === eventId,
       }));
+
+      console.log('sortParam = ', this.sortParam);
 
       return eventType && eventType !== 'All'
         ? formattedEvents.filter(result => result.eventType.includes(eventType))
@@ -502,6 +513,24 @@ export default {
           query: { ...this.$route.query, showGraph: true },
         });
       }
+    },
+    toggleSortParam(key) {
+      console.log('toggleSortParam:', key);
+      const ascending = key === this.sortParam.key
+        ? !this.sortParam.ascending
+        : true;
+
+      this.sortParam = {
+        ascending,
+        key,
+      };
+
+      console.log('this.sortParam:', this.sortParam);
+
+      localStorage.setItem(
+        `${this.domain}:history-sort-param`,
+        JSON.stringify(this.sortParam)
+      );
     },
   },
   watch: {

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -85,8 +85,8 @@
                   <span
                     class="icon"
                     :class="{
-                      'icon_down-arrow': this.sortParam.ascending,
-                      'icon_up-arrow': !this.sortParam.ascending,
+                      'icon_down-arrow': !this.sortParam.ascending,
+                      'icon_up-arrow': this.sortParam.ascending,
                     }"
                     v-if="this.sortParam.key === 'eventId'"
                   />

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -80,11 +80,15 @@
           >
             <div class="thead" ref="thead">
               <div class="th col-id">
-                <a
-                  class="icon icon_down-arrow"
-                  @click.prevent="toggleSortParam('ID')"
-                >
-                ID
+                <a class="cursor" @click.prevent="toggleSortParam('ID')">
+                  ID
+                  <span
+                    class="icon"
+                    :class="{
+                      'icon_down-arrow': this.sortParam.ascending,
+                      'icon_up-arrow': !this.sortParam.ascending,
+                    }"
+                  />
                 </a>
               </div>
               <div class="th col-type">
@@ -571,6 +575,10 @@ section.history
   display flex
   flex-direction column
   flex 1 1 auto
+
+  .cursor {
+    cursor: pointer;
+  }
 
   header.controls
     display flex

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -283,6 +283,7 @@ import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
 import timeline from './timeline.vue';
 import eventDetails from './event-details.vue';
+import { sortComparatorNumeric } from './helpers';
 
 export default {
   name: 'history',
@@ -405,7 +406,9 @@ export default {
     sortedEvents() {
       return this.filteredEvents
         .slice()
-        .sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending));
+        .sort(
+          sortComparatorNumeric(this.sortParam.key, this.sortParam.ascending)
+        );
     },
     sortedEventIdToIndex() {
       return this.sortedEvents
@@ -511,18 +514,6 @@ export default {
         'eventId',
         i.eventIds[i.eventIds.length - 1]
       );
-    },
-    sortComparator(key, ascending) {
-      switch (key) {
-        case 'eventId':
-          return this.sortComparatorEventId(ascending);
-        default:
-          return this.sortComparatorEventId(ascending);
-      }
-    },
-    sortComparatorEventId(ascending) {
-      const sign = ascending ? -1 : 1;
-      return (eventA, eventB) => sign * (eventB.eventId - eventA.eventId);
     },
     toggleShowGraph() {
       if (this.showGraph) {

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -80,7 +80,7 @@
           >
             <div class="thead" ref="thead">
               <div class="th col-id">
-                <a class="cursor" @click.prevent="toggleSortParam('id')">
+                <a class="cursor" @click.prevent="toggleSortParam('eventId')">
                   ID
                   <span
                     class="icon"
@@ -88,7 +88,7 @@
                       'icon_down-arrow': this.sortParam.ascending,
                       'icon_up-arrow': !this.sortParam.ascending,
                     }"
-                    v-if="this.sortParam.key === 'id'"
+                    v-if="this.sortParam.key === 'eventId'"
                   />
                 </a>
               </div>
@@ -306,7 +306,7 @@ export default {
         { value: 'ChildWorkflow', label: 'ChildWorkflow' },
         { value: 'Workflow', label: 'Workflow' },
       ],
-      sortParam: JSON.tryParse(localStorage.getItem(`${this.domain}:history-sort-param`)) || { key: 'id', ascending: true },
+      sortParam: JSON.tryParse(localStorage.getItem(`${this.domain}:history-sort-param`)) || { key: 'eventId', ascending: true },
       splitSizeSet: [1, 99],
       splitSizeMinSet: [0, 0],
       unwatch: [],
@@ -404,7 +404,12 @@ export default {
     },
     sortedEvents() {
       // TODO - Add sorting logic here...
-      return this.filteredEvents;
+      console.log('filteredEvents = ', this.filteredEvents);
+
+      console.log('sortedEvents = ', this.filteredEvents.sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending)));
+
+      return this.filteredEvents.sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending));
+      // return this.filteredEvents;
     },
     sortedEventIdToIndex() {
       return this.sortedEvents
@@ -511,6 +516,18 @@ export default {
         i.eventIds[i.eventIds.length - 1]
       );
     },
+    sortComparator(key, ascending) {
+      switch (key) {
+        case 'eventId':
+          return this.sortComparatorEventId(ascending);
+        default:
+          return this.sortComparatorEventId(ascending);
+      }
+    },
+    sortComparatorEventId(ascending) {
+      const sign = ascending ? 1 : -1;
+      return (eventA, eventB) => sign * (eventB.eventId - eventA.eventId);
+    },
     toggleShowGraph() {
       if (this.showGraph) {
         this.$router.replace({ query: omit(this.$route.query, 'showGraph') });
@@ -540,7 +557,12 @@ export default {
     eventId(eventId) {
       this.scrollEventIntoView(eventId);
     },
+    showGraph() {
+      this.splitSizeSet = this.showGraph ? [20, 80] : [1, 99];
+      this.onSplitResize();
+    },
     sortedEvents() {
+      console.log('sortedEvents watch called???');
       if (
         !this.scrolledToEventOnInit &&
         this.eventId !== undefined &&
@@ -550,9 +572,10 @@ export default {
         setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
       }
     },
-    showGraph() {
-      this.splitSizeSet = this.showGraph ? [20, 80] : [1, 99];
-      this.onSplitResize();
+    sortParam() {
+      const { scrollerCompact, scrollerGrid } = this.$refs;
+      const scroller = this.isGrid ? scrollerGrid : scrollerCompact;
+      scroller.forceUpdate();
     },
   },
   components: {

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -403,13 +403,9 @@ export default {
       return !this.error && !this.loading && this.events.length === 0;
     },
     sortedEvents() {
-      // TODO - Add sorting logic here...
-      console.log('filteredEvents = ', this.filteredEvents);
-
-      console.log('sortedEvents = ', this.filteredEvents.sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending)));
-
-      return this.filteredEvents.sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending));
-      // return this.filteredEvents;
+      return this.filteredEvents
+        .slice()
+        .sort(this.sortComparator(this.sortParam.key, this.sortParam.ascending));
     },
     sortedEventIdToIndex() {
       return this.sortedEvents
@@ -525,7 +521,7 @@ export default {
       }
     },
     sortComparatorEventId(ascending) {
-      const sign = ascending ? 1 : -1;
+      const sign = ascending ? -1 : 1;
       return (eventA, eventB) => sign * (eventB.eventId - eventA.eventId);
     },
     toggleShowGraph() {
@@ -562,7 +558,6 @@ export default {
       this.onSplitResize();
     },
     sortedEvents() {
-      console.log('sortedEvents watch called???');
       if (
         !this.scrolledToEventOnInit &&
         this.eventId !== undefined &&
@@ -571,11 +566,6 @@ export default {
         this.scrolledToEventOnInit = true;
         setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
       }
-    },
-    sortParam() {
-      const { scrollerCompact, scrollerGrid } = this.$refs;
-      const scroller = this.isGrid ? scrollerGrid : scrollerCompact;
-      scroller.forceUpdate();
     },
   },
   components: {

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -307,7 +307,9 @@ export default {
         { value: 'ChildWorkflow', label: 'ChildWorkflow' },
         { value: 'Workflow', label: 'Workflow' },
       ],
-      sortParam: JSON.tryParse(localStorage.getItem(`${this.domain}:history-sort-param`)) || { key: 'eventId', ascending: true },
+      sortParam: JSON.tryParse(
+        localStorage.getItem(`${this.domain}:history-sort-param`)
+      ) || { key: 'eventId', ascending: true },
       splitSizeSet: [1, 99],
       splitSizeMinSet: [0, 0],
       unwatch: [],
@@ -525,9 +527,8 @@ export default {
       }
     },
     toggleSortParam(key) {
-      const ascending = key === this.sortParam.key
-        ? !this.sortParam.ascending
-        : true;
+      const ascending =
+        key === this.sortParam.key ? !this.sortParam.ascending : true;
 
       this.sortParam = {
         ascending,


### PR DESCRIPTION
For troubleshooting seeing the last event first in UI is more useful.

### Screenshots
Ascending sort
<img width="1246" alt="ascending" src="https://user-images.githubusercontent.com/58960161/74595785-b5477980-4ffa-11ea-9e9a-1ad225c04709.png">

Descending sort
<img width="1246" alt="descending" src="https://user-images.githubusercontent.com/58960161/74595792-bf697800-4ffa-11ea-9b7e-d5aa61b2b50d.png">

### Links
See github issue in cadence repository: https://github.com/uber/cadence/issues/1216