### PR TITLE
fix/news-link

### DIFF
--- a/client/components/news-modal.vue
+++ b/client/components/news-modal.vue
@@ -34,7 +34,7 @@
           <flex-grid-item>
             <router-link
               class="see-more"
-              to="news"
+              :to="{ name: 'news' }"
               v-on:click.native="onLinkClick"
             >
               See more news . . .


### PR DESCRIPTION
Fixing link to now navigate to news page irrelevant on the current route you are on.
Previously if you were say on workflows list screen, it would try to switch to `/domain/news` instead of just `/news`