### PR TITLE
fix/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM node:dubnium-stretch AS BUILD_IMAGE
 ### Build step ###
 WORKDIR /usr/build
 
-# Install app dependencies
-COPY package*.json ./
-RUN npm install --production
-
 # Bundle app source
 COPY . .
+
+# Install app dependencies
+RUN npm install --production --unsafe-perm
 
 # Bundle the client code
 RUN npm run build-production

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "server/index.js",
   "licence": "MIT",
   "scripts": {
+    "clean": "rm -rf dist",
     "dev": "NODE_ENV=development node server.js",
     "eslint": "eslint --ext .js,.vue client --fix",
     "install": "npm run install:idl && npm run install:news",
@@ -16,7 +17,7 @@
     "test-server": "CADENCE_WEB_PORT=8090 TEST_RUN=ci node server.js",
     "build": "webpack",
     "build:news": "cd news && npm run build && cp -R blog/.vuepress/dist ../",
-    "build-production": "NODE_ENV=production npm run build && npm run build:news"
+    "build-production": "NODE_ENV=production npm run clean && npm run build && npm run build:news"
   },
   "keywords": [
     "uber",


### PR DESCRIPTION
Fixing dockerfile and build step to ensure container can build without `node_modules` present in repository.

This is to fix error when npm install failed with `“cannot run in wd”` for install step.
See [stackoverflow: cannot run in wd](https://stackoverflow.com/questions/18136746/npm-install-failed-with-cannot-run-in-wd)

See more documentation on `--unsafe-perm` here (should be a relatively safe option to include):
[What does unsafe perm in npm actually do](https://geedew.com/What-does-unsafe-perm-in-npm-actually-do/)

The clean step is added to ensure the `dist` folder doesn't grow with each subsequent container build if running locally (as these files are not deleted after each build).