### PR TITLE
Feature/version number

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -1,9 +1,12 @@
 <script>
 import logo from './assets/logo.svg';
+import { version } from '../package.json';
 
 export default {
   data() {
-    return { logo };
+    return {
+      logo,
+    };
   },
   methods: {
     globalClick(e) {
@@ -27,13 +30,21 @@ export default {
       }
     },
   },
+  computed: {
+    version() {
+      return `v${version}`;
+    },
+  },
 };
 </script>
 
 <template>
   <main @click="globalClick">
     <header class="top-bar">
-      <a href="/" class="logo" v-html="logo"></a>
+      <a href="/" class="logo">
+        <div v-html="logo"></div>
+        <span class="version">{{ version }}</span>
+      </a>
       <div class="domain" v-if="$route.params.domain">
         <a
           :href="`/domain/${$route.params.domain}/workflows`"
@@ -102,8 +113,11 @@ header.top-bar
     &.config
       margin-left inline-spacing-medium
       icon('\ea5f')
-    &.logo
-      margin-right layout-spacing-medium
+    &.logo {
+      margin-right: layout-spacing-medium;
+      position: relative;
+    }
+
   svg
     display inline-block
     height top-nav-height - 20px
@@ -145,6 +159,13 @@ header.top-bar
       content 'WORKFLOW ID'
   div.task-list span::before
       content 'TASK LIST'
+  .version {
+    color: #c6c6c6;
+    font-size: 10px;
+    position: absolute;
+    right: 3px;
+    bottom: 0;
+  }
 
 body, main
   height 100%

--- a/client/App.vue
+++ b/client/App.vue
@@ -163,7 +163,7 @@ header.top-bar
     color: #c6c6c6;
     font-size: 10px;
     position: absolute;
-    right: 3px;
+    right: 4px;
     bottom: 0;
   }
 

--- a/client/App.vue
+++ b/client/App.vue
@@ -1,6 +1,6 @@
 <script>
-import logo from './assets/logo.svg';
 import { version } from '../package.json';
+import logo from './assets/logo.svg';
 
 export default {
   data() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.8.0",
+  "version": "3.9.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
Adding a version number just below cadence logo to help with verifying the current version that is running in production.

See issue: https://github.com/uber/cadence-web/issues/91

![Screen Shot 2020-02-26 at 2 54 31 PM](https://user-images.githubusercontent.com/58960161/75395860-164b3900-58a8-11ea-8f44-cf7bf634fa01.png)
