### PR TITLE
Feature/babel alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,16 @@
 {
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "@constants": "./client/constants",
+          "@components": "./client/components",
+          "@helpers": "./client/helpers"
+        }
+      }
+    ]
+  ],
   "presets": [
     [
       "env",

--- a/.babelrc
+++ b/.babelrc
@@ -4,9 +4,9 @@
       "module-resolver",
       {
         "alias": {
-          "@constants": "./client/constants",
-          "@components": "./client/components",
-          "@helpers": "./client/helpers"
+          "~constants": "./client/constants",
+          "~components": "./client/components",
+          "~helpers": "./client/helpers"
         }
       }
     ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,9 +64,9 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      "babel-module": {},
-      "webpack": {
-        "config": "webpack.config.js",
+      'babel-module': {},
+      webpack: {
+        config: 'webpack.config.js',
       },
     },
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,11 @@ module.exports = {
     'space-before-blocks': 'error',
   },
   settings: {
-    'import/resolver': 'webpack',
+    'import/resolver': {
+      "babel-module": {},
+      "webpack": {
+        "config": "webpack.config.js",
+      },
+    },
   },
 };

--- a/client/App.vue
+++ b/client/App.vue
@@ -23,26 +23,6 @@ export default {
     clearTimeout(this.notification.timeout);
   },
   methods: {
-    globalClick(e) {
-      if (this.editing && !this.$refs.domain.contains(e.target)) {
-        this.clearEdit();
-      }
-
-      if (e.target.tagName === 'A') {
-        const href = e.target.getAttribute('href');
-
-        if (
-          href &&
-          href.startsWith('/') &&
-          !e.target.getAttribute('download') &&
-          !e.target.getAttribute('target')
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          this.$router.push(href);
-        }
-      }
-    },
     onNotification({ message, type = NOTIFICATION_TYPE_SUCCESS }) {
       this.notification.message = message;
       this.notification.type = type;
@@ -73,7 +53,7 @@ export default {
 </script>
 
 <template>
-  <main @click="globalClick">
+  <main>
     <NotificationBar
       :message="notification.message"
       :onClose="onNotificationClose"

--- a/client/App.vue
+++ b/client/App.vue
@@ -1,8 +1,8 @@
 <script>
 import { version } from '../package.json';
 import logo from './assets/logo.svg';
-import NotificationBar from './components/notification-bar.vue';
-import { NOTIFICATION_TIMEOUT, NOTIFICATION_TYPE_SUCCESS } from './constants';
+import { NotificationBar } from '@components';
+import { NOTIFICATION_TIMEOUT, NOTIFICATION_TYPE_SUCCESS } from '@constants';
 
 export default {
   components: {

--- a/client/App.vue
+++ b/client/App.vue
@@ -23,6 +23,23 @@ export default {
     clearTimeout(this.notification.timeout);
   },
   methods: {
+    globalClick(e) {
+      // Code required for mocha tests to run correctly without infinite looping.
+      if (e.target.tagName === 'A') {
+        const href = e.target.getAttribute('href');
+
+        if (
+          href &&
+          href.startsWith('/') &&
+          !e.target.getAttribute('download') &&
+          !e.target.getAttribute('target')
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          this.$router.push(href);
+        }
+      }
+    },
     onNotification({ message, type = NOTIFICATION_TYPE_SUCCESS }) {
       this.notification.message = message;
       this.notification.type = type;
@@ -53,7 +70,7 @@ export default {
 </script>
 
 <template>
-  <main>
+  <main @click="globalClick">
     <NotificationBar
       :message="notification.message"
       :onClose="onNotificationClose"

--- a/client/App.vue
+++ b/client/App.vue
@@ -1,8 +1,8 @@
 <script>
 import { version } from '../package.json';
 import logo from './assets/logo.svg';
-import { NotificationBar } from '@components';
-import { NOTIFICATION_TIMEOUT, NOTIFICATION_TYPE_SUCCESS } from '@constants';
+import { NotificationBar } from '~components';
+import { NOTIFICATION_TIMEOUT, NOTIFICATION_TYPE_SUCCESS } from '~constants';
 
 export default {
   components: {

--- a/client/components/copy.vue
+++ b/client/components/copy.vue
@@ -4,6 +4,7 @@
 
 <script>
 export default {
+  name: 'copy',
   props: ['text'],
   methods: {
     copy() {

--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -1,6 +1,6 @@
 <script>
-import { DataViewer } from '@components';
-import { preKeys } from '@constants';
+import { DataViewer } from '~components';
+import { preKeys } from '~constants';
 
 export default {
   name: 'details-list',

--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -1,9 +1,13 @@
 <script>
-import { preKeys } from '../constants';
+import { DataViewer } from '@components';
+import { preKeys } from '@constants';
 
 export default {
   name: 'details-list',
   props: ['compact', 'highlight', 'item', 'title'],
+  components: {
+    'data-viewer': DataViewer,
+  },
   data() {
     return {};
   },

--- a/client/components/domain-navigation.vue
+++ b/client/components/domain-navigation.vue
@@ -50,8 +50,8 @@
 import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
 import { stringify } from 'friendly-querystring';
-import { getKeyValuePairs, mapDomainDescription } from '@helpers';
-import { DetailList } from '@components';
+import { getKeyValuePairs, mapDomainDescription } from '~helpers';
+import { DetailList } from '~components';
 
 const validationMessages = {
   valid: d => `${d} exists`,

--- a/client/components/domain-navigation.vue
+++ b/client/components/domain-navigation.vue
@@ -41,7 +41,7 @@
       v-if="domainDesc"
     >
       <span class="domain-name">{{ domainDescName }}</span>
-      <details-list :item="domainDesc" :title="domainDescName" />
+      <detail-list :item="domainDesc" :title="domainDescName" />
     </div>
   </div>
 </template>
@@ -50,7 +50,8 @@
 import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
 import { stringify } from 'friendly-querystring';
-import { getKeyValuePairs, mapDomainDescription } from '../helpers';
+import { getKeyValuePairs, mapDomainDescription } from '@helpers';
+import { DetailList } from '@components';
 
 const validationMessages = {
   valid: d => `${d} exists`,
@@ -71,6 +72,9 @@ export default {
       domainDescName: undefined,
       domainDescRequest: undefined,
     };
+  },
+  components: {
+    'detail-list': DetailList,
   },
   created() {
     this.domainDescCache = {};

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,0 +1,7 @@
+export { default as BarLoader } from './bar-loader';
+export { default as Copy } from './copy';
+export { default as DataViewer } from './data-viewer';
+export { default as DetailList } from './detail-list';
+export { default as DateRangePicker } from './date-range-picker';
+export { default as DomainNavigation } from './domain-navigation';
+export { default as NotificationBar } from './notification-bar';

--- a/client/helpers/get-error-message.js
+++ b/client/helpers/get-error-message.js
@@ -1,4 +1,4 @@
-import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '../constants';
+import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '@constants';
 
 export default (
   error,

--- a/client/helpers/get-error-message.js
+++ b/client/helpers/get-error-message.js
@@ -1,4 +1,4 @@
-import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '@constants';
+import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '~constants';
 
 export default (
   error,

--- a/client/helpers/get-error-message.spec.js
+++ b/client/helpers/get-error-message.spec.js
@@ -1,5 +1,5 @@
 import getErrorMessage from './get-error-message';
-import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '@constants';
+import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '~constants';
 
 describe('getErrorMessage', () => {
   describe('When passing error.json.message', () => {

--- a/client/helpers/get-error-message.spec.js
+++ b/client/helpers/get-error-message.spec.js
@@ -1,5 +1,5 @@
-import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '../constants';
 import getErrorMessage from './get-error-message';
+import { NOTIFICATION_TYPE_ERROR_MESSAGE_DEFAULT } from '@constants';
 
 describe('getErrorMessage', () => {
   describe('When passing error.json.message', () => {

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
-import { jsonKeys, preKeys } from '../constants';
 import getJsonStringObject from './get-json-string-object';
+import { jsonKeys, preKeys } from '@constants';
 
 const getKeyValuePairs = event => {
   const kvps = [];

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import getJsonStringObject from './get-json-string-object';
-import { jsonKeys, preKeys } from '@constants';
+import { jsonKeys, preKeys } from '~constants';
 
 const getKeyValuePairs = event => {
   const kvps = [];

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,4 +1,4 @@
-import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '@constants';
+import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '~constants';
 
 const getStringElipsis = input =>
   input.length < MAXIMUM_JSON_CHARACTER_LIMIT

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,7 +1,4 @@
-import {
-  MAXIMUM_JSON_CHARACTER_LIMIT,
-  MAXIMUM_JSON_MESSAGE,
-} from '../constants';
+import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '@constants';
 
 const getStringElipsis = input =>
   input.length < MAXIMUM_JSON_CHARACTER_LIMIT

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -1,8 +1,5 @@
-import {
-  MAXIMUM_JSON_CHARACTER_LIMIT,
-  MAXIMUM_JSON_MESSAGE,
-} from '../constants';
 import getStringElipsis from './get-string-elipsis';
+import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '@constants';
 
 describe('getStringElipsis', () => {
   describe('when passed a string that has a length less than MAXIMUM_JSON_CHARACTER_LIMIT', () => {

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -1,5 +1,5 @@
 import getStringElipsis from './get-string-elipsis';
-import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '@constants';
+import { MAXIMUM_JSON_CHARACTER_LIMIT, MAXIMUM_JSON_MESSAGE } from '~constants';
 
 describe('getStringElipsis', () => {
   describe('when passed a string that has a length less than MAXIMUM_JSON_CHARACTER_LIMIT', () => {

--- a/client/main.js
+++ b/client/main.js
@@ -22,7 +22,7 @@ import History from './routes/execution/history.vue';
 import StackTrace from './routes/execution/stack-trace.vue';
 import Queries from './routes/execution/queries.vue';
 import TaskList from './routes/task-list.vue';
-import { http, injectMomentDurationFormat, jsonTryParse } from '@helpers';
+import { http, injectMomentDurationFormat, jsonTryParse } from '~helpers';
 
 const routeOpts = {
   mode: 'history',

--- a/client/main.js
+++ b/client/main.js
@@ -8,12 +8,6 @@ import qs from 'friendly-querystring';
 import moment from 'moment';
 import promiseFinally from 'promise.prototype.finally';
 
-import { http, injectMomentDurationFormat, jsonTryParse } from './helpers';
-
-import DateRangePicker from './components/date-range-picker';
-import detailList from './components/detail-list.vue';
-import barLoader from './components/bar-loader.vue';
-import dataViewer from './components/data-viewer.vue';
 import copyButton from './components/copy.vue';
 
 import snapscroll from './directives/snapscroll';
@@ -28,6 +22,7 @@ import History from './routes/execution/history.vue';
 import StackTrace from './routes/execution/stack-trace.vue';
 import Queries from './routes/execution/queries.vue';
 import TaskList from './routes/task-list.vue';
+import { http, injectMomentDurationFormat, jsonTryParse } from '@helpers';
 
 const routeOpts = {
   mode: 'history',
@@ -188,11 +183,7 @@ Vue.use(vueModal, {
 });
 Vue.use(vueSplit);
 Vue.component('v-select', vueSelect);
-Vue.component('date-range-picker', DateRangePicker);
 Vue.component('copy', copyButton);
-Vue.component('bar-loader', barLoader);
-Vue.component('data-viewer', dataViewer);
-Vue.component('details-list', detailList);
 Vue.directive('snapscroll', snapscroll);
 Vue.config.ignoredElements = ['loader'];
 

--- a/client/routes/Intro.vue
+++ b/client/routes/Intro.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import { DomainNavigation } from '@components';
+import { DomainNavigation } from '~components';
 
 export default {
   data() {

--- a/client/routes/Intro.vue
+++ b/client/routes/Intro.vue
@@ -30,14 +30,14 @@
 </template>
 
 <script>
-import domainNav from '../components/domain-navigate.vue';
+import { DomainNavigation } from '@components';
 
 export default {
   data() {
     return {};
   },
   components: {
-    'domain-navigation': domainNav,
+    'domain-navigation': DomainNavigation,
   },
 };
 </script>

--- a/client/routes/Workflows.vue
+++ b/client/routes/Workflows.vue
@@ -108,7 +108,8 @@
 <script>
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
-import pagedGrid from '../components/paged-grid';
+import pagedGrid from '@components/paged-grid';
+import { DateRangePicker } from '@components';
 
 export default pagedGrid({
   data() {
@@ -158,6 +159,9 @@ export default pagedGrid({
   },
   beforeDestroy() {
     clearInterval(this.interval);
+  },
+  components: {
+    'date-range-picker': DateRangePicker,
   },
   computed: {
     filterBy() {

--- a/client/routes/Workflows.vue
+++ b/client/routes/Workflows.vue
@@ -108,8 +108,8 @@
 <script>
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
-import pagedGrid from '@components/paged-grid';
-import { DateRangePicker } from '@components';
+import pagedGrid from '~components/paged-grid';
+import { DateRangePicker } from '~components';
 
 export default pagedGrid({
   data() {

--- a/client/routes/domain-config.vue
+++ b/client/routes/domain-config.vue
@@ -3,7 +3,7 @@
     <header>
       <h3>{{ domain }}</h3>
     </header>
-    <details-list
+    <detail-list
       v-if="domainConfig"
       :item="domainConfig"
       :title="`Domain ${domain} Configuration`"
@@ -13,7 +13,8 @@
 </template>
 
 <script>
-import { getKeyValuePairs, mapDomainDescription } from '../helpers';
+import { getKeyValuePairs, mapDomainDescription } from '@helpers';
+import { DetailList } from '@components';
 
 export default {
   data() {
@@ -24,6 +25,9 @@ export default {
     };
   },
   props: ['domain'],
+  components: {
+    'detail-list': DetailList,
+  },
   created() {
     this.$http(`/api/domain/${this.domain}`)
       .then(

--- a/client/routes/domain-config.vue
+++ b/client/routes/domain-config.vue
@@ -13,8 +13,8 @@
 </template>
 
 <script>
-import { getKeyValuePairs, mapDomainDescription } from '@helpers';
-import { DetailList } from '@components';
+import { getKeyValuePairs, mapDomainDescription } from '~helpers';
+import { DetailList } from '~components';
 
 export default {
   data() {

--- a/client/routes/execution/event-details.vue
+++ b/client/routes/execution/event-details.vue
@@ -1,13 +1,18 @@
 <script>
+import { DetailList } from '@components';
+
 export default {
   name: 'event-details',
   props: ['event', 'compact', 'highlight'],
+  components: {
+    'detail-list': DetailList,
+  },
   render(h) {
     if (!this.event) {
       return null;
     }
 
-    return h('details-list', {
+    return h('detail-list', {
       props: {
         item: this.event,
         highlight: this.highlight,

--- a/client/routes/execution/event-details.vue
+++ b/client/routes/execution/event-details.vue
@@ -1,5 +1,5 @@
 <script>
-import { DetailList } from '@components';
+import { DetailList } from '~components';
 
 export default {
   name: 'event-details',

--- a/client/routes/execution/event-node.vue
+++ b/client/routes/execution/event-node.vue
@@ -1,6 +1,7 @@
 <script>
 import moment from 'moment';
-import { getKeyValuePairs, shortName } from '../../helpers';
+import { getKeyValuePairs, shortName } from '@helpers';
+import { DetailList } from '@components';
 
 const titlesForGroups = {
   ActivityTaskScheduled: n =>
@@ -73,6 +74,9 @@ function titleForNode(n) {
 export default {
   name: 'event-node',
   props: ['node'],
+  components: {
+    'detail-list': DetailList,
+  },
   render(h) {
     const activeId = this.$route.query.eventId;
     const router = this.$router;
@@ -87,7 +91,7 @@ export default {
         showDetails && findActiveGroupNode(node, activeId, true);
       const detailsList =
         activeGroupNode &&
-        h('details-list', {
+        h('detail-list', {
           props: {
             item: {
               kvps: getKeyValuePairs(activeGroupNode.details),

--- a/client/routes/execution/event-node.vue
+++ b/client/routes/execution/event-node.vue
@@ -1,7 +1,7 @@
 <script>
 import moment from 'moment';
-import { getKeyValuePairs, shortName } from '@helpers';
-import { DetailList } from '@components';
+import { getKeyValuePairs, shortName } from '~helpers';
+import { DetailList } from '~components';
 
 const titlesForGroups = {
   ActivityTaskScheduled: n =>

--- a/client/routes/execution/helpers/get-event-details.js
+++ b/client/routes/execution/helpers/get-event-details.js
@@ -1,4 +1,4 @@
-import { getKeyValuePairs } from '@helpers';
+import { getKeyValuePairs } from '~helpers';
 
 const getEventDetails = event => {
   const { details, eventId, eventType, timeStampDisplay } = event;

--- a/client/routes/execution/helpers/get-event-details.js
+++ b/client/routes/execution/helpers/get-event-details.js
@@ -1,4 +1,4 @@
-import { getKeyValuePairs } from '../../../helpers';
+import { getKeyValuePairs } from '@helpers';
 
 const getEventDetails = event => {
   const { details, eventId, eventType, timeStampDisplay } = event;

--- a/client/routes/execution/helpers/get-event-details.spec.js
+++ b/client/routes/execution/helpers/get-event-details.spec.js
@@ -1,6 +1,6 @@
 import getEventDetails from './get-event-details';
 
-jest.mock('@helpers');
+jest.mock('~helpers');
 
 describe('getEventDetails', () => {
   describe('When passed an event', () => {

--- a/client/routes/execution/helpers/get-event-details.spec.js
+++ b/client/routes/execution/helpers/get-event-details.spec.js
@@ -1,6 +1,6 @@
 import getEventDetails from './get-event-details';
 
-jest.mock('../../../helpers');
+jest.mock('@helpers');
 
 describe('getEventDetails', () => {
   describe('When passed an event', () => {

--- a/client/routes/execution/helpers/get-event-full-details.js
+++ b/client/routes/execution/helpers/get-event-full-details.js
@@ -1,5 +1,5 @@
 import { eventFullTransforms } from './event-full-transforms';
-import { getKeyValuePairs } from '@helpers';
+import { getKeyValuePairs } from '~helpers';
 
 const getEventFullDetails = event => {
   if (!event) {

--- a/client/routes/execution/helpers/get-event-full-details.js
+++ b/client/routes/execution/helpers/get-event-full-details.js
@@ -1,5 +1,5 @@
-import { getKeyValuePairs } from '../../../helpers';
 import { eventFullTransforms } from './event-full-transforms';
+import { getKeyValuePairs } from '@helpers';
 
 const getEventFullDetails = event => {
   if (!event) {

--- a/client/routes/execution/helpers/get-event-full-details.spec.js
+++ b/client/routes/execution/helpers/get-event-full-details.spec.js
@@ -1,6 +1,6 @@
 import getEventFullDetails from './get-event-full-details';
 
-jest.mock('../../../helpers');
+jest.mock('@helpers');
 
 describe('getEventFullDetails', () => {
   describe('When passed no event', () => {

--- a/client/routes/execution/helpers/get-event-full-details.spec.js
+++ b/client/routes/execution/helpers/get-event-full-details.spec.js
@@ -1,6 +1,6 @@
 import getEventFullDetails from './get-event-full-details';
 
-jest.mock('@helpers');
+jest.mock('~helpers');
 
 describe('getEventFullDetails', () => {
   describe('When passed no event', () => {

--- a/client/routes/execution/helpers/get-event-summary.js
+++ b/client/routes/execution/helpers/get-event-summary.js
@@ -1,5 +1,5 @@
-import { getKeyValuePairs } from '../../../helpers';
 import { summarizeEvents } from './summarize-events';
+import { getKeyValuePairs } from '@helpers';
 
 const getEventSummary = event => {
   if (!event) {

--- a/client/routes/execution/helpers/get-event-summary.js
+++ b/client/routes/execution/helpers/get-event-summary.js
@@ -1,5 +1,5 @@
 import { summarizeEvents } from './summarize-events';
-import { getKeyValuePairs } from '@helpers';
+import { getKeyValuePairs } from '~helpers';
 
 const getEventSummary = event => {
   if (!event) {

--- a/client/routes/execution/helpers/get-event-summary.spec.js
+++ b/client/routes/execution/helpers/get-event-summary.spec.js
@@ -1,6 +1,6 @@
 import getEventSummary from './get-event-summary';
 
-jest.mock('../../../helpers');
+jest.mock('@helpers');
 
 describe('getEventSummary', () => {
   describe('When passed no event', () => {

--- a/client/routes/execution/helpers/get-event-summary.spec.js
+++ b/client/routes/execution/helpers/get-event-summary.spec.js
@@ -1,6 +1,6 @@
 import getEventSummary from './get-event-summary';
 
-jest.mock('@helpers');
+jest.mock('~helpers');
 
 describe('getEventSummary', () => {
   describe('When passed no event', () => {

--- a/client/routes/execution/helpers/map-timeline-events.js
+++ b/client/routes/execution/helpers/map-timeline-events.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { summarizeEvents } from './summarize-events';
-import { shortName } from '@helpers';
+import { shortName } from '~helpers';
 
 export default function(historyEvents) {
   const events = [];

--- a/client/routes/execution/helpers/map-timeline-events.js
+++ b/client/routes/execution/helpers/map-timeline-events.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
-import { shortName } from '../../../helpers';
 import { summarizeEvents } from './summarize-events';
+import { shortName } from '@helpers';
 
 export default function(historyEvents) {
   const events = [];

--- a/client/routes/execution/helpers/summarize-events.js
+++ b/client/routes/execution/helpers/summarize-events.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
-import { shortName } from '../../../helpers';
 import parentWorkflowLink from './parent-workflow-link';
 import workflowLink from './workflow-link';
+import { shortName } from '@helpers';
 
 export const summarizeEvents = {
   ActivityTaskCancelRequested: d => ({ ID: d.activityId }),

--- a/client/routes/execution/helpers/summarize-events.js
+++ b/client/routes/execution/helpers/summarize-events.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import parentWorkflowLink from './parent-workflow-link';
 import workflowLink from './workflow-link';
-import { shortName } from '@helpers';
+import { shortName } from '~helpers';
 
 export const summarizeEvents = {
   ActivityTaskCancelRequested: d => ({ ID: d.activityId }),

--- a/client/routes/execution/helpers/workflow-link.js
+++ b/client/routes/execution/helpers/workflow-link.js
@@ -1,4 +1,4 @@
-import { shortName } from '@helpers';
+import { shortName } from '~helpers';
 
 const workflowLink = (d, short) => {
   const text = [

--- a/client/routes/execution/helpers/workflow-link.js
+++ b/client/routes/execution/helpers/workflow-link.js
@@ -1,4 +1,4 @@
-import { shortName } from '../../../helpers';
+import { shortName } from '@helpers';
 
 const workflowLink = (d, short) => {
   const text = [

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -199,7 +199,7 @@
                   @click.prevent="selectTimelineEvent(item)"
                 >
                   <span class="event-title">{{ item.content }}</span>
-                  <details-list
+                  <detail-list
                     :compact="true"
                     :item="item.details"
                     :title="item.content"
@@ -224,7 +224,7 @@
                 :to="selectedTimelineEvent.titleLink"
                 >{{ selectedTimelineEvent.content }}</router-link
               >
-              <details-list
+              <detail-list
                 class="timeline-details"
                 :item="selectedTimelineEvent.details"
                 :title="selectedTimelineEvent.content"
@@ -242,7 +242,7 @@
                   {{ events.find(event => event.eventId === eid).eventType }}
                 </a>
               </div>
-              <details-list
+              <detail-list
                 class="event-details"
                 :item="selectedEventDetails"
                 :title="
@@ -270,6 +270,7 @@ import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
 import timeline from './timeline.vue';
 import eventDetails from './event-details.vue';
+import { DetailList } from '@components';
 
 export default {
   name: 'history',
@@ -519,6 +520,7 @@ export default {
     },
   },
   components: {
+    'detail-list': DetailList,
     DynamicScroller,
     DynamicScrollerItem,
     'event-details': eventDetails,

--- a/client/routes/execution/history.vue
+++ b/client/routes/execution/history.vue
@@ -270,7 +270,7 @@ import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
 import timeline from './timeline.vue';
 import eventDetails from './event-details.vue';
-import { DetailList } from '@components';
+import { DetailList } from '~components';
 
 export default {
   name: 'history',

--- a/client/routes/execution/index.vue
+++ b/client/routes/execution/index.vue
@@ -59,8 +59,8 @@ import {
   getHistoryTimelineEvents,
   getSummary,
 } from './helpers';
-import { NOTIFICATION_TYPE_ERROR } from '@constants';
-import { getErrorMessage } from '@helpers';
+import { NOTIFICATION_TYPE_ERROR } from '~constants';
+import { getErrorMessage } from '~helpers';
 
 export default {
   data() {

--- a/client/routes/execution/index.vue
+++ b/client/routes/execution/index.vue
@@ -53,14 +53,14 @@
 </template>
 
 <script>
-import { NOTIFICATION_TYPE_ERROR } from '../../constants';
-import { getErrorMessage } from '../../helpers';
 import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from './constants';
 import {
   getHistoryEvents,
   getHistoryTimelineEvents,
   getSummary,
 } from './helpers';
+import { NOTIFICATION_TYPE_ERROR } from '@constants';
+import { getErrorMessage } from '@helpers';
 
 export default {
   data() {

--- a/client/routes/execution/summary.vue
+++ b/client/routes/execution/summary.vue
@@ -124,9 +124,9 @@
 <script>
 import moment from 'moment';
 import { TERMINATE_DEFAULT_ERROR_MESSAGE } from './constants';
-import { NOTIFICATION_TYPE_ERROR, NOTIFICATION_TYPE_SUCCESS } from '@constants';
-import { getErrorMessage } from '@helpers';
-import { BarLoader, DataViewer, DetailList } from '@components';
+import { NOTIFICATION_TYPE_ERROR, NOTIFICATION_TYPE_SUCCESS } from '~constants';
+import { getErrorMessage } from '~helpers';
+import { BarLoader, DataViewer, DetailList } from '~components';
 
 export default {
   data() {

--- a/client/routes/execution/summary.vue
+++ b/client/routes/execution/summary.vue
@@ -114,7 +114,7 @@
       <div class="pending-activities" v-if="workflow.pendingActivities">
         <dt>Pending Activities</dt>
         <dd v-for="pa in workflow.pendingActivities" :key="pa.activityID">
-          <details-list :item="pa" />
+          <detail-list :item="pa" />
         </dd>
       </div>
     </dl>
@@ -123,12 +123,10 @@
 
 <script>
 import moment from 'moment';
-import {
-  NOTIFICATION_TYPE_ERROR,
-  NOTIFICATION_TYPE_SUCCESS,
-} from '../../constants';
-import { getErrorMessage } from '../../helpers';
 import { TERMINATE_DEFAULT_ERROR_MESSAGE } from './constants';
+import { NOTIFICATION_TYPE_ERROR, NOTIFICATION_TYPE_SUCCESS } from '@constants';
+import { getErrorMessage } from '@helpers';
+import { BarLoader, DataViewer, DetailList } from '@components';
 
 export default {
   data() {
@@ -147,6 +145,11 @@ export default {
     'workflow',
     'workflowId',
   ],
+  components: {
+    'bar-loader': BarLoader,
+    'data-viewer': DataViewer,
+    'detail-list': DetailList,
+  },
   computed: {
     workflowCloseTime() {
       return this.workflow.workflowExecutionInfo.closeTime

--- a/jest.config.js
+++ b/jest.config.js
@@ -83,7 +83,11 @@ module.exports = {
   ],
 
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '@components': '<rootDir>/client/components',
+    '@constants': '<rootDir>/client/constants',
+    '@helpers': '<rootDir>/client/helpers',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/jest.config.js
+++ b/jest.config.js
@@ -83,11 +83,7 @@ module.exports = {
   ],
 
   // A map from regular expressions to module names that allow to stub out resources with a single module
-  moduleNameMapper: {
-    '@components': '<rootDir>/client/components',
-    '@constants': '<rootDir>/client/constants',
-    '@helpers': '<rootDir>/client/helpers',
-  },
+  // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/polyfill": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "babel-loader": "^8.0.6",
+    "babel-plugin-module-resolver": "^4.0.0",
     "babel-preset-env": "^1.7.0",
     "css-loader": "^0.28.7",
     "deepmerge": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.10.1",
+  "version": "3.11.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint": "^6.8.0",
     "eslint-config-fusion": "^6.1.0",
     "eslint-config-prettier": "^6.9.0",
+    "eslint-import-resolver-babel-module": "^5.1.2",
     "eslint-import-resolver-webpack": "^0.12.1",
     "eslint-plugin-chai-friendly": "^0.5.0",
     "eslint-plugin-cup": "^2.0.2",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,6 @@
 // polyfills for web browser to node
 import atob from 'atob';
-import { injectMomentDurationFormat, jsonTryParse } from '../client/helpers';
+import { injectMomentDurationFormat, jsonTryParse } from '@helpers';
 
 global.atob = atob;
 global.JSON.tryParse = jsonTryParse;

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,6 @@
 // polyfills for web browser to node
 import atob from 'atob';
-import { injectMomentDurationFormat, jsonTryParse } from '@helpers';
+import { injectMomentDurationFormat, jsonTryParse } from '~helpers';
 
 global.atob = atob;
 global.JSON.tryParse = jsonTryParse;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,11 +85,11 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: ['.js', '.vue']
-  },
-  resolve: {
     alias: {
-      'vue$': 'vue/dist/vue.esm.js'
+      'vue$': 'vue/dist/vue.esm.js',
+      '@components': path.resolve(__dirname, 'client/components'),
+      '@constants': path.resolve(__dirname, 'client/constants'),
+      '@helpers': path.resolve(__dirname, 'client/helpers'),
     },
     extensions: ['*', '.js', '.vue', '.json']
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,9 +87,6 @@ module.exports = {
   resolve: {
     alias: {
       'vue$': 'vue/dist/vue.esm.js',
-      '@components': path.resolve(__dirname, 'client/components'),
-      '@constants': path.resolve(__dirname, 'client/constants'),
-      '@helpers': path.resolve(__dirname, 'client/helpers'),
     },
     extensions: ['*', '.js', '.vue', '.json']
   },


### PR DESCRIPTION
- Adding babel alias which helps with importing global constants, components & helpers.
- Removing clearEdit in App.vue as there is no method to call anymore.
- Removed most component init code in main, it will now need those components imported in the relevant places where these are used. Makes it easier to know where a custom component comes from as it is needed when referencing now.