### PR TITLE
Fix/random dev dependency fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:dubnium
 WORKDIR /usr/cadence-web
 
 ENV NODE_ENV=production
+ENV NPM_CONFIG_PRODUCTION=true
 
 # Install app dependencies
 COPY package*.json ./

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.13.0",
+  "version": "3.13.1-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.13.1-beta.0",
+  "version": "3.13.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
See related issue on stack overflow and their suggested fix:
https://stackoverflow.com/questions/55550262/why-is-devdependencies-pruning-skipped-even-if-npm-config-production-is-true

It essentially is installing dev dependencies and then deleting them after build completes. The env variable just disallows dev dependencies from installing (how node used to work).