### PR TITLE
Fix/last failure details ellipsis

### DIFF
--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="executions" :class="{ loading: wfLoading }">
+  <section class="execution" :class="{ loading: wfLoading }">
     <navigation-bar>
       <navigation-link
         id="nav-link-summary"

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="workflow" :class="{ loading: wfLoading }">
+  <section class="executions" :class="{ loading: wfLoading }">
     <navigation-bar>
       <navigation-link
         id="nav-link-summary"

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -199,6 +199,14 @@ section.workflow-summary
   overflow auto
   padding layout-spacing-small
 
+  .pending-activities {
+    dl.details {
+      dd {
+        white-space: normal;
+      }
+    }
+  }
+
   dl:not(.details)
     & > div
       margin-bottom 1em

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -38,7 +38,7 @@ describe('Workflow', () => {
     scenario.withFullHistory(opts.events);
     const summaryEl = await scenario
       .render(opts.attach)
-      .waitUntilExists('section.workflow section.workflow-summary dl');
+      .waitUntilExists('section.execution section.workflow-summary dl');
 
     return [summaryEl.parentElement, scenario];
   }
@@ -1056,7 +1056,7 @@ describe('Workflow', () => {
       const [, scenario] = await summaryTest(this.test);
 
       scenario.vm.$el
-        .attrValues('section.workflow > nav a', 'href')
+        .attrValues('section.execution > nav a', 'href')
         .should.deep.equal([
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/summary',
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/history',
@@ -1064,10 +1064,10 @@ describe('Workflow', () => {
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/query',
         ]);
       scenario.vm.$el
-        .querySelector('section.workflow > nav a#nav-link-stack-trace')
+        .querySelector('section.execution > nav a#nav-link-stack-trace')
         .should.not.have.property('display', 'none');
       scenario.vm.$el
-        .querySelector('section.workflow > nav a#nav-link-query')
+        .querySelector('section.execution > nav a#nav-link-query')
         .should.not.have.property('display', 'none');
     });
 
@@ -1151,7 +1151,7 @@ describe('Workflow', () => {
 
       const queryEl = await scenario
         .render()
-        .waitUntilExists('section.workflow section.query');
+        .waitUntilExists('section.execution section.query');
 
       return [queryEl, scenario];
     }
@@ -1230,7 +1230,7 @@ describe('Workflow', () => {
       });
 
       scenario.vm.$el
-        .attrValues('section.workflow > nav a', 'href')
+        .attrValues('section.execution > nav a', 'href')
         .should.deep.equal([
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/summary',
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/history',
@@ -1238,13 +1238,13 @@ describe('Workflow', () => {
           '/domains/ci-test/workflows/email-daily-summaries/emailRun1/query',
         ]);
       scenario.vm.$el
-        .querySelector('section.workflow > nav a#nav-link-summary')
+        .querySelector('section.execution > nav a#nav-link-summary')
         .should.have.class('router-link-active');
       await retry(() => {
         scenario.vm.$el.querySelector(
-          'section.workflow > nav a#nav-link-stack-trace'
+          'section.execution > nav a#nav-link-stack-trace'
         ).should.not.be.displayed;
-        scenario.vm.$el.querySelector('section.workflow > nav a#nav-link-query')
+        scenario.vm.$el.querySelector('section.execution > nav a#nav-link-query')
           .should.not.be.displayed;
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.14.0-beta.0",
+  "version": "3.13.2-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.13.2-beta.0",
+  "version": "3.13.2",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
Fixing bug: https://github.com/uber/cadence-web/issues/118

Essentially allowing content to wrap to fix failure details from ellipsis