### PR TITLE
Update thrift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/server/idl/admin.thrift
+++ b/server/idl/admin.thrift
@@ -20,10 +20,11 @@
 
 namespace java com.uber.cadence.admin
 
-include "./shared.thrift"
+include "shared.thrift"
+include "replicator.thrift"
 
 /**
-* AdminService provides advanced APIs for debugging and analysis with admin privillege
+* AdminService provides advanced APIs for debugging and analysis with admin privilege
 **/
 service AdminService {
   /**
@@ -47,6 +48,21 @@ service AdminService {
       3: shared.AccessDeniedError     accessDeniedError,
     )
 
+  void CloseShard(1: shared.CloseShardRequest request)
+    throws (
+      1: shared.BadRequestError       badRequestError,
+      2: shared.InternalServiceError  internalServiceError,
+      3: shared.AccessDeniedError     accessDeniedError,
+    )
+
+  void RemoveTask(1: shared.RemoveTaskRequest request)
+    throws (
+      1: shared.BadRequestError       badRequestError,
+      2: shared.InternalServiceError  internalServiceError,
+      3: shared.AccessDeniedError     accessDeniedError,
+    )
+
+
   /**
   * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow
   * execution in unknown to the service.
@@ -58,6 +74,117 @@ service AdminService {
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
     )
+
+  /**
+  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow
+  * execution in unknown to the service.
+  * StartEventId defines the beginning of the event to fetch. The first event is inclusive.
+  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.
+  **/
+  GetWorkflowExecutionRawHistoryV2Response GetWorkflowExecutionRawHistoryV2(1: GetWorkflowExecutionRawHistoryV2Request getRequest)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.EntityNotExistsError entityNotExistError,
+      4: shared.ServiceBusyError serviceBusyError,
+    )
+
+  replicator.GetReplicationMessagesResponse GetReplicationMessages(1: replicator.GetReplicationMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      3: shared.LimitExceededError limitExceededError,
+      4: shared.ServiceBusyError serviceBusyError,
+      5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      )
+
+  replicator.GetDomainReplicationMessagesResponse GetDomainReplicationMessages(1: replicator.GetDomainReplicationMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      3: shared.LimitExceededError limitExceededError,
+      4: shared.ServiceBusyError serviceBusyError,
+      5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+    )
+
+  replicator.GetDLQReplicationMessagesResponse GetDLQReplicationMessages(1: replicator.GetDLQReplicationMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.ServiceBusyError serviceBusyError,
+    )
+
+  /**
+  * ReapplyEvents applies stale events to the current workflow and current run
+  **/
+  void ReapplyEvents(1: shared.ReapplyEventsRequest reapplyEventsRequest)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      3: shared.DomainNotActiveError domainNotActiveError,
+      4: shared.LimitExceededError limitExceededError,
+      5: shared.ServiceBusyError serviceBusyError,
+      6: shared.EntityNotExistsError entityNotExistError,
+    )
+
+  /**
+  * AddSearchAttribute whitelist search attribute in request.
+  **/
+  void AddSearchAttribute(1: AddSearchAttributeRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+    )
+
+  /**
+  * DescribeCluster returns information about cadence cluster
+  **/
+  DescribeClusterResponse DescribeCluster()
+    throws (
+      1: shared.InternalServiceError internalServiceError,
+      2: shared.ServiceBusyError serviceBusyError,
+    )
+
+  /**
+  * ReadDLQMessages returns messages from DLQ
+  **/
+  replicator.ReadDLQMessagesResponse ReadDLQMessages(1: replicator.ReadDLQMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: shared.EntityNotExistsError entityNotExistError,
+    )
+
+  /**
+  * PurgeDLQMessages purges messages from DLQ
+  **/
+  void PurgeDLQMessages(1: replicator.PurgeDLQMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: shared.EntityNotExistsError entityNotExistError,
+    )
+
+  /**
+  * MergeDLQMessages merges messages from DLQ
+  **/
+  replicator.MergeDLQMessagesResponse MergeDLQMessages(1: replicator.MergeDLQMessagesRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: shared.EntityNotExistsError entityNotExistError,
+    )
+
+  /**
+  * RefreshWorkflowTasks refreshes all tasks of a workflow
+  **/
+  void RefreshWorkflowTasks(1: shared.RefreshWorkflowTasksRequest request)
+   throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.DomainNotActiveError domainNotActiveError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: shared.EntityNotExistsError entityNotExistError,
+   )
 }
 
 struct DescribeWorkflowExecutionRequest {
@@ -65,7 +192,7 @@ struct DescribeWorkflowExecutionRequest {
   20: optional shared.WorkflowExecution     execution
 }
 
-struct DescribeWorkflowExecutionResponse{
+struct DescribeWorkflowExecutionResponse {
   10: optional string shardId
   20: optional string historyAddr
   40: optional string mutableStateInCache
@@ -86,4 +213,51 @@ struct GetWorkflowExecutionRawHistoryResponse {
   20: optional list<shared.DataBlob> historyBatches
   30: optional map<string, shared.ReplicationInfo> replicationInfo
   40: optional i32 eventStoreVersion
+}
+
+/**
+  * StartEventId defines the beginning of the event to fetch. The first event is exclusive.
+  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.
+  **/
+struct GetWorkflowExecutionRawHistoryV2Request {
+  10: optional string domain
+  20: optional shared.WorkflowExecution execution
+  30: optional i64 (js.type = "Long") startEventId
+  40: optional i64 (js.type = "Long") startEventVersion
+  50: optional i64 (js.type = "Long") endEventId
+  60: optional i64 (js.type = "Long") endEventVersion
+  70: optional i32 maximumPageSize
+  80: optional binary nextPageToken
+}
+
+struct GetWorkflowExecutionRawHistoryV2Response {
+  10: optional binary nextPageToken
+  20: optional list<shared.DataBlob> historyBatches
+  30: optional shared.VersionHistory versionHistory
+}
+
+struct AddSearchAttributeRequest {
+  10: optional map<string, shared.IndexedValueType> searchAttribute
+  20: optional string securityToken
+}
+
+struct HostInfo {
+  10: optional string Identity
+}
+
+struct RingInfo {
+  10: optional string role
+  20: optional i32 memberCount
+  30: optional list<HostInfo> members
+}
+
+struct MembershipInfo {
+  10: optional HostInfo currentHost
+  20: optional list<string> reachableMembers
+  30: optional list<RingInfo> rings
+}
+
+struct DescribeClusterResponse {
+  10: optional shared.SupportedClientVersions supportedClientVersions
+  20: optional MembershipInfo membershipInfo
 }

--- a/server/idl/cadence.thrift
+++ b/server/idl/cadence.thrift
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-include "./shared.thrift"
+include "shared.thrift"
 
 namespace java com.uber.cadence
 
@@ -40,7 +40,6 @@ service WorkflowService {
   void RegisterDomain(1: shared.RegisterDomainRequest registerRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.DomainAlreadyExistsError domainExistsError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -52,7 +51,6 @@ service WorkflowService {
   shared.DescribeDomainResponse DescribeDomain(1: shared.DescribeDomainRequest describeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -64,7 +62,6 @@ service WorkflowService {
     shared.ListDomainsResponse ListDomains(1: shared.ListDomainsRequest listRequest)
       throws (
         1: shared.BadRequestError badRequestError,
-        2: shared.InternalServiceError internalServiceError,
         3: shared.EntityNotExistsError entityNotExistError,
         4: shared.ServiceBusyError serviceBusyError,
         5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -76,7 +73,6 @@ service WorkflowService {
   shared.UpdateDomainResponse UpdateDomain(1: shared.UpdateDomainRequest updateRequest)
       throws (
         1: shared.BadRequestError badRequestError,
-        2: shared.InternalServiceError internalServiceError,
         3: shared.EntityNotExistsError entityNotExistError,
         4: shared.ServiceBusyError serviceBusyError,
         5: shared.DomainNotActiveError domainNotActiveError,
@@ -91,7 +87,6 @@ service WorkflowService {
   void DeprecateDomain(1: shared.DeprecateDomainRequest deprecateRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -107,7 +102,6 @@ service WorkflowService {
   shared.StartWorkflowExecutionResponse StartWorkflowExecution(1: shared.StartWorkflowExecutionRequest startRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.WorkflowExecutionAlreadyStartedError sessionAlreadyExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -123,7 +117,6 @@ service WorkflowService {
   shared.GetWorkflowExecutionHistoryResponse GetWorkflowExecutionHistory(1: shared.GetWorkflowExecutionHistoryRequest getRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -139,7 +132,6 @@ service WorkflowService {
   shared.PollForDecisionTaskResponse PollForDecisionTask(1: shared.PollForDecisionTaskRequest pollRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.ServiceBusyError serviceBusyError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.EntityNotExistsError entityNotExistError,
@@ -158,7 +150,6 @@ service WorkflowService {
   shared.RespondDecisionTaskCompletedResponse RespondDecisionTaskCompleted(1: shared.RespondDecisionTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -175,7 +166,6 @@ service WorkflowService {
   void RespondDecisionTaskFailed(1: shared.RespondDecisionTaskFailedRequest failedRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -195,7 +185,6 @@ service WorkflowService {
   shared.PollForActivityTaskResponse PollForActivityTask(1: shared.PollForActivityTaskRequest pollRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.ServiceBusyError serviceBusyError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.EntityNotExistsError entityNotExistError,
@@ -213,7 +202,6 @@ service WorkflowService {
   shared.RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeat(1: shared.RecordActivityTaskHeartbeatRequest heartbeatRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -231,7 +219,6 @@ service WorkflowService {
   shared.RecordActivityTaskHeartbeatResponse RecordActivityTaskHeartbeatByID(1: shared.RecordActivityTaskHeartbeatByIDRequest heartbeatRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -249,7 +236,6 @@ service WorkflowService {
   void  RespondActivityTaskCompleted(1: shared.RespondActivityTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -267,7 +253,6 @@ service WorkflowService {
   void  RespondActivityTaskCompletedByID(1: shared.RespondActivityTaskCompletedByIDRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -285,7 +270,6 @@ service WorkflowService {
   void  RespondActivityTaskFailed(1: shared.RespondActivityTaskFailedRequest failRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -303,7 +287,6 @@ service WorkflowService {
   void  RespondActivityTaskFailedByID(1: shared.RespondActivityTaskFailedByIDRequest failRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -321,7 +304,6 @@ service WorkflowService {
   void RespondActivityTaskCanceled(1: shared.RespondActivityTaskCanceledRequest canceledRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -339,7 +321,6 @@ service WorkflowService {
   void RespondActivityTaskCanceledByID(1: shared.RespondActivityTaskCanceledByIDRequest canceledRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.DomainNotActiveError domainNotActiveError,
       5: shared.LimitExceededError limitExceededError,
@@ -356,7 +337,6 @@ service WorkflowService {
   void RequestCancelWorkflowExecution(1: shared.RequestCancelWorkflowExecutionRequest cancelRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.CancellationAlreadyRequestedError cancellationAlreadyRequestedError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -372,7 +352,6 @@ service WorkflowService {
   void SignalWorkflowExecution(1: shared.SignalWorkflowExecutionRequest signalRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -390,7 +369,6 @@ service WorkflowService {
   shared.StartWorkflowExecutionResponse SignalWithStartWorkflowExecution(1: shared.SignalWithStartWorkflowExecutionRequest signalWithStartRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -406,14 +384,13 @@ service WorkflowService {
   shared.ResetWorkflowExecutionResponse ResetWorkflowExecution(1: shared.ResetWorkflowExecutionRequest resetRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
     )
-    
+
   /**
   * TerminateWorkflowExecution terminates an existing workflow execution by recording WorkflowExecutionTerminated event
   * in the history and immediately terminating the execution instance.
@@ -421,7 +398,6 @@ service WorkflowService {
   void TerminateWorkflowExecution(1: shared.TerminateWorkflowExecutionRequest terminateRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.DomainNotActiveError domainNotActiveError,
@@ -435,7 +411,6 @@ service WorkflowService {
   shared.ListOpenWorkflowExecutionsResponse ListOpenWorkflowExecutions(1: shared.ListOpenWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.LimitExceededError limitExceededError,
@@ -448,7 +423,6 @@ service WorkflowService {
   shared.ListClosedWorkflowExecutionsResponse ListClosedWorkflowExecutions(1: shared.ListClosedWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -460,7 +434,17 @@ service WorkflowService {
   shared.ListWorkflowExecutionsResponse ListWorkflowExecutions(1: shared.ListWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
+      3: shared.EntityNotExistsError entityNotExistError,
+      4: shared.ServiceBusyError serviceBusyError,
+      5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+    )
+
+  /**
+  * ListArchivedWorkflowExecutions is a visibility API to list archived workflow executions in a specific domain.
+  **/
+  shared.ListArchivedWorkflowExecutionsResponse ListArchivedWorkflowExecutions(1: shared.ListArchivedWorkflowExecutionsRequest listRequest)
+    throws (
+      1: shared.BadRequestError badRequestError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -472,7 +456,6 @@ service WorkflowService {
   shared.ListWorkflowExecutionsResponse ScanWorkflowExecutions(1: shared.ListWorkflowExecutionsRequest listRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -484,7 +467,6 @@ service WorkflowService {
   shared.CountWorkflowExecutionsResponse CountWorkflowExecutions(1: shared.CountWorkflowExecutionsRequest countRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.ServiceBusyError serviceBusyError,
       5: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
@@ -495,7 +477,6 @@ service WorkflowService {
   **/
   shared.GetSearchAttributesResponse GetSearchAttributes()
     throws (
-      1: shared.InternalServiceError internalServiceError,
       2: shared.ServiceBusyError serviceBusyError,
       3: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
     )
@@ -508,7 +489,6 @@ service WorkflowService {
   void RespondQueryTaskCompleted(1: shared.RespondQueryTaskCompletedRequest completeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -528,7 +508,6 @@ service WorkflowService {
   shared.ResetStickyTaskListResponse ResetStickyTaskList(1: shared.ResetStickyTaskListRequest resetRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -542,7 +521,6 @@ service WorkflowService {
   shared.QueryWorkflowResponse QueryWorkflow(1: shared.QueryWorkflowRequest queryRequest)
 	throws (
 	  1: shared.BadRequestError badRequestError,
-	  2: shared.InternalServiceError internalServiceError,
 	  3: shared.EntityNotExistsError entityNotExistError,
 	  4: shared.QueryFailedError queryFailedError,
 	  5: shared.LimitExceededError limitExceededError,
@@ -551,12 +529,22 @@ service WorkflowService {
 	)
 
   /**
+  * Returns raw history in binary for specified workflow execution.
+  **/
+  shared.GetWorkflowExecutionRawHistoryResponse GetWorkflowExecutionRawHistory(1: shared.GetWorkflowExecutionRawHistoryRequest getRequest)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.EntityNotExistsError entityNotExistError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+    )
+
+  /**
   * DescribeWorkflowExecution returns information about the specified workflow execution.
   **/
   shared.DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: shared.DescribeWorkflowExecutionRequest describeRequest)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
@@ -570,11 +558,30 @@ service WorkflowService {
   shared.DescribeTaskListResponse DescribeTaskList(1: shared.DescribeTaskListRequest request)
     throws (
       1: shared.BadRequestError badRequestError,
-      2: shared.InternalServiceError internalServiceError,
       3: shared.EntityNotExistsError entityNotExistError,
       4: shared.LimitExceededError limitExceededError,
       5: shared.ServiceBusyError serviceBusyError,
       6: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+    )
+
+  /**
+  * GetClusterInfo returns information about cadence cluster
+  **/
+  shared.ClusterInfo GetClusterInfo()
+    throws (
+      1: shared.InternalServiceError internalServiceError,
+      2: shared.ServiceBusyError serviceBusyError,
+    )
+
+   /**
+   * ReapplyEvents applies stale events to the current workflow and current run
+   **/
+  shared.ListTaskListPartitionsResponse ListTaskListPartitions(1: shared.ListTaskListPartitionsRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      3: shared.EntityNotExistsError entityNotExistError,
+      4: shared.LimitExceededError limitExceededError,
+      5: shared.ServiceBusyError serviceBusyError,
     )
 
 }

--- a/server/idl/checksum.thrift
+++ b/server/idl/checksum.thrift
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+include "shared.thrift"
+
+namespace java com.uber.cadence
+
+struct MutableStateChecksumPayload {
+    10: optional bool cancelRequested
+    15: optional i16 state
+    16: optional i16 closeStatus
+
+    21: optional i64 (js.type = "Long") lastWriteVersion
+    22: optional i64 (js.type = "Long") lastWriteEventID
+    23: optional i64 (js.type = "Long") lastFirstEventID
+    24: optional i64 (js.type = "Long") nextEventID
+    25: optional i64 (js.type = "Long") lastProcessedEventID
+    26: optional i64 (js.type = "Long") signalCount
+
+    35: optional i32 decisionAttempt
+    36: optional i64 (js.type = "Long") decisionVersion
+    37: optional i64 (js.type = "Long") decisionScheduledID
+    38: optional i64 (js.type = "Long") decisionStartedID
+
+    45: optional list<i64> pendingTimerStartedIDs
+    46: optional list<i64> pendingActivityScheduledIDs
+    47: optional list<i64> pendingSignalInitiatedIDs
+    48: optional list<i64> pendingReqCancelInitiatedIDs
+    49: optional list<i64> pendingChildInitiatedIDs
+
+    55: optional string stickyTaskListName
+    56: optional shared.VersionHistories VersionHistories
+}

--- a/server/idl/indexer.thrift
+++ b/server/idl/indexer.thrift
@@ -20,7 +20,7 @@
 
 namespace java com.uber.cadence.indexer
 
-include "./shared.thrift"
+include "shared.thrift"
 
 enum MessageType {
   Index

--- a/server/idl/matching.thrift
+++ b/server/idl/matching.thrift
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-include "./shared.thrift"
+include "shared.thrift"
 
 namespace java com.uber.cadence.matching
 
@@ -26,6 +26,7 @@ struct PollForDecisionTaskRequest {
   10: optional string domainUUID
   15: optional string pollerID
   20: optional shared.PollForDecisionTaskRequest pollRequest
+  30: optional string forwardedFrom
 }
 
 struct PollForDecisionTaskResponse {
@@ -43,14 +44,16 @@ struct PollForDecisionTaskResponse {
   100: optional shared.TaskList WorkflowExecutionTaskList
   110: optional i32 eventStoreVersion
   120: optional binary branchToken
-  130:  optional i64 (js.type = "Long") scheduledTimestamp
-  140:  optional i64 (js.type = "Long") startedTimestamp
+  130: optional i64 (js.type = "Long") scheduledTimestamp
+  140: optional i64 (js.type = "Long") startedTimestamp
+  150: optional map<string, shared.WorkflowQuery> queries
 }
 
 struct PollForActivityTaskRequest {
   10: optional string domainUUID
   15: optional string pollerID
   20: optional shared.PollForActivityTaskRequest pollRequest
+  30: optional string forwardedFrom
 }
 
 struct AddDecisionTaskRequest {
@@ -59,6 +62,7 @@ struct AddDecisionTaskRequest {
   30: optional shared.TaskList taskList
   40: optional i64 (js.type = "Long") scheduleId
   50: optional i32 scheduleToStartTimeoutSeconds
+  60: optional string forwardedFrom
 }
 
 struct AddActivityTaskRequest {
@@ -68,12 +72,14 @@ struct AddActivityTaskRequest {
   40: optional shared.TaskList taskList
   50: optional i64 (js.type = "Long") scheduleId
   60: optional i32 scheduleToStartTimeoutSeconds
+  70: optional string forwardedFrom
 }
 
 struct QueryWorkflowRequest {
   10: optional string domainUUID
   20: optional shared.TaskList taskList
   30: optional shared.QueryWorkflowRequest queryRequest
+  40: optional string forwardedFrom
 }
 
 struct RespondQueryTaskCompletedRequest {
@@ -93,6 +99,11 @@ struct CancelOutstandingPollRequest {
 struct DescribeTaskListRequest {
   10: optional string domainUUID
   20: optional shared.DescribeTaskListRequest descRequest
+}
+
+struct ListTaskListPartitionsRequest {
+  10: optional string domain
+  20: optional shared.TaskList taskList
 }
 
 /**
@@ -205,4 +216,15 @@ service MatchingService {
         3: shared.EntityNotExistsError entityNotExistError,
         4: shared.ServiceBusyError serviceBusyError,
       )
+
+
+  /**
+  * ListTaskListPartitions returns a map of partitionKey and hostAddress for a taskList
+  **/
+  shared.ListTaskListPartitionsResponse ListTaskListPartitions(1: ListTaskListPartitionsRequest request)
+    throws (
+        1: shared.BadRequestError badRequestError,
+        2: shared.InternalServiceError internalServiceError,
+        4: shared.ServiceBusyError serviceBusyError,
+    )
 }

--- a/server/idl/sqlblobs.thrift
+++ b/server/idl/sqlblobs.thrift
@@ -20,7 +20,7 @@
 
 namespace java com.uber.cadence.sqlblobs
 
-include "./shared.thrift"
+include "shared.thrift"
 
 struct ShardInfo {
   10: optional i32 stolenSinceRenew
@@ -32,6 +32,7 @@ struct ShardInfo {
   34: optional map<string, i64> clusterTransferAckLevel
   36: optional map<string, i64> clusterTimerAckLevel
   38: optional string owner
+  40: optional map<string, i64> clusterReplicationLevel
 }
 
 struct DomainInfo {
@@ -52,6 +53,10 @@ struct DomainInfo {
   38: optional map<string, string> data
   39: optional binary badBinaries
   40: optional string badBinariesEncoding
+  42: optional i16 historyArchivalStatus
+  44: optional string historyArchivalURI
+  46: optional i16 visibilityArchivalStatus
+  48: optional string visibilityArchivalURI
 }
 
 struct HistoryTreeInfo {
@@ -97,6 +102,7 @@ struct WorkflowExecutionInfo {
   68: optional i64 (js.type = "Long") decisionStartedTimestampNanos
   69: optional i64 (js.type = "Long") decisionScheduledTimestampNanos
   70: optional bool cancelRequested
+  71: optional i64 (js.type = "Long") decisionOriginalScheduledTimestampNanos
   72: optional string createRequestID
   74: optional string decisionRequestID
   76: optional string cancelRequestID
@@ -122,6 +128,9 @@ struct WorkflowExecutionInfo {
   115: optional binary autoResetPoints
   116: optional string autoResetPointsEncoding
   118: optional map<string, binary> searchAttributes
+  120: optional map<string, binary> memo
+  122: optional binary versionHistories
+  124: optional string versionHistoriesEncoding
 }
 
 struct ActivityInfo {
@@ -153,6 +162,9 @@ struct ActivityInfo {
   60: optional i64 (js.type = "Long") retryExpirationTimeNanos
   62: optional double retryBackoffCoefficient
   64: optional list<string> retryNonRetryableErrors
+  66: optional string retryLastFailureReason
+  68: optional string retryLastWorkerIdentity
+  70: optional binary retryLastFailureDetails
 }
 
 struct ChildExecutionInfo {
@@ -168,10 +180,12 @@ struct ChildExecutionInfo {
   28: optional string createRequestID
   30: optional string domainName
   32: optional string workflowTypeName
+  35: optional i32 parentClosePolicy
 }
 
 struct SignalInfo {
   10: optional i64 (js.type = "Long") version
+  11: optional i64 (js.type = "Long") initiatedEventBatchID
   12: optional string requestID
   14: optional string name
   16: optional binary input
@@ -180,6 +194,7 @@ struct SignalInfo {
 
 struct RequestCancelInfo {
   10: optional i64 (js.type = "Long") version
+  11: optional i64 (js.type = "Long") initiatedEventBatchID
   12: optional string cancelRequestID
 }
 
@@ -187,6 +202,9 @@ struct TimerInfo {
   10: optional i64 (js.type = "Long") version
   12: optional i64 (js.type = "Long") startedID
   14: optional i64 (js.type = "Long") expiryTimeNanos
+  // TaskID is a misleading variable, it actually serves
+  // the purpose of indicating whether a timer task is
+  // generated for this timer info
   16: optional i64 (js.type = "Long") taskID
 }
 

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -12,12 +12,12 @@ describe('Describe Domain', function() {
       isGlobalDomain: false,
       failoverVersion: 0,
       configuration: {
-        archivalBucketName: null,
-        archivalBucketOwner: null,
-        archivalRetentionPeriodInDays: null,
-        archivalStatus: null,
         badBinaries: null,
         emitMetric: false,
+        historyArchivalStatus: null,
+        historyArchivalURI: null,
+        visibilityArchivalStatus: null,
+        visibilityArchivalURI: null,
         workflowExecutionRetentionPeriodInDays: 14
       },
       replicationConfiguration: {
@@ -51,13 +51,13 @@ describe('Describe Domain', function() {
       failoverVersion: 0,
       isGlobalDomain: true,
       configuration: {
-        archivalBucketName: null,
-        archivalBucketOwner: null,
-        archivalRetentionPeriodInDays: null,
-        archivalStatus: null,
         badBinaries: null,
         workflowExecutionRetentionPeriodInDays: 14,
-        emitMetric: true
+        emitMetric: true,
+        historyArchivalStatus: null,
+        historyArchivalURI: null,
+        visibilityArchivalStatus: null,
+        visibilityArchivalURI: null
       },
       replicationConfiguration: {
         activeClusterName: 'ci-cluster',

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -18,7 +18,6 @@ wfHistoryThrift = [{
       emails: ['jane@example.com', 'bob@example.com'],
       includeFooter: true
     })),
-    childPolicy: 'TERMINATE',
     expirationTimestamp: null,
     continuedExecutionRunId: null,
     continuedFailureDetails: null,
@@ -170,7 +169,7 @@ describe('Workflow History', function() {
   })
 
   describe('Export', function() {
-    const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30,"childPolicy":"TERMINATE"}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`
+    const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`
 
     it('should be able to export history in a format compatible with the CLI', function() {
       this.test.GetWorkflowExecutionHistory = ({ getRequest }) => ({

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -29,7 +29,9 @@ describe('Query Workflow', function() {
         query: {
           queryType: 'state',
           queryArgs: null
-        }
+        },
+        queryConsistencyLevel: null,
+        queryRejectCondition: null,
       })
 
       return { queryResult: Buffer.from('foobar') }
@@ -40,6 +42,7 @@ describe('Query Workflow', function() {
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
+        queryRejected: null,
         queryResult: 'foobar',
         queryResult_base64: Buffer.from('foobar').toString('base64')
       })

--- a/server/test/workflow-execution.test.js
+++ b/server/test/workflow-execution.test.js
@@ -15,7 +15,6 @@ describe('Workflow Execution', function() {
       .expect('Content-Type', /json/)
       .expect({
         executionConfiguration: {
-          childPolicy: null,
           taskList: {
             name: 'ci-task-list',
             kind: null
@@ -24,6 +23,7 @@ describe('Workflow Execution', function() {
           executionStartToCloseTimeoutSeconds: null
         },
         workflowExecutionInfo: null,
+        pendingChildren: null,
         pendingActivities: null
       })
   })


### PR DESCRIPTION
Primary motivation for this update was to include the "last" details for a pending activity. This allow you to see this information in the UI rather than having to hit the describe workflow endpoint via the CLI. 

lastFailureReason
lastWorkerIdentity
lastFailureDetails

![image](https://user-images.githubusercontent.com/2300103/75121664-c4ae6e80-565b-11ea-8a7a-a9a6c1d6670b.png)

Running locally seems to show everything working as expected. 

@just-at-uber anyone else I should tag for a review?