### PR TITLE
Fix/open date range

### DIFF
--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -85,21 +85,9 @@ export const getShortcuts = (maxDays, minStartDate) => {
 export const getTimePanelLabel = showTimePanel =>
   showTimePanel ? 'Select date' : 'Select time';
 
-export const isDateValid = (date, minStartDate, maxEndDate) => {
-  if (!date._isValid) {
-    return false;
-  }
-
-  if (date.isAfter(maxEndDate)) {
-    return false;
-  }
-
-  if (minStartDate && date.isBefore(minStartDate)) {
-    return false;
-  }
-
-  return true;
-};
+export const isDateValid = (date, minStartDate, maxEndDate) => date.isValid &&
+  !date.isAfter(maxEndDate) &&
+  !(minStartDate && date.isBefore(minStartDate));
 
 export const isDayDisabled = minStartDate => date => {
   const momentDate = moment(date);

--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -87,7 +87,7 @@ export const getTimePanelLabel = showTimePanel =>
 
 export const isDateValid = (date, minStartDate, maxEndDate) => date.isValid &&
   !date.isAfter(maxEndDate) &&
-  !(minStartDate && date.isBefore(minStartDate));
+  !(minStartDate && date.isBefore(minStartDate)) || false;
 
 export const isDayDisabled = minStartDate => date => {
   const momentDate = moment(date);

--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -85,9 +85,11 @@ export const getShortcuts = (maxDays, minStartDate) => {
 export const getTimePanelLabel = showTimePanel =>
   showTimePanel ? 'Select date' : 'Select time';
 
-export const isDateValid = (date, minStartDate, maxEndDate) => date.isValid &&
-  !date.isAfter(maxEndDate) &&
-  !(minStartDate && date.isBefore(minStartDate)) || false;
+export const isDateValid = (date, minStartDate, maxEndDate) =>
+  (date.isValid &&
+    !date.isAfter(maxEndDate) &&
+    !(minStartDate && date.isBefore(minStartDate))) ||
+  false;
 
 export const isDayDisabled = minStartDate => date => {
   const momentDate = moment(date);

--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -9,11 +9,6 @@ export const getDateString = date => moment(date).format(DATETIME_FORMAT);
 
 export const getMaxEndDate = now => moment(now).endOf('day');
 
-export const getMinStartDate = (maxDays, now) =>
-  moment(now)
-    .startOf('day')
-    .subtract(maxDays, 'days');
-
 export const getRange = dateRange => {
   if (!dateRange) {
     return [];
@@ -63,8 +58,12 @@ export const getRangeDisplayText = dateRange => {
   return `Last ${parsedCount} ${unit}`;
 };
 
-export const getShortcuts = (maxDays, onClickHandler) => {
+export const getShortcuts = (maxDays, minStartDate) => {
   let options = RANGE_OPTIONS;
+
+  if (!minStartDate) {
+    return options;
+  }
 
   if (maxDays && maxDays < 90) {
     options = options.filter(o => o.daysAgo < maxDays);
@@ -80,21 +79,27 @@ export const getShortcuts = (maxDays, onClickHandler) => {
     options.sort((a, b) => a.daysAgo - b.daysAgo);
   }
 
-  options = options.map(option => ({
-    ...option,
-    onClick: () => onClickHandler(option),
-  }));
-
   return options;
 };
 
 export const getTimePanelLabel = showTimePanel =>
   showTimePanel ? 'Select date' : 'Select time';
 
-export const isDateValid = (date, minStartDate, maxEndDate) =>
-  date._isValid &&
-  date.isSameOrAfter(minStartDate) &&
-  date.isSameOrBefore(maxEndDate);
+export const isDateValid = (date, minStartDate, maxEndDate) => {
+  if (!date._isValid) {
+    return false;
+  }
+
+  if (date.isAfter(maxEndDate)) {
+    return false;
+  }
+
+  if (minStartDate && date.isBefore(minStartDate)) {
+    return false;
+  }
+
+  return true;
+};
 
 export const isDayDisabled = minStartDate => date => {
   const momentDate = moment(date);

--- a/client/components/date-range-picker/helpers.spec.js
+++ b/client/components/date-range-picker/helpers.spec.js
@@ -2,7 +2,6 @@ import moment from 'moment';
 import {
   getDateString,
   getMaxEndDate,
-  getMinStartDate,
   getRange,
   getRangeDisplayText,
   getShortcuts,
@@ -35,43 +34,6 @@ describe('DateRangePicker helpers', () => {
         const output = getMaxEndDate();
 
         expect(output.toISOString()).toEqual('2020-03-11T06:59:59.999Z');
-      });
-    });
-  });
-
-  describe('getMinStartDate', () => {
-    describe('When moment is set to March 10th 2020', () => {
-      beforeEach(() => {
-        jest
-          .spyOn(Date, 'now')
-          .mockImplementation(() => new Date(2020, 2, 10).getTime());
-      });
-
-      describe('and maxDays = 1', () => {
-        it('should return date March 9th 2020.', () => {
-          const maxDays = 1;
-          const output = getMinStartDate(maxDays);
-
-          expect(output.toISOString()).toEqual('2020-03-09T07:00:00.000Z');
-        });
-      });
-
-      describe('and maxDays = 3', () => {
-        it('should return date March 7th 2020.', () => {
-          const maxDays = 3;
-          const output = getMinStartDate(maxDays);
-
-          expect(output.toISOString()).toEqual('2020-03-07T08:00:00.000Z');
-        });
-      });
-
-      describe('and maxDays = 30', () => {
-        it('should return date Feburary 9th 2020.', () => {
-          const maxDays = 30;
-          const output = getMinStartDate(maxDays);
-
-          expect(output.toISOString()).toEqual('2020-02-09T08:00:00.000Z');
-        });
       });
     });
   });
@@ -370,27 +332,18 @@ describe('DateRangePicker helpers', () => {
   });
 
   describe('getShortcuts', () => {
-    describe('When maxDays = 1', () => {
+    describe('When maxDays = 1 and minStartDate is defined', () => {
       const maxDays = 1;
-
-      describe('and onClick function is called', () => {
-        it('should try to call the passed in onClickHandler.', () => {
-          const onClickHandler = jest.fn();
-          const output = getShortcuts(maxDays, onClickHandler);
-
-          output[0].onClick();
-          expect(onClickHandler).toHaveBeenCalled();
-        });
-      });
+      const minStartDate = {};
 
       it('should return 4 shortcuts.', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
 
         expect(output.length).toEqual(4);
       });
 
       it('should not contain "Last 24 hours".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
         const last24HourOption = output.find(
           option => option.text === 'Last 24 hours'
         );
@@ -399,75 +352,97 @@ describe('DateRangePicker helpers', () => {
       });
 
       it('should return the last option as "Last 1 day".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
         const lastOption = output[output.length - 1];
 
         expect(lastOption.text).toEqual('Last 1 day');
       });
     });
 
-    describe('When maxDays = 3', () => {
+    describe('When maxDays = 3 and minStartDate is defined', () => {
       const maxDays = 3;
+      const minStartDate = {};
 
       it('should return 5 shortcuts.', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
 
         expect(output.length).toEqual(5);
       });
 
       it('should return the last option as "Last 3 days".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
         const lastOption = output[output.length - 1];
 
         expect(lastOption.text).toEqual('Last 3 days');
       });
     });
 
-    describe('When maxDays = 7', () => {
+    describe('When maxDays = 7 and minStartDate is defined', () => {
       const maxDays = 7;
+      const minStartDate = {};
 
       it('should return 6 shortcuts.', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
 
         expect(output.length).toEqual(6);
       });
 
       it('should return the last option as "Last 7 days".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
         const lastOption = output[output.length - 1];
 
         expect(lastOption.text).toEqual('Last 7 days');
       });
     });
 
-    describe('When maxDays = 30', () => {
+    describe('When maxDays = 30 and minStartDate is defined', () => {
       const maxDays = 30;
+      const minStartDate = {};
 
       it('should return 7 shortcuts.', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
 
         expect(output.length).toEqual(7);
       });
 
       it('should return the last option as "Last 30 days".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
         const lastOption = output[output.length - 1];
 
         expect(lastOption.text).toEqual('Last 30 days');
       });
     });
 
-    describe('When maxDays = 90', () => {
+    describe('When maxDays = 90 and minStartDate is defined', () => {
       const maxDays = 90;
+      const minStartDate = {};
 
       it('should return 8 shortcuts.', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
 
         expect(output.length).toEqual(8);
       });
 
       it('should return the last option as "Last 3 months".', () => {
-        const output = getShortcuts(maxDays);
+        const output = getShortcuts(maxDays, minStartDate);
+        const lastOption = output[output.length - 1];
+
+        expect(lastOption.text).toEqual('Last 3 months');
+      });
+    });
+
+    describe('When maxDays = 3 and minStartDate = null', () => {
+      const maxDays = 3;
+      const minStartDate = null;
+
+      it('should return 8 shortcuts', () => {
+        const output = getShortcuts(maxDays, minStartDate);
+
+        expect(output.length).toEqual(8);
+      });
+
+      it('should return the last option as "Last 3 months".', () => {
+        const output = getShortcuts(maxDays, minStartDate);
         const lastOption = output[output.length - 1];
 
         expect(lastOption.text).toEqual('Last 3 months');

--- a/client/components/date-range-picker/index.vue
+++ b/client/components/date-range-picker/index.vue
@@ -53,10 +53,6 @@
               />
             </div>
             <div>
-              <label for="custom-range-filter-by">Filter by:</label>
-              <input id="custom-range-filter-by" disabled :value="filterBy" />
-            </div>
-            <div>
               <button
                 class="sidebar-button"
                 type="submit"
@@ -83,7 +79,6 @@ import DatePicker from 'vue2-datepicker';
 import {
   getDateString,
   getMaxEndDate,
-  getMinStartDate,
   getRange,
   getRangeDisplayText,
   getShortcuts,
@@ -93,7 +88,7 @@ import {
 } from './helpers';
 
 export default {
-  props: ['dateRange', 'filterBy', 'maxDays'],
+  props: ['dateRange', 'maxDays', 'minStartDate'],
   data() {
     const range = getRange(this.dateRange);
 
@@ -128,14 +123,11 @@ export default {
     maxEndDate() {
       return getMaxEndDate(this.now);
     },
-    minStartDate() {
-      return getMinStartDate(this.maxDays, this.now);
-    },
     rangeDisplayText() {
       return getRangeDisplayText(this.dateRange);
     },
     shortcuts() {
-      return getShortcuts(this.maxDays, this.onShortcutClick);
+      return getShortcuts(this.maxDays, this.minStartDate);
     },
     startTime() {
       return moment(this.startTimeString);
@@ -200,7 +192,7 @@ export default {
 </script>
 
 <style lang="stylus">
-sidebarColumnCustomRangeWidth = 175px;
+sidebarColumnCustomRangeWidth = 181px;
 sidebarColumnShortcutsWidth = 130px;
 sidebarColumnPadding = 12px;
 sidebarWidth = sidebarColumnShortcutsWidth + sidebarColumnCustomRangeWidth;
@@ -240,7 +232,7 @@ sidebarWidth = sidebarColumnShortcutsWidth + sidebarColumnCustomRangeWidth;
     input {
       margin: 0 0 8px 0;
       padding: 8px 10px;
-      width: 150px;
+      width: 156px;
 
       &.invalid {
         border: 1px solid #D44333;

--- a/client/routes/Workflows.vue
+++ b/client/routes/Workflows.vue
@@ -220,6 +220,7 @@ export default pagedGrid({
 
       if (!this.isRouteRangeValid(this.minStartDate)) {
         this.setRange(`last-${Math.min(30, this.maxRetentionDays)}-days`);
+
         return;
       }
 
@@ -239,7 +240,10 @@ export default pagedGrid({
       this.fetch(`/api/domain/${domain}/workflows/${state}`, q);
     },
     minStartDate() {
-      const { maxRetentionDays, status: { value: status } } = this;
+      const {
+        maxRetentionDays,
+        status: { value: status },
+      } = this;
 
       if (status === 'OPEN') {
         return null;
@@ -342,7 +346,7 @@ export default pagedGrid({
     },
     isRouteRangeValid(minStartDate) {
       const q = this.$route.query || {};
-      const { endTime, range, startTime, status: { value: status } } = q;
+      const { endTime, range, startTime } = q;
 
       if (range) {
         return this.isRangeValid(range, minStartDate);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.10.0",
+  "version": "3.10.1-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.10.1-beta.1",
+  "version": "3.10.1-beta.2",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.10.1-beta.2",
+  "version": "3.10.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.10.1-beta.0",
+  "version": "3.10.1-beta.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
When searching for an Open workflow, there should not be any minimum start date disabled as retention period does not apply to open workflows (only closed workflows).

### Screenshots
<img width="1169" alt="Screen Shot 2020-03-13 at 12 04 15 PM" src="https://user-images.githubusercontent.com/58960161/76652047-03c93480-6523-11ea-9281-7c81c9449e5c.png">

<img width="1169" alt="Screen Shot 2020-03-13 at 12 04 20 PM" src="https://user-images.githubusercontent.com/58960161/76652083-16436e00-6523-11ea-919d-fc35576a6027.png">

<img width="1169" alt="Screen Shot 2020-03-13 at 12 04 36 PM" src="https://user-images.githubusercontent.com/58960161/76652104-20fe0300-6523-11ea-8852-332565ed0e90.png">
