### PR TITLE
Update IDL to match cadence-server v0.15 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "webpack-hot-client": "^1.3.0"
   },
   "napa": {
-    "cadence-idl": "uber/cadence-idl#ecaf5a6121ad015e836b7a8cfda111e3400e45ed"
+    "cadence-idl": "uber/cadence-idl#87b3154c204df27e6055a5a1cf840973b627877f"
   }
 }

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -4,6 +4,7 @@ describe('Listing Workflows', function() {
       workflowId: 'demo',
       runId: 'd92bb92c-5f49-487f-80a8-f8f375ba55a8'
     },
+    // taskList: ['helloworld'],
     type: {
       name: 'github.com/uber/cadence/demo.cronWorkflow'
     },
@@ -20,6 +21,7 @@ describe('Listing Workflows', function() {
   },
   demoExecJson = Object.assign({}, demoExecThrift, {
     startTime: '2017-11-10T21:30:00.000Z',
+    taskList: null,
   })
 
   it('should list open workflows', function() {

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -4,7 +4,6 @@ describe('Listing Workflows', function() {
       workflowId: 'demo',
       runId: 'd92bb92c-5f49-487f-80a8-f8f375ba55a8'
     },
-    // taskList: ['helloworld'],
     type: {
       name: 'github.com/uber/cadence/demo.cronWorkflow'
     },


### PR DESCRIPTION
**What changed**
- bump idl package to commit 87b3154 to match cadence-server v0.15 release.
- Fixed failing integration tests

I have tested locally spinning up cadence server with latest IDL change and seems to run fine.