### PR TITLE
Add linter to build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ env:
     secure: RpfO25V9JlHtiLzQqtSiu9kGAS3RdczVV2XE4ley/6f/n/bsFUPMezqPG7INnb/pDNJTU1WvdKjbt1Neavr9Y8qPzWYopgmD+zV74er+2x5r0GPni/3jyGztuvGWVYl131BStA3Rjx4tf5cz+N02Fwx71ERu1S21nHeYsy5mifxyps9VIvLhxdt/RkXQDGz4iqv44AMIJHobGxl1OPgPWKB113Ob2E+vpqOiraxdpMmgO4VJbqKm0qy7An/q/1OEQ+MPuYWYQA8gJAx8fUdkg/ckptFed55mTIW3R+4IlSLOxj8MdDpythyqaypC3T39YCA43NXQGNxujZ0zpp7CgBBWf/F+wNacQ1B5DYFdkIe2CfcDBZHe8ERQcn+sbldbV0xoTly7FB2xmQPZBb3uIePtqCOYPz8gEl3XugcuRAnT4bQ14FOQ7jFxxHzEW/+qOXgSRosF2t+4oFkTK1zjtwn4gWBm09Rdy6/L/BvPBgzPZ5LRGe4JAegWjB76lmZ3IF70Oj6ZJPe3fnJE64fC7ogdYM8RhEED2cEdNQdH0mNU30/Z9jsodT/fIAba3etwqF5AZbuc8HCfVz7ojS2Hl3twKtbHZ3T0VPkhcNb8v6RHIO4PbqkWfTEAG3rh54dpHXq9Gqn3RexycrhRPtCD0xulPdp5i7T39Xzo/tCb96w=
 
 before_script:
+  - npm run lint:check
   - npm run test-server &
   - sleep 5

--- a/client/helpers/get-escaped-forward-slash.js
+++ b/client/helpers/get-escaped-forward-slash.js
@@ -1,2 +1,3 @@
-const getEscapedForwardSlash = (str) => str.replace(/\//g, '%2F');
+const getEscapedForwardSlash = str => str.replace(/\//g, '%2F');
+
 export default getEscapedForwardSlash;

--- a/client/helpers/get-escaped-forward-slash.spec.js
+++ b/client/helpers/get-escaped-forward-slash.spec.js
@@ -4,24 +4,28 @@ describe('getEscapedForwardSlash', () => {
   it('should escape one forward slash and convert to %2F.', () => {
     const input = '/';
     const output = getEscapedForwardSlash(input);
+
     expect(output).toEqual('%2F');
   });
 
   it('should escape many forward slashes and convert each to %2F.', () => {
     const input = '///';
     const output = getEscapedForwardSlash(input);
+
     expect(output).toEqual('%2F%2F%2F');
   });
 
   it('should convert forward slashes in a string containing other characters with forward slashes.', () => {
     const input = 'hello/world';
     const output = getEscapedForwardSlash(input);
+
     expect(output).toEqual('hello%2Fworld');
   });
 
   it('should not do anything if string does not contain forward slash.', () => {
-    const input = 'hello\world';
+    const input = 'helloworld';
     const output = getEscapedForwardSlash(input);
-    expect(output).toEqual('hello\world');
+
+    expect(output).toEqual('helloworld');
   });
 });

--- a/client/main.js
+++ b/client/main.js
@@ -34,7 +34,12 @@ import WorkflowList from './routes/domain/workflow-list';
 import WorkflowSummary from './routes/workflow/summary';
 import WorkflowTabs from './routes/workflow';
 
-import { getEscapedForwardSlash, http, injectMomentDurationFormat, jsonTryParse } from '~helpers';
+import {
+  getEscapedForwardSlash,
+  http,
+  injectMomentDurationFormat,
+  jsonTryParse,
+} from '~helpers';
 
 const routeOpts = {
   mode: 'history',

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -135,6 +135,7 @@ export default {
   computed: {
     baseAPIURL() {
       const { domain, workflowId, runId } = this;
+
       return `/api/domains/${domain}/workflows/${workflowId}/${runId}`;
     },
     historyEvents() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "clean": "rm -rf dist",
     "dev": "NODE_ENV=development node server.js",
-    "eslint": "eslint --ext .js,.vue client --fix",
+    "lint": "npm run lint-check -- --fix",
+    "lint:check": "eslint --ext .js,.vue client",
     "install": "npm run install:idl && npm run install:news",
     "install:idl": "napa && rm -rf server/idl && cp -R node_modules/cadence-idl/thrift server/idl",
     "install:news": "cd news && npm install",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "dev": "NODE_ENV=development node server.js",
-    "lint": "npm run lint-check -- --fix",
+    "lint": "npm run lint:check -- --fix",
     "lint:check": "eslint --ext .js,.vue client",
     "install": "npm run install:idl && npm run install:news",
     "install:idl": "napa && rm -rf server/idl && cp -R node_modules/cadence-idl/thrift server/idl",


### PR DESCRIPTION
Currently lint is not enforced on the CI build pipeline.
This PR will introduce it to the pipeline to make sure lint is passing.
This PR also contains lint fixes to ensure the build is passing.
Running `npm run lint` will try to auto fix simple lint errors.
Running `npm run lint:check` will run the linter but will not auto fix lint errors (this is what will be run on the CI build pipeline).

## Screenshots
**Build failing**
<img width="1224" alt="Screen Shot 2020-11-20 at 9 49 24 AM" src="https://user-images.githubusercontent.com/58960161/99832782-ec146800-2b15-11eb-98db-2893e6e08183.png">

**Build passing**
<img width="1135" alt="Screen Shot 2020-11-20 at 9 55 39 AM" src="https://user-images.githubusercontent.com/58960161/99833200-955b5e00-2b16-11eb-9fd1-678d5bb8fb53.png">
