### PR TITLE
Feature/reduce docker size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required # https://github.com/travis-ci/travis-ci/issues/8836
 language: node_js
 node_js:
-  - 8
+  - 10
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:dubnium-stretch AS BUILD_IMAGE
 
+### Build step ###
 WORKDIR /usr/build
 
 # Install app dependencies
@@ -12,16 +13,23 @@ COPY . .
 # Bundle the client code
 RUN npm run build-production
 
+# switch to lite version of node
 FROM node:dubnium-slim
 
+### Run step ###
 WORKDIR /usr/app
 
+# copy from build image
+COPY --from=BUILD_IMAGE /usr/build/server.js ./
+COPY --from=BUILD_IMAGE /usr/build/webpack.config.js ./
+COPY --from=BUILD_IMAGE /usr/build/dist ./dist
+COPY --from=BUILD_IMAGE /usr/build/server ./server
+COPY --from=BUILD_IMAGE /usr/build/node_modules ./node_modules
+
+# setup production environment variables
 ENV NODE_ENV=production
 ENV NPM_CONFIG_PRODUCTION=true
 
-# copy from build image
-COPY --from=BUILD_IMAGE /usr/build/dist ./dist
-COPY --from=BUILD_IMAGE /usr/build/node_modules ./node_modules
-
+# run node server
 EXPOSE 8088
 CMD [ "node", "server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:dubnium
+FROM node:dubnium-stretch AS BUILD_IMAGE
 
 WORKDIR /usr/cadence-web
 
@@ -14,6 +14,17 @@ COPY . .
 
 # Bundle the client code
 RUN npm run build-production
+
+FROM node:dubnium-slim
+
+WORKDIR /usr/cadence-web
+
+ENV NODE_ENV=production
+ENV NPM_CONFIG_PRODUCTION=true
+
+# copy from build image
+COPY --from=BUILD_IMAGE /usr/cadence-web/dist ./dist
+COPY --from=BUILD_IMAGE /usr/cadence-web/node_modules ./node_modules
 
 EXPOSE 8088
 CMD [ "node", "server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM node:dubnium-stretch AS BUILD_IMAGE
 
-WORKDIR /usr/cadence-web
-
-ENV NODE_ENV=production
-ENV NPM_CONFIG_PRODUCTION=true
+WORKDIR /usr/build
 
 # Install app dependencies
 COPY package*.json ./
@@ -17,14 +14,14 @@ RUN npm run build-production
 
 FROM node:dubnium-slim
 
-WORKDIR /usr/cadence-web
+WORKDIR /usr/app
 
 ENV NODE_ENV=production
 ENV NPM_CONFIG_PRODUCTION=true
 
 # copy from build image
-COPY --from=BUILD_IMAGE /usr/cadence-web/dist ./dist
-COPY --from=BUILD_IMAGE /usr/cadence-web/node_modules ./node_modules
+COPY --from=BUILD_IMAGE /usr/build/dist ./dist
+COPY --from=BUILD_IMAGE /usr/build/node_modules ./node_modules
 
 EXPOSE 8088
 CMD [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Set these environment variables if you need to change their defaults
 
 ### Running locally
 
-`cadence-web` uses all the standard [npm scripts](https://docs.npmjs.com/misc/scripts) to install dependencies, run the server, and run tests. Additionally to run locally with webpack hot reloading and other conveniences, use
+`cadence-web` requires node `v10.22.1` or greater to be able to run correctly. `cadence-web` uses all the standard [npm scripts](https://docs.npmjs.com/misc/scripts) to install dependencies, run the
+server, and run tests. Additionally to run locally with webpack hot reloading and other conveniences, use
 
 ```
 npm run dev

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Nathan Black <nathanbl@uber.com>",
   "engines": {
-    "node": "10.21.0",
+    "node": "10.22.1",
     "npm": "6.14.4"
   },
   "dependencies": {


### PR DESCRIPTION
**Changes include:**
- updated minimum supported node version in package.json (`v10.22.1`)
- document minimum supported node version in README.md
- bump node version to `v10` for travis CI (inline with minimum supported node version)
- changes to dockerfile to help improve size (reduced `1.25Gb` -> `285Mb`):
  - separate build & run steps with separate working directories (`/usr/build` & `/usr/app`)
  - change to stretch & slim versions of node dubnium (`v10.22.1`)
  - only copy over build files that are used by server in run step
  - tested image with cadence samples and is working

**Screenshots**
Before:
<img width="703" alt="Screen Shot 2020-10-09 at 10 30 06 AM" src="https://user-images.githubusercontent.com/58960161/95630446-b10f1700-0a36-11eb-901d-4bc0b783b4df.png">

After:
<img width="725" alt="Screen Shot 2020-10-09 at 10 29 49 AM" src="https://user-images.githubusercontent.com/58960161/95630467-b9ffe880-0a36-11eb-82ce-3dac63bc1153.png">