### PR TITLE
Fix for event which should not be a span but a point.

### DIFF
--- a/client/routes/workflow/helpers/map-timeline-events.js
+++ b/client/routes/workflow/helpers/map-timeline-events.js
@@ -168,7 +168,6 @@ export default function(historyEvents) {
         className: 'external-signal',
         eventIds: [e.eventId],
         start: moment(e.timestamp),
-        ongoing: true,
         content: 'External Workflow Signaled',
         details: summarizeEvents.SignalExternalWorkflowExecutionInitiated(
           e.details


### PR DESCRIPTION
Closes #99 

This change fixes a bug where even if the reset workflow is completed, the timeline still continues to grow. This is because the "External Workflow Signaled" event should be a point on the timeline rather than a span. Because it's a span, the timeline will remain open which causes the timeline to never complete. This change will change the event span to a point which also closes the timeline as it is expected to be. See screenshot for more context.

## Screenshots
### Before
<img width="1680" alt="Screen Shot 2020-06-22 at 3 49 06 PM" src="https://user-images.githubusercontent.com/58960161/85342628-f3b8dd80-b49f-11ea-8662-782c18a240d2.png">

### After
<img width="1680" alt="Screen Shot 2020-06-22 at 3 44 35 PM" src="https://user-images.githubusercontent.com/58960161/85342648-fca9af00-b49f-11ea-9cd0-6886f8317824.png">
