### PR TITLE
Changing selecting eventId will no longer snap event into view.

### DIFF
--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -488,13 +488,6 @@ export default {
         console.warn('vue-virtual-scroller: Could not scrollToItem:', error);
       }
     },
-    scrollerUpdate() {
-      const { scrollerCompact, scrollerGrid } = this.$refs;
-      const scroller = this.isGrid ? scrollerGrid : scrollerCompact;
-      if (scroller && scroller.forceUpdate) {
-        scroller.forceUpdate();
-      }
-    },
     selectTimelineEvent(i) {
       this.$router.replaceQueryParam(
         'eventId',
@@ -512,9 +505,6 @@ export default {
     },
   },
   watch: {
-    eventId(eventId) {
-      this.scrollerUpdate();
-    },
     filteredEvents() {
       if (
         !this.scrolledToEventOnInit &&
@@ -652,6 +642,7 @@ section.history
     .tr
       display: flex;
       flex: 1;
+      border: 1px solid transparent;
       &.odd
         background-color: #f8f8f9;
     .td, .th

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -488,6 +488,11 @@ export default {
         console.warn('vue-virtual-scroller: Could not scrollToItem:', error);
       }
     },
+    scrollerUpdate() {
+      const { scrollerCompact, scrollerGrid } = this.$refs;
+      const scroller = this.isGrid ? scrollerGrid : scrollerCompact;
+      scroller.forceUpdate();
+    },
     selectTimelineEvent(i) {
       this.$router.replaceQueryParam(
         'eventId',
@@ -506,7 +511,7 @@ export default {
   },
   watch: {
     eventId(eventId) {
-      this.scrollEventIntoView(eventId);
+      this.scrollerUpdate();
     },
     filteredEvents() {
       if (

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -491,7 +491,9 @@ export default {
     scrollerUpdate() {
       const { scrollerCompact, scrollerGrid } = this.$refs;
       const scroller = this.isGrid ? scrollerGrid : scrollerCompact;
-      scroller.forceUpdate();
+      if (scroller && scroller.forceUpdate) {
+        scroller.forceUpdate();
+      }
     },
     selectTimelineEvent(i) {
       this.$router.replaceQueryParam(

--- a/client/test/execution.test.js
+++ b/client/test/execution.test.js
@@ -1062,66 +1062,6 @@ describe('Execution', () => {
             '/domain/child-domain/workflows/child-wfid/2345/summary'
           );
       });
-
-      it('should scroll the selected event id from compact view into view', async function test() {
-        const [testEl, scenario] = new Scenario(this.test)
-          .withDomain('ci-test')
-          .startingAt(
-            '/domain/ci-test/workflows/long-running-op-1/theRunId/history?format=compact&showGraph=true'
-          )
-          .withExecution('long-running-op-1', 'theRunId')
-          .withHistory(
-            [
-              {
-                timestamp: moment().toISOString(),
-                eventType: 'WorkflowExecutionStarted',
-                eventId: 1,
-                details: {
-                  workflowType: {
-                    name: 'long-running-op',
-                  },
-                },
-              },
-            ].concat(generateActivityEvents(100))
-          )
-          .go(true);
-
-        const historyEl = await testEl.waitUntilExists('section.history');
-
-        await retry(() => {
-          historyEl
-            .querySelectorAll('.compact-view .timeline-event.activity')
-            .should.have.length(8);
-          testEl
-            .querySelectorAll('section.history .timeline .vis-range.activity')
-            .should.have.length(100);
-        });
-
-        historyEl
-          .querySelector(
-            '.vue-recycle-scroller__item-view:nth-of-type(8) .timeline-event.activity'
-          )
-          .trigger('click');
-        await retry(() =>
-          scenario.location.should.equal(
-            '/domain/ci-test/workflows/long-running-op-1/theRunId/history?format=compact&showGraph=true&eventId=9'
-          )
-        );
-        await Promise.delay(100);
-
-        testEl.querySelector('.view-formats a.grid').trigger('click');
-
-        await retry(() => {
-          testEl
-            .querySelectorAll(
-              'section.results .vue-recycle-scroller__item-view .tr'
-            )
-            .should.have.length(17);
-          testEl
-            .querySelector('section.results .vue-recycle-scroller')
-            .scrollTop.should.be.above(450);
-        });
-      });
     });
   });
 


### PR DESCRIPTION
See related issue for detail: 
https://github.com/uber/cadence-web/issues/87

Changing behavior so it no longer snaps the event into view when clicking on a row.

![Screen Shot 2020-02-26 at 2 23 37 PM](https://user-images.githubusercontent.com/58960161/75393759-a33fc380-58a3-11ea-8e38-d89e711cf6e2.png)
