### PR TITLE
Resolves issue where the summary page would throw an error due to a activity task cancelled appearing in the event history

### DIFF
--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -6,6 +6,7 @@ import { shortName } from '~helpers';
 export const summarizeEvents = {
   ActivityTaskCancelRequested: d => ({ ID: d.activityId }),
   ActivityTaskCompleted: d => ({ result: d.result }),
+  ActivityTaskCanceled: d => ({}),
   ActivityTaskFailed: d => ({
     details: d.details,
     reason: d.reason,


### PR DESCRIPTION
Fixes #148 