### PR TITLE
Feature/populate history result

### DIFF
--- a/client/routes/workflow/helpers/get-summary.js
+++ b/client/routes/workflow/helpers/get-summary.js
@@ -25,7 +25,7 @@ const getSummary = ({ events, isWorkflowRunning, workflow }) => {
   }
 
   const firstEvent = events[0];
-  const lastEvent = events.length > 1 && events[events.length - 1];
+  const lastEvent = workflow.workflowExecutionInfo.closeEvent || events.length > 1 && events[events.length - 1];
 
   const input = getJsonStringObject(firstEvent.details.input);
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -193,10 +193,10 @@ router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (
     if (describeResponse.workflowExecutionInfo) {
       describeResponse.workflowExecutionInfo.closeEvent = null;
       if (describeResponse.workflowExecutionInfo.closeStatus) {
-        const lastEventResponse = await ctx.cadence.getHistory({
+        const closeEventResponse = await ctx.cadence.getHistory({
           HistoryEventFilterType: 'CLOSE_EVENT',
         });
-        describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(lastEventResponse.history)[0];
+        describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(closeEventResponse.history)[0];
       }
     }
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -188,7 +188,18 @@ router.post('/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal', 
 
 router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (ctx) {
   try {
-    ctx.body = await ctx.cadence.describeWorkflow();
+    const describeResponse = await ctx.cadence.describeWorkflow();
+
+    // TODO - check if workflow is still running - i.e. don't populate result if it is still running...
+
+    /*
+    const lastEventResponse = await ctx.cadence.getHistory({
+      HistoryEventFilterType: 'CLOSE_EVENT',
+    });
+    describeResponse.workflowExecutionInfo.result = mapHistoryResponse(lastEventResponse.history)[0];
+    */
+
+    ctx.body = describeResponse;
   } catch (error) {
     if (error.name !== 'NotFoundError') {
       throw error;

--- a/server/routes.js
+++ b/server/routes.js
@@ -189,13 +189,15 @@ router.post('/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal', 
 router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (ctx) {
   try {
     const describeResponse = await ctx.cadence.describeWorkflow();
-    describeResponse.workflowExecutionInfo.closeEvent = null;
 
-    if (describeResponse.workflowExecutionInfo.closeStatus) {
-      const lastEventResponse = await ctx.cadence.getHistory({
-        HistoryEventFilterType: 'CLOSE_EVENT',
-      });
-      describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(lastEventResponse.history)[0];
+    if (describeResponse.workflowExecutionInfo) {
+      describeResponse.workflowExecutionInfo.closeEvent = null;
+      if (describeResponse.workflowExecutionInfo.closeStatus) {
+        const lastEventResponse = await ctx.cadence.getHistory({
+          HistoryEventFilterType: 'CLOSE_EVENT',
+        });
+        describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(lastEventResponse.history)[0];
+      }
     }
 
     ctx.body = describeResponse;

--- a/server/routes.js
+++ b/server/routes.js
@@ -189,15 +189,14 @@ router.post('/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal', 
 router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (ctx) {
   try {
     const describeResponse = await ctx.cadence.describeWorkflow();
+    describeResponse.workflowExecutionInfo.closeEvent = null;
 
-    // TODO - check if workflow is still running - i.e. don't populate result if it is still running...
-
-    /*
-    const lastEventResponse = await ctx.cadence.getHistory({
-      HistoryEventFilterType: 'CLOSE_EVENT',
-    });
-    describeResponse.workflowExecutionInfo.result = mapHistoryResponse(lastEventResponse.history)[0];
-    */
+    if (describeResponse.workflowExecutionInfo.closeStatus) {
+      const lastEventResponse = await ctx.cadence.getHistory({
+        HistoryEventFilterType: 'CLOSE_EVENT',
+      });
+      describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(lastEventResponse.history)[0];
+    }
 
     ctx.body = describeResponse;
   } catch (error) {


### PR DESCRIPTION
Fixing a bug where the frontend can't populate the result in summary page because history size is too large. This change will fetch the close event on the summary call if the workflow has finished executing. This means the frontend doesn't need to wait for all the history request calls to return before rendering the result.