### PR TITLE
Force dependency resolution after sub dependencies breaks build

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
     "nathanboktae-browser-test-utils": "^0.1.0",
     "supertest": "^3.0.0",
     "webpack-hot-client": "^1.3.0"
+  },
+  "optionalDependencies": {
+    "hammerjs": "2.0.8",
+    "propagating-hammerjs": "1.4.6"
   }
 }


### PR DESCRIPTION
Going back to a previously stable build is currently not an option (v3.4.1).
This hotfix is to address hammerjs bumping its version to a non-backwards compatible change.
For releases prior to v3.19.3, this will also fix this issue if including this change.