### PR TITLE
Fix query types parsing for Java workflows

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -164,7 +164,7 @@ router.get('/api/domains/:domain/workflows/:workflowId/:runId/query', async func
   } catch(e) {
     ctx.body = ((e.message || '')
       .match(/(KnownQueryTypes|knownTypes)=\[(.*)\]/) || [null, null, ''])[2]
-      .split(' ')
+      .split(/, | /)
       .filter(q => q)
   }
 })


### PR DESCRIPTION
Fix verified with both Java and Go workflows

closes #194 