### PR TITLE
Fix/script ordering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,12 @@ module.exports = {
       },
     ],
     'space-before-blocks': 'error',
+    'vue/component-tags-order': [
+      'error',
+      {
+        'order': ['script', 'template', 'style'],
+      }
+    ],
   },
   settings: {
     'import/resolver': {

--- a/client/components/bar-loader.vue
+++ b/client/components/bar-loader.vue
@@ -1,3 +1,9 @@
+<script>
+export default {
+  name: 'bar-loader',
+};
+</script>
+
 <template>
   <loader class="bar"
     ><div></div>
@@ -5,12 +11,6 @@
     <div></div
   ></loader>
 </template>
-
-<script>
-export default {
-  name: 'bar-loader',
-};
-</script>
 
 <style lang="stylus">
 @require "../styles/definitions.styl"

--- a/client/components/button-fill.vue
+++ b/client/components/button-fill.vue
@@ -1,22 +1,3 @@
-<template>
-  <component
-    :aria-disabled="disabled"
-    class="button-fill"
-    :class="{
-      disabled: disabled,
-      [color]: color,
-    }"
-    :disabled="disabled"
-    :href="href"
-    :is="tag"
-    :to="to"
-    :title="disabledLabelText"
-    @click="onClick"
-  >
-    {{ label }}
-  </component>
-</template>
-
 <script>
 export default {
   name: 'button-fill',
@@ -60,6 +41,25 @@ export default {
   },
 };
 </script>
+
+<template>
+  <component
+    :aria-disabled="disabled"
+    class="button-fill"
+    :class="{
+      disabled: disabled,
+      [color]: color,
+    }"
+    :disabled="disabled"
+    :href="href"
+    :is="tag"
+    :to="to"
+    :title="disabledLabelText"
+    @click="onClick"
+  >
+    {{ label }}
+  </component>
+</template>
 
 <style lang="stylus">
 .button-fill {

--- a/client/components/button-icon.vue
+++ b/client/components/button-icon.vue
@@ -1,4 +1,3 @@
-
 <script>
 export default {
   name: 'button-icon',

--- a/client/components/button-icon.vue
+++ b/client/components/button-icon.vue
@@ -1,24 +1,3 @@
-<template>
-  <component
-    :aria-disabled="disabled"
-    class="button-icon"
-    :class="{ disabled: disabled }"
-    :disabled="disabled"
-    :href="href"
-    :is="tag"
-    :to="to"
-    @click="onClick"
-  >
-    <span
-      class="icon"
-      :class="{ [icon]: icon, [color]: color }"
-      :style="{ 'font-size': size }"
-    />
-    <span class="label" :class="{ [color]: color }" v-if="label">{{
-      label
-    }}</span>
-  </component>
-</template>
 
 <script>
 export default {
@@ -61,6 +40,28 @@ export default {
   },
 };
 </script>
+
+<template>
+  <component
+    :aria-disabled="disabled"
+    class="button-icon"
+    :class="{ disabled: disabled }"
+    :disabled="disabled"
+    :href="href"
+    :is="tag"
+    :to="to"
+    @click="onClick"
+  >
+    <span
+      class="icon"
+      :class="{ [icon]: icon, [color]: color }"
+      :style="{ 'font-size': size }"
+    />
+    <span class="label" :class="{ [color]: color }" v-if="label">{{
+      label
+    }}</span>
+  </component>
+</template>
 
 <style lang="stylus">
 .button-icon {

--- a/client/components/copy.vue
+++ b/client/components/copy.vue
@@ -1,4 +1,3 @@
-
 <script>
 export default {
   name: 'copy',

--- a/client/components/copy.vue
+++ b/client/components/copy.vue
@@ -1,6 +1,3 @@
-<template>
-  <a href="#" class="copy" @click.prevent="copy"></a>
-</template>
 
 <script>
 export default {
@@ -33,6 +30,10 @@ export default {
   },
 };
 </script>
+
+<template>
+  <a href="#" class="copy" @click.prevent="copy"></a>
+</template>
 
 <style lang="stylus">
 @require "../styles/definitions.styl"

--- a/client/components/data-viewer.vue
+++ b/client/components/data-viewer.vue
@@ -1,14 +1,3 @@
-<template>
-  <div class="data-viewer">
-    <a
-      href="#"
-      class="view-full-screen"
-      @click.stop.prevent="viewFullScreen"
-    ></a>
-    <prism language="json" ref="codebox">{{ item.jsonStringDisplay }}</prism>
-  </div>
-</template>
-
 <script>
 import 'prismjs';
 import 'prismjs/components/prism-json';
@@ -78,6 +67,17 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="data-viewer">
+    <a
+      href="#"
+      class="view-full-screen"
+      @click.stop.prevent="viewFullScreen"
+    ></a>
+    <prism language="json" ref="codebox">{{ item.jsonStringDisplay }}</prism>
+  </div>
+</template>
 
 <style lang="stylus">
 @require "../styles/definitions.styl"

--- a/client/components/date-range-picker/index.vue
+++ b/client/components/date-range-picker/index.vue
@@ -1,78 +1,3 @@
-<template>
-  <div class="date-range-picker">
-    <date-picker
-      range
-      type="datetime"
-      v-model="range"
-      :clearable="false"
-      :disabled-date="isDayDisabled"
-      :showTimePanel="showTimePanel"
-      :open.sync="open"
-      @change="onDateRangeChange"
-    >
-      <template v-slot:input>
-        <input
-          placeholder="Date Range"
-          readonly
-          type="text"
-          :value="rangeDisplayText"
-        />
-      </template>
-      <template v-slot:sidebar>
-        <div class="sidebar-column sidebar-column-shortcuts">
-          <h5>Quick ranges</h5>
-          <button
-            class="mx-btn mx-btn-text mx-btn-shortcut"
-            type="button"
-            v-for="shortcut in shortcuts"
-            :key="shortcut.value"
-            @click="onShortcutClick(shortcut)"
-          >
-            {{ shortcut.text }}
-          </button>
-        </div>
-        <div class="sidebar-column sidebar-column-custom-range">
-          <form @submit.prevent="onCustomRangeSubmit">
-            <h5>Custom range</h5>
-            <div>
-              <label for="custom-range-from">From:</label>
-              <input
-                id="custom-range-from"
-                maxlength="19"
-                v-model="startTimeString"
-                :class="{ invalid: startTimeInvalid }"
-              />
-            </div>
-            <div>
-              <label for="custom-range-to">To:</label>
-              <input
-                id="custom-range-to"
-                maxlength="19"
-                v-model="endTimeString"
-                :class="{ invalid: endTimeInvalid }"
-              />
-            </div>
-            <div>
-              <button
-                class="sidebar-button"
-                type="submit"
-                :disabled="startOrEndTimeInvalid"
-              >
-                Apply
-              </button>
-            </div>
-          </form>
-        </div>
-      </template>
-      <template v-slot:footer>
-        <button class="mx-btn mx-btn-text" @click="onClickTimePanelLabel">
-          {{ timePanelLabel }}
-        </button>
-      </template>
-    </date-picker>
-  </div>
-</template>
-
 <script>
 import moment from 'moment';
 import DatePicker from 'vue2-datepicker';
@@ -190,6 +115,81 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="date-range-picker">
+    <date-picker
+      range
+      type="datetime"
+      v-model="range"
+      :clearable="false"
+      :disabled-date="isDayDisabled"
+      :showTimePanel="showTimePanel"
+      :open.sync="open"
+      @change="onDateRangeChange"
+    >
+      <template v-slot:input>
+        <input
+          placeholder="Date Range"
+          readonly
+          type="text"
+          :value="rangeDisplayText"
+        />
+      </template>
+      <template v-slot:sidebar>
+        <div class="sidebar-column sidebar-column-shortcuts">
+          <h5>Quick ranges</h5>
+          <button
+            class="mx-btn mx-btn-text mx-btn-shortcut"
+            type="button"
+            v-for="shortcut in shortcuts"
+            :key="shortcut.value"
+            @click="onShortcutClick(shortcut)"
+          >
+            {{ shortcut.text }}
+          </button>
+        </div>
+        <div class="sidebar-column sidebar-column-custom-range">
+          <form @submit.prevent="onCustomRangeSubmit">
+            <h5>Custom range</h5>
+            <div>
+              <label for="custom-range-from">From:</label>
+              <input
+                id="custom-range-from"
+                maxlength="19"
+                v-model="startTimeString"
+                :class="{ invalid: startTimeInvalid }"
+              />
+            </div>
+            <div>
+              <label for="custom-range-to">To:</label>
+              <input
+                id="custom-range-to"
+                maxlength="19"
+                v-model="endTimeString"
+                :class="{ invalid: endTimeInvalid }"
+              />
+            </div>
+            <div>
+              <button
+                class="sidebar-button"
+                type="submit"
+                :disabled="startOrEndTimeInvalid"
+              >
+                Apply
+              </button>
+            </div>
+          </form>
+        </div>
+      </template>
+      <template v-slot:footer>
+        <button class="mx-btn mx-btn-text" @click="onClickTimePanelLabel">
+          {{ timePanelLabel }}
+        </button>
+      </template>
+    </date-picker>
+  </div>
+</template>
 
 <style lang="stylus">
 sidebarColumnCustomRangeWidth = 181px;

--- a/client/components/domain-navigation.vue
+++ b/client/components/domain-navigation.vue
@@ -1,51 +1,3 @@
-<template>
-  <div class="domain-navigation" :class="'validation-' + validation">
-    <div class="input-and-validation">
-      <div class="input-wrapper">
-        <input
-          type="text"
-          name="domain"
-          spellcheck="false"
-          autocorrect="off"
-          ref="input"
-          v-bind:value="d"
-          :placeholder="$props.placeholder"
-          @input="onInput"
-          @keydown.enter="changeDomain"
-          @keydown.esc="onEsc"
-        />
-        <a
-          :href="validation === 'valid' ? '#' : ''"
-          class="change-domain"
-          @click="changeDomain"
-        ></a>
-      </div>
-      <p :class="'validation validation-' + validation">
-        {{ validationMessage }}
-      </p>
-    </div>
-    <ul class="recent-domains" v-if="recentDomains.length">
-      <h3>Recent Domains</h3>
-      <li v-for="domain in recentDomains" :key="domain">
-        <a
-          :href="domainLink(domain)"
-          :data-domain="domain"
-          @click="recordDomainFromClick"
-          @mouseover="showDomainDesc(domain)"
-          >{{ domain }}</a
-        >
-      </li>
-    </ul>
-    <div
-      :class="{ 'domain-description': true, pending: !!domainDescRequest }"
-      v-if="domainDesc"
-    >
-      <span class="domain-name">{{ domainDescName }}</span>
-      <detail-list :item="domainDesc" :title="domainDescName" />
-    </div>
-  </div>
-</template>
-
 <script>
 import debounce from 'lodash-es/debounce';
 import omit from 'lodash-es/omit';
@@ -193,6 +145,54 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="domain-navigation" :class="'validation-' + validation">
+    <div class="input-and-validation">
+      <div class="input-wrapper">
+        <input
+          type="text"
+          name="domain"
+          spellcheck="false"
+          autocorrect="off"
+          ref="input"
+          v-bind:value="d"
+          :placeholder="$props.placeholder"
+          @input="onInput"
+          @keydown.enter="changeDomain"
+          @keydown.esc="onEsc"
+        />
+        <a
+          :href="validation === 'valid' ? '#' : ''"
+          class="change-domain"
+          @click="changeDomain"
+        ></a>
+      </div>
+      <p :class="'validation validation-' + validation">
+        {{ validationMessage }}
+      </p>
+    </div>
+    <ul class="recent-domains" v-if="recentDomains.length">
+      <h3>Recent Domains</h3>
+      <li v-for="domain in recentDomains" :key="domain">
+        <a
+          :href="domainLink(domain)"
+          :data-domain="domain"
+          @click="recordDomainFromClick"
+          @mouseover="showDomainDesc(domain)"
+          >{{ domain }}</a
+        >
+      </li>
+    </ul>
+    <div
+      :class="{ 'domain-description': true, pending: !!domainDescRequest }"
+      v-if="domainDesc"
+    >
+      <span class="domain-name">{{ domainDescName }}</span>
+      <detail-list :item="domainDesc" :title="domainDescName" />
+    </div>
+  </div>
+</template>
 
 <style lang="stylus">
 @require "../styles/definitions.styl"

--- a/client/components/error-message.vue
+++ b/client/components/error-message.vue
@@ -1,3 +1,10 @@
+<script>
+export default {
+  name: 'error-message',
+  props: ['error'],
+};
+</script>
+
 <template>
   <div class="error-message-container" v-if="error">
     <span class="error">
@@ -5,13 +12,6 @@
     </span>
   </div>
 </template>
-
-<script>
-export default {
-  name: 'error-message',
-  props: ['error'],
-};
-</script>
 
 <style lang="stylus">
 .error-message-container {

--- a/client/components/feature-flag.vue
+++ b/client/components/feature-flag.vue
@@ -1,13 +1,3 @@
-<template>
-  <div
-    class="feature-flag"
-    :class="{ [display]: display }"
-    v-if="isFeatureFlagEnabled"
-  >
-    <slot></slot>
-  </div>
-</template>
-
 <script>
 import { FeatureFlagService } from '~services';
 
@@ -42,6 +32,17 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div
+    class="feature-flag"
+    :class="{ [display]: display }"
+    v-if="isFeatureFlagEnabled"
+  >
+    <slot></slot>
+  </div>
+</template>
+
 <style lang="stylus">
 .feature-flag {
   &.inline {

--- a/client/components/flex-grid-item.vue
+++ b/client/components/flex-grid-item.vue
@@ -1,3 +1,10 @@
+<script>
+export default {
+  name: 'flex-grid-item',
+  props: ['grow', 'margin', 'width'],
+};
+</script>
+
 <template>
   <div
     class="flex-grid-item"
@@ -6,13 +13,6 @@
     <slot></slot>
   </div>
 </template>
-
-<script>
-export default {
-  name: 'flex-grid-item',
-  props: ['grow', 'margin', 'width'],
-};
-</script>
 
 <style lang="stylus">
 .flex-grid-item {

--- a/client/components/flex-grid.vue
+++ b/client/components/flex-grid.vue
@@ -1,17 +1,3 @@
-<template>
-  <div
-    class="flex-grid"
-    :style="{
-      'align-items': alignItems,
-      'flex-direction': flexDirection,
-      'justify-content': justifyContent,
-      width: width,
-    }"
-  >
-    <slot></slot>
-  </div>
-</template>
-
 <script>
 export default {
   props: {
@@ -31,6 +17,20 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div
+    class="flex-grid"
+    :style="{
+      'align-items': alignItems,
+      'flex-direction': flexDirection,
+      'justify-content': justifyContent,
+      width: width,
+    }"
+  >
+    <slot></slot>
+  </div>
+</template>
 
 <style lang="stylus">
 .flex-grid {

--- a/client/components/highlight-toggle.vue
+++ b/client/components/highlight-toggle.vue
@@ -1,19 +1,3 @@
-<template>
-  <component class="highlight-toggle" :is="tag">
-    <span class="label" :class="{ highlight: isHighlighted }">
-      {{ label }}
-    </span>
-    <button-icon
-      :class="{
-        active: isHighlighted,
-        disabled: !isEnabled,
-      }"
-      icon="icon_search"
-      @click="onClick"
-    />
-  </component>
-</template>
-
 <script>
 import ButtonIcon from './button-icon';
 
@@ -48,6 +32,22 @@ export default {
   },
 };
 </script>
+
+<template>
+  <component class="highlight-toggle" :is="tag">
+    <span class="label" :class="{ highlight: isHighlighted }">
+      {{ label }}
+    </span>
+    <button-icon
+      :class="{
+        active: isHighlighted,
+        disabled: !isEnabled,
+      }"
+      icon="icon_search"
+      @click="onClick"
+    />
+  </component>
+</template>
 
 <style lang="stylus">
 .highlight-toggle {

--- a/client/components/loading-message.vue
+++ b/client/components/loading-message.vue
@@ -1,9 +1,3 @@
-<template>
-  <div class="loading-message" v-if="showMessage">
-    <slot></slot>
-  </div>
-</template>
-
 <script>
 export default {
   name: 'loading-message',
@@ -42,6 +36,12 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="loading-message" v-if="showMessage">
+    <slot></slot>
+  </div>
+</template>
 
 <style lang="stylus">
 @keyframes loadingMessageFadeIn {

--- a/client/components/loading-spinner.vue
+++ b/client/components/loading-spinner.vue
@@ -1,3 +1,9 @@
+<script>
+export default {
+  name: 'loading-spinner',
+};
+</script>
+
 <template>
   <div class="loading-spinner">
     <div class="spinner"></div>

--- a/client/components/navigation-bar.vue
+++ b/client/components/navigation-bar.vue
@@ -1,14 +1,14 @@
-<template>
-  <nav class="navigation-bar">
-    <slot></slot>
-  </nav>
-</template>
-
 <script>
 export default {
   name: 'navigation-bar',
 };
 </script>
+
+<template>
+  <nav class="navigation-bar">
+    <slot></slot>
+  </nav>
+</template>
 
 <style lang="stylus">
 .navigation-bar {

--- a/client/components/navigation-link.vue
+++ b/client/components/navigation-link.vue
@@ -1,3 +1,10 @@
+<script>
+export default {
+  name: 'navigation-link',
+  props: ['exact', 'icon', 'id', 'label', 'to'],
+};
+</script>
+
 <template>
   <router-link
     class="navigation-link"
@@ -9,13 +16,6 @@
     {{ label }}
   </router-link>
 </template>
-
-<script>
-export default {
-  name: 'navigation-link',
-  props: ['exact', 'icon', 'id', 'label', 'to'],
-};
-</script>
 
 <style lang="stylus">
 a.navigation-link {

--- a/client/components/news-modal.vue
+++ b/client/components/news-modal.vue
@@ -1,3 +1,28 @@
+<script>
+import { ButtonFill, ButtonIcon, FlexGrid, FlexGridItem } from '~components';
+
+export default {
+  props: ['newsItems'],
+  methods: {
+    onLinkClick() {
+      this.$modal.hide('news-modal');
+    },
+    onDismissClick() {
+      this.$modal.hide('news-modal');
+    },
+    onBeforeClose() {
+      this.$emit('before-close');
+    },
+  },
+  components: {
+    'button-fill': ButtonFill,
+    'button-icon': ButtonIcon,
+    'flex-grid': FlexGrid,
+    'flex-grid-item': FlexGridItem,
+  },
+};
+</script>
+
 <template>
   <modal name="news-modal" @before-close="onBeforeClose">
     <div class="news-modal">
@@ -48,31 +73,6 @@
     </div>
   </modal>
 </template>
-
-<script>
-import { ButtonFill, ButtonIcon, FlexGrid, FlexGridItem } from '~components';
-
-export default {
-  props: ['newsItems'],
-  methods: {
-    onLinkClick() {
-      this.$modal.hide('news-modal');
-    },
-    onDismissClick() {
-      this.$modal.hide('news-modal');
-    },
-    onBeforeClose() {
-      this.$emit('before-close');
-    },
-  },
-  components: {
-    'button-fill': ButtonFill,
-    'button-icon': ButtonIcon,
-    'flex-grid': FlexGrid,
-    'flex-grid-item': FlexGridItem,
-  },
-};
-</script>
 
 <style lang="stylus">
 .news-modal {

--- a/client/components/no-results.vue
+++ b/client/components/no-results.vue
@@ -1,3 +1,10 @@
+<script>
+export default {
+  name: 'no-results',
+  props: ['results'],
+};
+</script>
+
 <template>
   <div class="no-results-container" v-if="results && !results.length">
     <div class="no-results">
@@ -5,13 +12,6 @@
     </div>
   </div>
 </template>
-
-<script>
-export default {
-  name: 'no-results',
-  props: ['results'],
-};
-</script>
 
 <style lang="stylus">
 .no-results-container {

--- a/client/components/notification-bar.vue
+++ b/client/components/notification-bar.vue
@@ -1,14 +1,3 @@
-<template>
-  <transition name="fade">
-    <div class="notification-bar" :class="type" v-if="show">
-      <div class="message">
-        {{ message }}
-      </div>
-      <span class="close icon icon_delete" @click="onClose" />
-    </div>
-  </transition>
-</template>
-
 <script>
 export default {
   name: 'notification-bar',
@@ -20,6 +9,17 @@ export default {
   ],
 };
 </script>
+
+<template>
+  <transition name="fade">
+    <div class="notification-bar" :class="type" v-if="show">
+      <div class="message">
+        {{ message }}
+      </div>
+      <span class="close icon icon_delete" @click="onClose" />
+    </div>
+  </transition>
+</template>
 
 <style scoped lang="stylus">
 UberGreen = #3AA76D;

--- a/client/components/settings-modal/components/settings-date-format.vue
+++ b/client/components/settings-modal/components/settings-date-format.vue
@@ -1,62 +1,3 @@
-<template>
-  <div>
-    <div class="content">
-      <div class="content-item">
-        <label for="settingsExample">
-          Example
-        </label>
-        <text-input
-          name="settingsExample"
-          :readonly="true"
-          :value="exampleFormattedDateTime"
-        />
-      </div>
-      <div class="content-item">
-        <flex-grid>
-          <flex-grid-item grow="1">
-            <label for="settingsDateFormat">
-              Date format
-            </label>
-            <v-select
-              input-id="settingsDateFormat"
-              :on-change="onDateFormatChange"
-              :options="dateFormatOptions"
-              :value="modalDateFormat"
-            />
-          </flex-grid-item>
-          <flex-grid-item grow="1">
-            <label for="settingsTimeFormat">
-              Time format
-            </label>
-            <v-select
-              input-id="settingsTimeFormat"
-              :on-change="onTimeFormatChange"
-              :options="timeFormatOptions"
-              :value="modalTimeFormat"
-            />
-          </flex-grid-item>
-          <flex-grid-item grow="1">
-            <label for="settingsTimezone">
-              Timezone
-            </label>
-            <v-select
-              input-id="settingsTimezone"
-              :on-change="onTimezoneChange"
-              :options="timezoneOptions"
-              :value="modalTimezone"
-            />
-          </flex-grid-item>
-        </flex-grid>
-      </div>
-    </div>
-    <settings-footer
-      :submit-enabled="isSettingsChanged"
-      @cancel="onClose"
-      @submit="onSubmit"
-    />
-  </div>
-</template>
-
 <script>
 import FlexGrid from '../../flex-grid';
 import FlexGridItem from '../../flex-grid-item';
@@ -182,3 +123,62 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div>
+    <div class="content">
+      <div class="content-item">
+        <label for="settingsExample">
+          Example
+        </label>
+        <text-input
+          name="settingsExample"
+          :readonly="true"
+          :value="exampleFormattedDateTime"
+        />
+      </div>
+      <div class="content-item">
+        <flex-grid>
+          <flex-grid-item grow="1">
+            <label for="settingsDateFormat">
+              Date format
+            </label>
+            <v-select
+              input-id="settingsDateFormat"
+              :on-change="onDateFormatChange"
+              :options="dateFormatOptions"
+              :value="modalDateFormat"
+            />
+          </flex-grid-item>
+          <flex-grid-item grow="1">
+            <label for="settingsTimeFormat">
+              Time format
+            </label>
+            <v-select
+              input-id="settingsTimeFormat"
+              :on-change="onTimeFormatChange"
+              :options="timeFormatOptions"
+              :value="modalTimeFormat"
+            />
+          </flex-grid-item>
+          <flex-grid-item grow="1">
+            <label for="settingsTimezone">
+              Timezone
+            </label>
+            <v-select
+              input-id="settingsTimezone"
+              :on-change="onTimezoneChange"
+              :options="timezoneOptions"
+              :value="modalTimezone"
+            />
+          </flex-grid-item>
+        </flex-grid>
+      </div>
+    </div>
+    <settings-footer
+      :submit-enabled="isSettingsChanged"
+      @cancel="onClose"
+      @submit="onSubmit"
+    />
+  </div>
+</template>

--- a/client/components/settings-modal/components/settings-footer.vue
+++ b/client/components/settings-modal/components/settings-footer.vue
@@ -1,18 +1,3 @@
-<template>
-  <flex-grid align-items="center" justify-content="flex-end">
-    <flex-grid-item width="102px">
-      <button-fill color="tertiary" label="CANCEL" @click="onCancelClick" />
-    </flex-grid-item>
-    <flex-grid-item>
-      <button-fill
-        :disabled="!submitEnabled"
-        label="APPLY"
-        @click="onSubmitClick"
-      />
-    </flex-grid-item>
-  </flex-grid>
-</template>
-
 <script>
 import ButtonFill from '../../button-fill';
 import FlexGrid from '../../flex-grid';
@@ -40,3 +25,18 @@ export default {
   },
 };
 </script>
+
+<template>
+  <flex-grid align-items="center" justify-content="flex-end">
+    <flex-grid-item width="102px">
+      <button-fill color="tertiary" label="CANCEL" @click="onCancelClick" />
+    </flex-grid-item>
+    <flex-grid-item>
+      <button-fill
+        :disabled="!submitEnabled"
+        label="APPLY"
+        @click="onSubmitClick"
+      />
+    </flex-grid-item>
+  </flex-grid>
+</template>

--- a/client/components/settings-modal/components/settings-header.vue
+++ b/client/components/settings-modal/components/settings-header.vue
@@ -1,14 +1,3 @@
-<template>
-  <flex-grid align-items="center" class="settings-header">
-    <flex-grid-item grow="1">
-      <h2>{{ displayTitle }}</h2>
-    </flex-grid-item>
-    <flex-grid-item width="40px">
-      <button-icon icon="icon_delete-thin" size="30px" @click="onCloseClick" />
-    </flex-grid-item>
-  </flex-grid>
-</template>
-
 <script>
 import ButtonIcon from '../../button-icon';
 import FlexGrid from '../../flex-grid';
@@ -43,6 +32,17 @@ export default {
   },
 };
 </script>
+
+<template>
+  <flex-grid align-items="center" class="settings-header">
+    <flex-grid-item grow="1">
+      <h2>{{ displayTitle }}</h2>
+    </flex-grid-item>
+    <flex-grid-item width="40px">
+      <button-icon icon="icon_delete-thin" size="30px" @click="onCloseClick" />
+    </flex-grid-item>
+  </flex-grid>
+</template>
 
 <style lang="stylus">
 .settings-header {

--- a/client/components/settings-modal/components/settings-list.vue
+++ b/client/components/settings-modal/components/settings-list.vue
@@ -1,16 +1,3 @@
-<template>
-  <flex-grid class="settings-list" flex-direction="column">
-    <flex-grid-item v-for="view in viewList" :key="view.name" margin="0">
-      <button-fill
-        class="settings-list-item"
-        :color="view.name === activeViewName ? 'primary' : 'tertiary'"
-        :label="view.displayName"
-        @click="() => onClick(view)"
-      />
-    </flex-grid-item>
-  </flex-grid>
-</template>
-
 <script>
 import ButtonFill from '../../button-fill';
 import FlexGrid from '../../flex-grid';
@@ -40,6 +27,19 @@ export default {
   },
 };
 </script>
+
+<template>
+  <flex-grid class="settings-list" flex-direction="column">
+    <flex-grid-item v-for="view in viewList" :key="view.name" margin="0">
+      <button-fill
+        class="settings-list-item"
+        :color="view.name === activeViewName ? 'primary' : 'tertiary'"
+        :label="view.displayName"
+        @click="() => onClick(view)"
+      />
+    </flex-grid-item>
+  </flex-grid>
+</template>
 
 <style lang="stylus">
 .settings-list {

--- a/client/components/settings-modal/components/settings-toggle.vue
+++ b/client/components/settings-modal/components/settings-toggle.vue
@@ -1,21 +1,3 @@
-<template>
-  <flex-grid class="settings-toggle" align-items="center">
-    <flex-grid-item grow="1">
-      <label :for="name">
-        {{ label }}
-      </label>
-    </flex-grid-item>
-    <flex-grid-item>
-      <toggle-button
-        :labels="true"
-        :name="name"
-        :value="value"
-        @change="onChange"
-      />
-    </flex-grid-item>
-  </flex-grid>
-</template>
-
 <script>
 import { ToggleButton } from 'vue-js-toggle-button';
 import FlexGrid from '../../flex-grid';
@@ -46,6 +28,24 @@ export default {
   },
 };
 </script>
+
+<template>
+  <flex-grid class="settings-toggle" align-items="center">
+    <flex-grid-item grow="1">
+      <label :for="name">
+        {{ label }}
+      </label>
+    </flex-grid-item>
+    <flex-grid-item>
+      <toggle-button
+        :labels="true"
+        :name="name"
+        :value="value"
+        @change="onChange"
+      />
+    </flex-grid-item>
+  </flex-grid>
+</template>
 
 <style lang="stylus">
 .settings-toggle {

--- a/client/components/settings-modal/components/settings-workflow-history.vue
+++ b/client/components/settings-modal/components/settings-workflow-history.vue
@@ -1,117 +1,3 @@
-<template>
-  <div class="settings-workflow-history">
-    <div class="content">
-      <div class="content-item">
-        <settings-toggle
-          label="Enable history event param highlighting"
-          name="workflowHistoryEventHighlightListEnabled"
-          :value="modalWorkflowHistoryEventHighlightListEnabled"
-          @change="onWorkflowHistoryEventHighlightListEnabledChange"
-        />
-      </div>
-
-      <div
-        class="history-event-param-content"
-        :class="{ disabled: !modalWorkflowHistoryEventHighlightListEnabled }"
-      >
-        <div class="content-item">
-          <flex-grid align-items="center">
-            <flex-grid-item grow="1">
-              <h4>History event params</h4>
-            </flex-grid-item>
-            <flex-grid-item>
-              <button-fill
-                :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
-                label="NEW"
-                @click="onWorkflowHistoryEventHighlightListAdd"
-              />
-            </flex-grid-item>
-          </flex-grid>
-        </div>
-
-        <div class="scrollable">
-          <div
-            class="content-item"
-            v-for="event in modalWorkflowHistoryEventHighlightList"
-            :key="event.id"
-          >
-            <flex-grid align-items="center">
-              <flex-grid-item grow="1">
-                <flex-grid align-items="center">
-                  <flex-grid-item grow="1" width="345px">
-                    <v-select
-                      :disabled="
-                        !modalWorkflowHistoryEventHighlightListEnabled ||
-                          !event.isEnabled
-                      "
-                      :value="event.eventType"
-                      :options="workflowEventTypes"
-                      :on-change="
-                        value =>
-                          onWorkflowHistoryEventHighlightListChange({
-                            event,
-                            key: 'eventType',
-                            value,
-                          })
-                      "
-                    />
-                  </flex-grid-item>
-                  <flex-grid-item>
-                    <text-input
-                      label="Event param name"
-                      :disabled="
-                        !modalWorkflowHistoryEventHighlightListEnabled ||
-                          !event.isEnabled
-                      "
-                      :value="event.eventParamName"
-                      @input="
-                        ({ target: { value } }) =>
-                          onWorkflowHistoryEventHighlightListChange({
-                            event,
-                            key: 'eventParamName',
-                            value,
-                          })
-                      "
-                    />
-                  </flex-grid-item>
-                </flex-grid>
-              </flex-grid-item>
-              <flex-grid-item>
-                <toggle-button
-                  :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
-                  :labels="true"
-                  :value="event.isEnabled"
-                  @change="
-                    ({ value }) =>
-                      onWorkflowHistoryEventHighlightListChange({
-                        event,
-                        key: 'isEnabled',
-                        value,
-                      })
-                  "
-                />
-              </flex-grid-item>
-              <flex-grid-item>
-                <button-icon
-                  :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
-                  icon="icon_trash"
-                  size="20px"
-                  @click="onWorkflowHistoryEventHighlightListRemove(event)"
-                />
-              </flex-grid-item>
-            </flex-grid>
-          </div>
-        </div>
-      </div>
-    </div>
-    <settings-footer
-      :submit-enabled="isSettingsChanged"
-      @cancel="onClose"
-      @submit="onSubmit"
-    />
-  </div>
-</template>
-
 <script>
 import { ToggleButton } from 'vue-js-toggle-button';
 import ButtonFill from '../../button-fill';
@@ -231,6 +117,120 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="settings-workflow-history">
+    <div class="content">
+      <div class="content-item">
+        <settings-toggle
+          label="Enable history event param highlighting"
+          name="workflowHistoryEventHighlightListEnabled"
+          :value="modalWorkflowHistoryEventHighlightListEnabled"
+          @change="onWorkflowHistoryEventHighlightListEnabledChange"
+        />
+      </div>
+
+      <div
+        class="history-event-param-content"
+        :class="{ disabled: !modalWorkflowHistoryEventHighlightListEnabled }"
+      >
+        <div class="content-item">
+          <flex-grid align-items="center">
+            <flex-grid-item grow="1">
+              <h4>History event params</h4>
+            </flex-grid-item>
+            <flex-grid-item>
+              <button-fill
+                :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
+                label="NEW"
+                @click="onWorkflowHistoryEventHighlightListAdd"
+              />
+            </flex-grid-item>
+          </flex-grid>
+        </div>
+
+        <div class="scrollable">
+          <div
+            class="content-item"
+            v-for="event in modalWorkflowHistoryEventHighlightList"
+            :key="event.id"
+          >
+            <flex-grid align-items="center">
+              <flex-grid-item grow="1">
+                <flex-grid align-items="center">
+                  <flex-grid-item grow="1" width="345px">
+                    <v-select
+                      :disabled="
+                        !modalWorkflowHistoryEventHighlightListEnabled ||
+                          !event.isEnabled
+                      "
+                      :value="event.eventType"
+                      :options="workflowEventTypes"
+                      :on-change="
+                        value =>
+                          onWorkflowHistoryEventHighlightListChange({
+                            event,
+                            key: 'eventType',
+                            value,
+                          })
+                      "
+                    />
+                  </flex-grid-item>
+                  <flex-grid-item>
+                    <text-input
+                      label="Event param name"
+                      :disabled="
+                        !modalWorkflowHistoryEventHighlightListEnabled ||
+                          !event.isEnabled
+                      "
+                      :value="event.eventParamName"
+                      @input="
+                        ({ target: { value } }) =>
+                          onWorkflowHistoryEventHighlightListChange({
+                            event,
+                            key: 'eventParamName',
+                            value,
+                          })
+                      "
+                    />
+                  </flex-grid-item>
+                </flex-grid>
+              </flex-grid-item>
+              <flex-grid-item>
+                <toggle-button
+                  :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
+                  :labels="true"
+                  :value="event.isEnabled"
+                  @change="
+                    ({ value }) =>
+                      onWorkflowHistoryEventHighlightListChange({
+                        event,
+                        key: 'isEnabled',
+                        value,
+                      })
+                  "
+                />
+              </flex-grid-item>
+              <flex-grid-item>
+                <button-icon
+                  :disabled="!modalWorkflowHistoryEventHighlightListEnabled"
+                  icon="icon_trash"
+                  size="20px"
+                  @click="onWorkflowHistoryEventHighlightListRemove(event)"
+                />
+              </flex-grid-item>
+            </flex-grid>
+          </div>
+        </div>
+      </div>
+    </div>
+    <settings-footer
+      :submit-enabled="isSettingsChanged"
+      @cancel="onClose"
+      @submit="onSubmit"
+    />
+  </div>
+</template>
 
 <style lang="stylus">
 .settings-workflow-history {

--- a/client/components/settings-modal/index.vue
+++ b/client/components/settings-modal/index.vue
@@ -1,52 +1,3 @@
-<template>
-  <modal
-    name="settings-modal"
-    @before-close="onBeforeClose"
-    @before-open="onBeforeOpen"
-  >
-    <div class="settings-modal">
-      <settings-header
-        :title="activeView.displayName"
-        title-suffix="Settings"
-        @close="onClose"
-      />
-      <flex-grid>
-        <flex-grid-item margin="20px">
-          <settings-list
-            :active-view-name="activeView.name"
-            :view-list="viewList"
-            @change="onSettingsListChange"
-          />
-        </flex-grid-item>
-        <flex-grid-item>
-          <settings-date-format
-            :date-format="dateFormat"
-            :date-format-options="dateFormatOptions"
-            :time-format="timeFormat"
-            :time-format-options="timeFormatOptions"
-            :timezone="timezone"
-            :timezone-options="timezoneOptions"
-            v-if="settingsDateFormatViewActive"
-            @change="onSettingsChange"
-            @close="onClose"
-          />
-          <settings-workflow-history
-            :workflow-history-event-highlight-list="
-              workflowHistoryEventHighlightList
-            "
-            :workflow-history-event-highlight-list-enabled="
-              workflowHistoryEventHighlightListEnabled
-            "
-            v-if="settingsWorkflowHistoryViewActive"
-            @change="onSettingsChange"
-            @close="onClose"
-          />
-        </flex-grid-item>
-      </flex-grid>
-    </div>
-  </modal>
-</template>
-
 <script>
 import FlexGrid from '../flex-grid';
 import FlexGridItem from '../flex-grid-item';
@@ -128,6 +79,55 @@ export default {
   },
 };
 </script>
+
+<template>
+  <modal
+    name="settings-modal"
+    @before-close="onBeforeClose"
+    @before-open="onBeforeOpen"
+  >
+    <div class="settings-modal">
+      <settings-header
+        :title="activeView.displayName"
+        title-suffix="Settings"
+        @close="onClose"
+      />
+      <flex-grid>
+        <flex-grid-item margin="20px">
+          <settings-list
+            :active-view-name="activeView.name"
+            :view-list="viewList"
+            @change="onSettingsListChange"
+          />
+        </flex-grid-item>
+        <flex-grid-item>
+          <settings-date-format
+            :date-format="dateFormat"
+            :date-format-options="dateFormatOptions"
+            :time-format="timeFormat"
+            :time-format-options="timeFormatOptions"
+            :timezone="timezone"
+            :timezone-options="timezoneOptions"
+            v-if="settingsDateFormatViewActive"
+            @change="onSettingsChange"
+            @close="onClose"
+          />
+          <settings-workflow-history
+            :workflow-history-event-highlight-list="
+              workflowHistoryEventHighlightList
+            "
+            :workflow-history-event-highlight-list-enabled="
+              workflowHistoryEventHighlightListEnabled
+            "
+            v-if="settingsWorkflowHistoryViewActive"
+            @change="onSettingsChange"
+            @close="onClose"
+          />
+        </flex-grid-item>
+      </flex-grid>
+    </div>
+  </modal>
+</template>
 
 <style lang="stylus">
 .settings-modal {

--- a/client/components/text-input.vue
+++ b/client/components/text-input.vue
@@ -1,3 +1,15 @@
+<script>
+export default {
+  name: 'text-input',
+  props: ['disabled', 'label', 'name', 'readonly', 'type', 'value'],
+  methods: {
+    onInputChange(...args) {
+      this.$emit('input', ...args);
+    },
+  },
+};
+</script>
+
 <template>
   <div class="text-input field">
     <input
@@ -12,18 +24,6 @@
     <label :for="name">{{ label }}</label>
   </div>
 </template>
-
-<script>
-export default {
-  name: 'text-input',
-  props: ['disabled', 'label', 'name', 'readonly', 'type', 'value'],
-  methods: {
-    onInputChange(...args) {
-      this.$emit('input', ...args);
-    },
-  },
-};
-</script>
 
 <style lang="stylus">
 @require "../styles/base.styl"

--- a/client/routes/domain-list.vue
+++ b/client/routes/domain-list.vue
@@ -1,9 +1,3 @@
-<template>
-  <section class="domain-search">
-    <domain-navigation type="text" placeholder="cadence-canary" />
-  </section>
-</template>
-
 <script>
 import { DomainNavigation } from '~components';
 
@@ -16,6 +10,12 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="domain-search">
+    <domain-navigation type="text" placeholder="cadence-canary" />
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../styles/definitions"

--- a/client/routes/domain/domain-metrics.vue
+++ b/client/routes/domain/domain-metrics.vue
@@ -1,10 +1,10 @@
-<template>
-  <section class="domain-metrics"></section>
-</template>
-
 <script>
 export default {
   name: 'domain-metrics',
   props: ['domain'],
 };
 </script>
+
+<template>
+  <section class="domain-metrics"></section>
+</template>

--- a/client/routes/domain/domain-settings.vue
+++ b/client/routes/domain/domain-settings.vue
@@ -1,17 +1,3 @@
-<template>
-  <section class="domain-settings domain-description" :class="{ loading }">
-    <header>
-      <h3>{{ domain }}</h3>
-    </header>
-    <detail-list
-      v-if="domainConfig"
-      :item="domainConfig"
-      :title="`Domain ${domain} Configuration`"
-    />
-    <span class="error" v-if="error">{{ error }}</span>
-  </section>
-</template>
-
 <script>
 import { getKeyValuePairs, mapDomainDescription } from '~helpers';
 import { DetailList } from '~components';
@@ -48,6 +34,20 @@ export default {
   methods: {},
 };
 </script>
+
+<template>
+  <section class="domain-settings domain-description" :class="{ loading }">
+    <header>
+      <h3>{{ domain }}</h3>
+    </header>
+    <detail-list
+      v-if="domainConfig"
+      :item="domainConfig"
+      :title="`Domain ${domain} Configuration`"
+    />
+    <span class="error" v-if="error">{{ error }}</span>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"

--- a/client/routes/domain/index.vue
+++ b/client/routes/domain/index.vue
@@ -1,3 +1,16 @@
+<script>
+import { FeatureFlag, NavigationBar, NavigationLink } from '~components';
+
+export default {
+  props: ['dateFormat', 'domain', 'timeFormat', 'timezone'],
+  components: {
+    'feature-flag': FeatureFlag,
+    'navigation-bar': NavigationBar,
+    'navigation-link': NavigationLink,
+  },
+};
+</script>
+
 <template>
   <section class="domain">
     <navigation-bar>
@@ -42,19 +55,6 @@
     />
   </section>
 </template>
-
-<script>
-import { FeatureFlag, NavigationBar, NavigationLink } from '~components';
-
-export default {
-  props: ['dateFormat', 'domain', 'timeFormat', 'timezone'],
-  components: {
-    'feature-flag': FeatureFlag,
-    'navigation-bar': NavigationBar,
-    'navigation-link': NavigationLink,
-  },
-};
-</script>
 
 <style lang="stylus">
 section.domain {

--- a/client/routes/domain/workflow-archival/advanced.vue
+++ b/client/routes/domain/workflow-archival/advanced.vue
@@ -1,56 +1,3 @@
-<template>
-  <section class="workflow-archival-basic">
-    <header>
-      <flex-grid>
-        <flex-grid-item grow="1">
-          <text-input
-            label="Query"
-            name="queryString"
-            type="search"
-            :value="queryString"
-            @input="onTextChange"
-          />
-        </flex-grid-item>
-        <flex-grid-item width="85px">
-          <button-fill
-            label="BASIC"
-            tag="router-link"
-            :to="{
-              name: 'workflow-archival-basic',
-            }"
-          />
-        </flex-grid-item>
-      </flex-grid>
-    </header>
-    <section class="results">
-      <archival-table
-        v-infinite-scroll="nextPage"
-        infinite-scroll-disabled="disableInfiniteScroll"
-        infinite-scroll-distance="20"
-        infinite-scroll-immediate-check="false"
-      >
-        <archival-table-row
-          v-for="result in formattedResults"
-          :close-status="result.closeStatus"
-          :close-time="result.closeTime"
-          :key="result.runId"
-          :run-id="result.runId"
-          :start-time="result.startTime"
-          :workflow-id="result.workflowId"
-          :workflow-name="result.workflowName"
-        />
-      </archival-table>
-      <error-message :error="error" />
-      <no-results :results="results" />
-      <loading-spinner v-if="loading" />
-      <loading-message :delay="loadingMessageDelay" :loading="loading">
-        <p>It looks like this request is taking some time to process.</p>
-        <p>Try reducing CloseTime range to improve search time.</p>
-      </loading-message>
-    </section>
-  </section>
-</template>
-
 <script>
 import debounce from 'lodash-es/debounce';
 import { ArchivalTable, ArchivalTableRow } from './components';
@@ -185,6 +132,59 @@ export default pagedGrid({
   },
 });
 </script>
+
+<template>
+  <section class="workflow-archival-basic">
+    <header>
+      <flex-grid>
+        <flex-grid-item grow="1">
+          <text-input
+            label="Query"
+            name="queryString"
+            type="search"
+            :value="queryString"
+            @input="onTextChange"
+          />
+        </flex-grid-item>
+        <flex-grid-item width="85px">
+          <button-fill
+            label="BASIC"
+            tag="router-link"
+            :to="{
+              name: 'workflow-archival-basic',
+            }"
+          />
+        </flex-grid-item>
+      </flex-grid>
+    </header>
+    <section class="results">
+      <archival-table
+        v-infinite-scroll="nextPage"
+        infinite-scroll-disabled="disableInfiniteScroll"
+        infinite-scroll-distance="20"
+        infinite-scroll-immediate-check="false"
+      >
+        <archival-table-row
+          v-for="result in formattedResults"
+          :close-status="result.closeStatus"
+          :close-time="result.closeTime"
+          :key="result.runId"
+          :run-id="result.runId"
+          :start-time="result.startTime"
+          :workflow-id="result.workflowId"
+          :workflow-name="result.workflowName"
+        />
+      </archival-table>
+      <error-message :error="error" />
+      <no-results :results="results" />
+      <loading-spinner v-if="loading" />
+      <loading-message :delay="loadingMessageDelay" :loading="loading">
+        <p>It looks like this request is taking some time to process.</p>
+        <p>Try reducing CloseTime range to improve search time.</p>
+      </loading-message>
+    </section>
+  </section>
+</template>
 
 <style lang="stylus">
 section.workflow-archival-basic {

--- a/client/routes/domain/workflow-archival/basic.vue
+++ b/client/routes/domain/workflow-archival/basic.vue
@@ -1,79 +1,3 @@
-<template>
-  <section class="workflow-archival-basic">
-    <header>
-      <flex-grid>
-        <flex-grid-item grow="1">
-          <text-input
-            label="Workflow ID"
-            name="workflowId"
-            type="search"
-            :value="workflowId"
-            @input="onTextChange"
-          />
-        </flex-grid-item>
-        <flex-grid-item grow="1">
-          <text-input
-            label="Workflow Name"
-            name="workflowName"
-            type="search"
-            :value="workflowName"
-            @input="onTextChange"
-          />
-        </flex-grid-item>
-        <flex-grid-item width="160px">
-          <v-select
-            :on-change="onSelectChange"
-            :options="statusList"
-            :searchable="false"
-            :value="status"
-          />
-        </flex-grid-item>
-        <flex-grid-item width="165px">
-          <text-input label="Filter by" readonly :value="filterBy" />
-        </flex-grid-item>
-        <flex-grid-item width="325px">
-          <date-range-picker :date-range="range" @change="onDateRangeChange" />
-        </flex-grid-item>
-        <flex-grid-item width="120px">
-          <button-fill
-            label="ADVANCED"
-            tag="router-link"
-            :to="{
-              name: 'workflow-archival-advanced',
-            }"
-          />
-        </flex-grid-item>
-      </flex-grid>
-    </header>
-    <section class="results">
-      <archival-table
-        v-infinite-scroll="nextPage"
-        infinite-scroll-disabled="disableInfiniteScroll"
-        infinite-scroll-distance="20"
-        infinite-scroll-immediate-check="false"
-      >
-        <archival-table-row
-          v-for="result in formattedResults"
-          :close-status="result.closeStatus"
-          :close-time="result.closeTime"
-          :key="result.runId"
-          :run-id="result.runId"
-          :start-time="result.startTime"
-          :workflow-id="result.workflowId"
-          :workflow-name="result.workflowName"
-        />
-      </archival-table>
-      <error-message :error="error" />
-      <no-results :results="results" />
-      <loading-spinner v-if="loading" />
-      <loading-message :delay="loadingMessageDelay" :loading="loading">
-        <p>It looks like this request is taking some time to process.</p>
-        <p>Try narrowing the time range to improve search time.</p>
-      </loading-message>
-    </section>
-  </section>
-</template>
-
 <script>
 import debounce from 'lodash-es/debounce';
 import { ArchivalTable, ArchivalTableRow } from './components';
@@ -286,6 +210,82 @@ export default pagedGrid({
   },
 });
 </script>
+
+<template>
+  <section class="workflow-archival-basic">
+    <header>
+      <flex-grid>
+        <flex-grid-item grow="1">
+          <text-input
+            label="Workflow ID"
+            name="workflowId"
+            type="search"
+            :value="workflowId"
+            @input="onTextChange"
+          />
+        </flex-grid-item>
+        <flex-grid-item grow="1">
+          <text-input
+            label="Workflow Name"
+            name="workflowName"
+            type="search"
+            :value="workflowName"
+            @input="onTextChange"
+          />
+        </flex-grid-item>
+        <flex-grid-item width="160px">
+          <v-select
+            :on-change="onSelectChange"
+            :options="statusList"
+            :searchable="false"
+            :value="status"
+          />
+        </flex-grid-item>
+        <flex-grid-item width="165px">
+          <text-input label="Filter by" readonly :value="filterBy" />
+        </flex-grid-item>
+        <flex-grid-item width="325px">
+          <date-range-picker :date-range="range" @change="onDateRangeChange" />
+        </flex-grid-item>
+        <flex-grid-item width="120px">
+          <button-fill
+            label="ADVANCED"
+            tag="router-link"
+            :to="{
+              name: 'workflow-archival-advanced',
+            }"
+          />
+        </flex-grid-item>
+      </flex-grid>
+    </header>
+    <section class="results">
+      <archival-table
+        v-infinite-scroll="nextPage"
+        infinite-scroll-disabled="disableInfiniteScroll"
+        infinite-scroll-distance="20"
+        infinite-scroll-immediate-check="false"
+      >
+        <archival-table-row
+          v-for="result in formattedResults"
+          :close-status="result.closeStatus"
+          :close-time="result.closeTime"
+          :key="result.runId"
+          :run-id="result.runId"
+          :start-time="result.startTime"
+          :workflow-id="result.workflowId"
+          :workflow-name="result.workflowName"
+        />
+      </archival-table>
+      <error-message :error="error" />
+      <no-results :results="results" />
+      <loading-spinner v-if="loading" />
+      <loading-message :delay="loadingMessageDelay" :loading="loading">
+        <p>It looks like this request is taking some time to process.</p>
+        <p>Try narrowing the time range to improve search time.</p>
+      </loading-message>
+    </section>
+  </section>
+</template>
 
 <style lang="stylus">
 section.workflow-archival-basic {

--- a/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
+++ b/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
@@ -1,36 +1,3 @@
-<template>
-  <div class="archival-disabled-messaging">
-    <div class="message-group">
-      <p v-for="(message, index) in archivalDisabledMessage" :key="index">
-        {{ message }}
-      </p>
-      <div v-if="historyArchivalLinks">
-        <div v-for="(link, index) in historyArchivalLinks" :key="index">
-          <a :href="link.href" rel="noopener noreferrer" target="_blank">
-            {{ link.label }}
-          </a>
-        </div>
-      </div>
-    </div>
-    <div v-if="!isHistoryArchivalEnabled" class="message-group">
-      <p>
-        {{ historyArchivalDisabledMessage }}
-      </p>
-      <div v-if="historyArchivalEnableCommand">
-        <pre>{{ historyArchivalEnableCommand }}</pre>
-      </div>
-    </div>
-    <div v-if="!isVisibilityArchivalEnabled" class="message-group">
-      <p>
-        {{ visibilityArchivalDisabledMessage }}
-      </p>
-      <div v-if="visibilityArchivalEnableCommand">
-        <pre>{{ visibilityArchivalEnableCommand }}</pre>
-      </div>
-    </div>
-  </div>
-</template>
-
 <script>
 import {
   isHistoryArchivalEnabled,
@@ -76,6 +43,39 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="archival-disabled-messaging">
+    <div class="message-group">
+      <p v-for="(message, index) in archivalDisabledMessage" :key="index">
+        {{ message }}
+      </p>
+      <div v-if="historyArchivalLinks">
+        <div v-for="(link, index) in historyArchivalLinks" :key="index">
+          <a :href="link.href" rel="noopener noreferrer" target="_blank">
+            {{ link.label }}
+          </a>
+        </div>
+      </div>
+    </div>
+    <div v-if="!isHistoryArchivalEnabled" class="message-group">
+      <p>
+        {{ historyArchivalDisabledMessage }}
+      </p>
+      <div v-if="historyArchivalEnableCommand">
+        <pre>{{ historyArchivalEnableCommand }}</pre>
+      </div>
+    </div>
+    <div v-if="!isVisibilityArchivalEnabled" class="message-group">
+      <p>
+        {{ visibilityArchivalDisabledMessage }}
+      </p>
+      <div v-if="visibilityArchivalEnableCommand">
+        <pre>{{ visibilityArchivalEnableCommand }}</pre>
+      </div>
+    </div>
+  </div>
+</template>
 
 <style lang="stylus">
 .archival-disabled-messaging {

--- a/client/routes/domain/workflow-archival/components/archival-table-row.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table-row.vue
@@ -1,3 +1,17 @@
+<script>
+export default {
+  name: 'archival-table-row',
+  props: [
+    'closeStatus',
+    'closeTime',
+    'runId',
+    'startTime',
+    'workflowId',
+    'workflowName',
+  ],
+};
+</script>
+
 <template>
   <tr>
     <td>
@@ -30,17 +44,3 @@
     </td>
   </tr>
 </template>
-
-<script>
-export default {
-  name: 'archival-table-row',
-  props: [
-    'closeStatus',
-    'closeTime',
-    'runId',
-    'startTime',
-    'workflowId',
-    'workflowName',
-  ],
-};
-</script>

--- a/client/routes/domain/workflow-archival/components/archival-table.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table.vue
@@ -1,3 +1,9 @@
+<script>
+export default {
+  name: 'archival-table',
+};
+</script>
+
 <template>
   <table class="archival-table">
     <thead>

--- a/client/routes/domain/workflow-archival/index.vue
+++ b/client/routes/domain/workflow-archival/index.vue
@@ -1,28 +1,3 @@
-<template>
-  <section class="workflow-archival" :class="{ loading }">
-    <archival-disabled-messaging
-      v-if="!loading && !isArchivalEnabled"
-      :domain-settings="domainSettings"
-    />
-    <router-view
-      name="workflow-archival-advanced"
-      v-if="!loading && isArchivalEnabled"
-      :date-format="dateFormat"
-      :domain="domain"
-      :timeFormat="timeFormat"
-      :timezone="timezone"
-    />
-    <router-view
-      name="workflow-archival-basic"
-      v-if="!loading && isArchivalEnabled"
-      :date-format="dateFormat"
-      :domain="domain"
-      :timeFormat="timeFormat"
-      :timezone="timezone"
-    />
-  </section>
-</template>
-
 <script>
 import DomainService from '../domain-service';
 import { isArchivalEnabled } from './helpers';
@@ -53,6 +28,31 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="workflow-archival" :class="{ loading }">
+    <archival-disabled-messaging
+      v-if="!loading && !isArchivalEnabled"
+      :domain-settings="domainSettings"
+    />
+    <router-view
+      name="workflow-archival-advanced"
+      v-if="!loading && isArchivalEnabled"
+      :date-format="dateFormat"
+      :domain="domain"
+      :timeFormat="timeFormat"
+      :timezone="timezone"
+    />
+    <router-view
+      name="workflow-archival-basic"
+      v-if="!loading && isArchivalEnabled"
+      :date-format="dateFormat"
+      :domain="domain"
+      :timeFormat="timeFormat"
+      :timezone="timezone"
+    />
+  </section>
+</template>
 
 <style lang="stylus">
 section.workflow-archival {

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -1,112 +1,3 @@
-<template>
-  <section class="workflow-list" :class="{ loading }">
-    <header class="filters">
-      <template v-if="filterMode === 'advanced'">
-        <div class="field query-string">
-          <input
-            type="search"
-            class="query-string"
-            placeholder=" "
-            key="sql-query"
-            name="queryString"
-            v-bind:value="$route.query.queryString"
-            @input="setWorkflowFilter"
-          />
-          <label for="queryString">Query</label>
-        </div>
-      </template>
-      <template v-else>
-        <div class="field workflow-id">
-          <input
-            type="search"
-            class="workflow-id"
-            placeholder=" "
-            name="workflowId"
-            v-bind:value="$route.query.workflowId"
-            @input="setWorkflowFilter"
-          />
-          <label for="workflowId">Workflow ID</label>
-        </div>
-        <div class="field workflow-name">
-          <input
-            type="search"
-            class="workflow-name"
-            placeholder=" "
-            name="workflowName"
-            v-bind:value="$route.query.workflowName"
-            @input="setWorkflowFilter"
-          />
-          <label for="workflowName">Workflow Name</label>
-        </div>
-        <v-select
-          class="status"
-          :value="status"
-          :options="statuses"
-          :on-change="setStatus"
-          :searchable="false"
-        />
-        <div class="field workflow-filter-by">
-          <input
-            class="workflow-filter-by"
-            name="filterBy"
-            placeholder=" "
-            readonly
-            v-bind:value="filterBy"
-          />
-          <label for="filterBy">Filter by</label>
-        </div>
-        <date-range-picker
-          :date-range="range"
-          :max-days="maxRetentionDays"
-          :min-start-date="minStartDate"
-          @change="setRange"
-        />
-      </template>
-      <a class="toggle-filter" @click="toggleFilter">{{
-        filterMode === 'advanced' ? 'basic' : 'advanced'
-      }}</a>
-    </header>
-    <span class="error" v-if="error">{{ error }}</span>
-    <span class="no-results" v-if="showNoResults">No Results</span>
-    <section
-      class="results"
-      v-infinite-scroll="nextPage"
-      infinite-scroll-disabled="disableInfiniteScroll"
-      infinite-scroll-distance="20"
-      infinite-scroll-immediate-check="false"
-    >
-      <table v-show="showTable">
-        <thead>
-          <th>Workflow ID</th>
-          <th>Run ID</th>
-          <th>Name</th>
-          <th>Status</th>
-          <th>Start Time</th>
-          <th>End Time</th>
-        </thead>
-        <tbody>
-          <tr v-for="wf in formattedResults" :key="wf.runId">
-            <td>{{ wf.workflowId }}</td>
-            <td>
-              <router-link
-                :to="{
-                  name: 'workflow/summary',
-                  params: { runId: wf.runId, workflowId: wf.workflowId },
-                }"
-                >{{ wf.runId }}</router-link
-              >
-            </td>
-            <td>{{ wf.workflowName }}</td>
-            <td :class="wf.status">{{ wf.status }}</td>
-            <td>{{ wf.startTime }}</td>
-            <td>{{ wf.endTime }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-  </section>
-</template>
-
 <script>
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
@@ -457,6 +348,115 @@ export default pagedGrid({
   },
 });
 </script>
+
+<template>
+  <section class="workflow-list" :class="{ loading }">
+    <header class="filters">
+      <template v-if="filterMode === 'advanced'">
+        <div class="field query-string">
+          <input
+            type="search"
+            class="query-string"
+            placeholder=" "
+            key="sql-query"
+            name="queryString"
+            v-bind:value="$route.query.queryString"
+            @input="setWorkflowFilter"
+          />
+          <label for="queryString">Query</label>
+        </div>
+      </template>
+      <template v-else>
+        <div class="field workflow-id">
+          <input
+            type="search"
+            class="workflow-id"
+            placeholder=" "
+            name="workflowId"
+            v-bind:value="$route.query.workflowId"
+            @input="setWorkflowFilter"
+          />
+          <label for="workflowId">Workflow ID</label>
+        </div>
+        <div class="field workflow-name">
+          <input
+            type="search"
+            class="workflow-name"
+            placeholder=" "
+            name="workflowName"
+            v-bind:value="$route.query.workflowName"
+            @input="setWorkflowFilter"
+          />
+          <label for="workflowName">Workflow Name</label>
+        </div>
+        <v-select
+          class="status"
+          :value="status"
+          :options="statuses"
+          :on-change="setStatus"
+          :searchable="false"
+        />
+        <div class="field workflow-filter-by">
+          <input
+            class="workflow-filter-by"
+            name="filterBy"
+            placeholder=" "
+            readonly
+            v-bind:value="filterBy"
+          />
+          <label for="filterBy">Filter by</label>
+        </div>
+        <date-range-picker
+          :date-range="range"
+          :max-days="maxRetentionDays"
+          :min-start-date="minStartDate"
+          @change="setRange"
+        />
+      </template>
+      <a class="toggle-filter" @click="toggleFilter">{{
+        filterMode === 'advanced' ? 'basic' : 'advanced'
+      }}</a>
+    </header>
+    <span class="error" v-if="error">{{ error }}</span>
+    <span class="no-results" v-if="showNoResults">No Results</span>
+    <section
+      class="results"
+      v-infinite-scroll="nextPage"
+      infinite-scroll-disabled="disableInfiniteScroll"
+      infinite-scroll-distance="20"
+      infinite-scroll-immediate-check="false"
+    >
+      <table v-show="showTable">
+        <thead>
+          <th>Workflow ID</th>
+          <th>Run ID</th>
+          <th>Name</th>
+          <th>Status</th>
+          <th>Start Time</th>
+          <th>End Time</th>
+        </thead>
+        <tbody>
+          <tr v-for="wf in formattedResults" :key="wf.runId">
+            <td>{{ wf.workflowId }}</td>
+            <td>
+              <router-link
+                :to="{
+                  name: 'workflow/summary',
+                  params: { runId: wf.runId, workflowId: wf.workflowId },
+                }"
+                >{{ wf.runId }}</router-link
+              >
+            </td>
+            <td>{{ wf.workflowName }}</td>
+            <td :class="wf.status">{{ wf.status }}</td>
+            <td>{{ wf.startTime }}</td>
+            <td>{{ wf.endTime }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"

--- a/client/routes/help/index.vue
+++ b/client/routes/help/index.vue
@@ -1,3 +1,16 @@
+<script>
+import { cliCommands } from './constants';
+
+export default {
+  props: ['hideDocs', 'hideSlack', 'hideStackOverflow'],
+  data() {
+    return {
+      cliCommands,
+    };
+  },
+};
+</script>
+
 <template>
   <section class="help">
     <section id="getting-started">
@@ -176,19 +189,6 @@
     </section>
   </section>
 </template>
-
-<script>
-import { cliCommands } from './constants';
-
-export default {
-  props: ['hideDocs', 'hideSlack', 'hideStackOverflow'],
-  data() {
-    return {
-      cliCommands,
-    };
-  },
-};
-</script>
 
 <style lang="stylus">
 @require "../../styles/definitions"

--- a/client/routes/index.vue
+++ b/client/routes/index.vue
@@ -1,3 +1,22 @@
+<script>
+import { NavigationBar, NavigationLink } from '~components';
+
+export default {
+  components: {
+    'navigation-bar': NavigationBar,
+    'navigation-link': NavigationLink,
+  },
+  methods: {
+    onNotification(event) {
+      this.$emit('onNotification', event);
+    },
+    onWorkflowHistoryEventParamToggle(event) {
+      this.$emit('onWorkflowHistoryEventParamToggle', event);
+    },
+  },
+};
+</script>
+
 <template>
   <section>
     <navigation-bar>
@@ -23,24 +42,5 @@
     <router-view name="news" @onNotification="onNotification" />
   </section>
 </template>
-
-<script>
-import { NavigationBar, NavigationLink } from '~components';
-
-export default {
-  components: {
-    'navigation-bar': NavigationBar,
-    'navigation-link': NavigationLink,
-  },
-  methods: {
-    onNotification(event) {
-      this.$emit('onNotification', event);
-    },
-    onWorkflowHistoryEventParamToggle(event) {
-      this.$emit('onWorkflowHistoryEventParamToggle', event);
-    },
-  },
-};
-</script>
 
 <style lang="stylus"></style>

--- a/client/routes/news/index.vue
+++ b/client/routes/news/index.vue
@@ -1,9 +1,3 @@
-<template>
-  <section class="news">
-    <iframe ref="iframe" :src="src" />
-  </section>
-</template>
-
 <script>
 import { getIFrameSrc, getUpdatedIFrameLocation } from './helpers';
 import {
@@ -137,6 +131,12 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="news">
+    <iframe ref="iframe" :src="src" />
+  </section>
+</template>
 
 <style lang="stylus">
 section.news {

--- a/client/routes/task-list/components/partition-table.vue
+++ b/client/routes/task-list/components/partition-table.vue
@@ -1,3 +1,10 @@
+<script>
+export default {
+  name: 'partition-table',
+  props: ['title', 'partitionList'],
+};
+</script>
+
 <template>
   <table v-if="partitionList">
     <caption>
@@ -17,10 +24,3 @@
     </tbody>
   </table>
 </template>
-
-<script>
-export default {
-  name: 'partition-table',
-  props: ['title', 'partitionList'],
-};
-</script>

--- a/client/routes/task-list/index.vue
+++ b/client/routes/task-list/index.vue
@@ -1,3 +1,16 @@
+<script>
+import { FeatureFlag, NavigationBar, NavigationLink } from '~components';
+
+export default {
+  props: ['dateFormat', 'domain', 'taskList', 'timeFormat', 'timezone'],
+  components: {
+    'feature-flag': FeatureFlag,
+    'navigation-bar': NavigationBar,
+    'navigation-link': NavigationLink,
+  },
+};
+</script>
+
 <template>
   <section class="task-list">
     <navigation-bar>
@@ -33,19 +46,6 @@
     <router-view name="metrics" :domain="domain" :task-list="taskList" />
   </section>
 </template>
-
-<script>
-import { FeatureFlag, NavigationBar, NavigationLink } from '~components';
-
-export default {
-  props: ['dateFormat', 'domain', 'taskList', 'timeFormat', 'timezone'],
-  components: {
-    'feature-flag': FeatureFlag,
-    'navigation-bar': NavigationBar,
-    'navigation-link': NavigationLink,
-  },
-};
-</script>
 
 <style lang="stylus">
 section.task-list {

--- a/client/routes/task-list/metrics.vue
+++ b/client/routes/task-list/metrics.vue
@@ -1,10 +1,10 @@
-<template>
-  <section class="task-list-metrics"></section>
-</template>
-
 <script>
 export default {
   name: 'metrics',
   props: ['domain', 'taskList'],
 };
 </script>
+
+<template>
+  <section class="task-list-metrics"></section>
+</template>

--- a/client/routes/task-list/partition.vue
+++ b/client/routes/task-list/partition.vue
@@ -1,22 +1,3 @@
-<template>
-  <section class="task-list-partition">
-    <flex-grid width="100%">
-      <flex-grid-item grow="1" margin="10px">
-        <partition-table
-          title="Activity Partitions"
-          :partition-list="activityPartitionList"
-        />
-      </flex-grid-item>
-      <flex-grid-item grow="1">
-        <partition-table
-          title="Decision Partitions"
-          :partition-list="decisionPartitionList"
-        />
-      </flex-grid-item>
-    </flex-grid>
-  </section>
-</template>
-
 <script>
 import PartitionTable from './components/partition-table';
 import { FlexGrid, FlexGridItem } from '~components';
@@ -45,3 +26,22 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="task-list-partition">
+    <flex-grid width="100%">
+      <flex-grid-item grow="1" margin="10px">
+        <partition-table
+          title="Activity Partitions"
+          :partition-list="activityPartitionList"
+        />
+      </flex-grid-item>
+      <flex-grid-item grow="1">
+        <partition-table
+          title="Decision Partitions"
+          :partition-list="decisionPartitionList"
+        />
+      </flex-grid-item>
+    </flex-grid>
+  </section>
+</template>

--- a/client/routes/task-list/pollers.vue
+++ b/client/routes/task-list/pollers.vue
@@ -1,24 +1,3 @@
-<template>
-  <section :class="{ 'task-list-pollers': true, loading }">
-    <table v-if="pollers">
-      <thead>
-        <th>Identity</th>
-        <th>Last Access Time</th>
-        <th>Decision Handler</th>
-        <th>Activity Handler</th>
-      </thead>
-      <tbody>
-        <tr v-for="p in formattedPollers" :key="p.identity">
-          <td>{{ p.identity }}</td>
-          <td>{{ p.lastAccessTime }}</td>
-          <td class="decision" :data-handled="p.handlesDecisions"></td>
-          <td class="activity" :data-handled="p.handlesActivities"></td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
-</template>
-
 <script>
 import { getDatetimeFormattedString } from '~helpers';
 
@@ -73,6 +52,27 @@ export default {
   methods: {},
 };
 </script>
+
+<template>
+  <section :class="{ 'task-list-pollers': true, loading }">
+    <table v-if="pollers">
+      <thead>
+        <th>Identity</th>
+        <th>Last Access Time</th>
+        <th>Decision Handler</th>
+        <th>Activity Handler</th>
+      </thead>
+      <tbody>
+        <tr v-for="p in formattedPollers" :key="p.identity">
+          <td>{{ p.identity }}</td>
+          <td>{{ p.lastAccessTime }}</td>
+          <td class="decision" :data-handled="p.handlesDecisions"></td>
+          <td class="activity" :data-handled="p.handlesActivities"></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"

--- a/client/routes/workflow/components/timeline.vue
+++ b/client/routes/workflow/components/timeline.vue
@@ -1,7 +1,3 @@
-<template>
-  <div class="timeline"></div>
-</template>
-
 <script>
 import moment from 'moment';
 import { Timeline, timeline } from 'vis-timeline';
@@ -147,6 +143,10 @@ export default {
   },
 };
 </script>
+
+<template>
+  <div class="timeline"></div>
+</template>
 
 <style lang="stylus">
 @require "../../../styles/definitions.styl"

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -1,77 +1,3 @@
-<template>
-  <section class="execution" :class="{ loading: wfLoading }">
-    <navigation-bar>
-      <navigation-link
-        id="nav-link-summary"
-        icon="icon_receipt"
-        label="Summary"
-        :to="{ name: 'workflow/summary' }"
-      />
-      <navigation-link
-        id="nav-link-history"
-        icon="icon_trip-history"
-        label="History"
-        :to="{ name: 'workflow/history' }"
-      />
-      <navigation-link
-        id="nav-link-stack-trace"
-        icon="icon_trips"
-        label="Stack Trace"
-        :to="{ name: 'workflow/stack-trace' }"
-        v-show="isWorkflowRunning"
-      />
-      <navigation-link
-        id="nav-link-query"
-        icon="icon_lost"
-        label="Query"
-        :to="{ name: 'workflow/query' }"
-        v-show="isWorkflowRunning"
-      />
-    </navigation-bar>
-    <router-view
-      name="summary"
-      :baseAPIURL="baseAPIURL"
-      :date-format="dateFormat"
-      :domain="domain"
-      :input="summary.input"
-      :isWorkflowRunning="summary.isWorkflowRunning"
-      :parentWorkflowRoute="summary.parentWorkflowRoute"
-      :result="summary.result"
-      :time-format="timeFormat"
-      :timezone="timezone"
-      :wfStatus="summary.wfStatus"
-      :workflow="summary.workflow"
-      @onNotification="onNotification"
-    />
-    <router-view
-      name="history"
-      :baseAPIURL="baseAPIURL"
-      :events="historyEvents"
-      :loading="history.loading"
-      :timelineEvents="historyTimelineEvents"
-      :workflow-history-event-highlight-list="workflowHistoryEventHighlightList"
-      :workflow-history-event-highlight-list-enabled="
-        workflowHistoryEventHighlightListEnabled
-      "
-      @onNotification="onNotification"
-      @onWorkflowHistoryEventParamToggle="onWorkflowHistoryEventParamToggle"
-    />
-    <router-view
-      name="stacktrace"
-      :baseAPIURL="baseAPIURL"
-      :date-format="dateFormat"
-      :time-format="timeFormat"
-      :timezone="timezone"
-      @onNotification="onNotification"
-    />
-    <router-view
-      name="query"
-      :baseAPIURL="baseAPIURL"
-      @onNotification="onNotification"
-    />
-  </section>
-</template>
-
 <script>
 import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from './constants';
 import {
@@ -334,3 +260,77 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="execution" :class="{ loading: wfLoading }">
+    <navigation-bar>
+      <navigation-link
+        id="nav-link-summary"
+        icon="icon_receipt"
+        label="Summary"
+        :to="{ name: 'workflow/summary' }"
+      />
+      <navigation-link
+        id="nav-link-history"
+        icon="icon_trip-history"
+        label="History"
+        :to="{ name: 'workflow/history' }"
+      />
+      <navigation-link
+        id="nav-link-stack-trace"
+        icon="icon_trips"
+        label="Stack Trace"
+        :to="{ name: 'workflow/stack-trace' }"
+        v-show="isWorkflowRunning"
+      />
+      <navigation-link
+        id="nav-link-query"
+        icon="icon_lost"
+        label="Query"
+        :to="{ name: 'workflow/query' }"
+        v-show="isWorkflowRunning"
+      />
+    </navigation-bar>
+    <router-view
+      name="summary"
+      :baseAPIURL="baseAPIURL"
+      :date-format="dateFormat"
+      :domain="domain"
+      :input="summary.input"
+      :isWorkflowRunning="summary.isWorkflowRunning"
+      :parentWorkflowRoute="summary.parentWorkflowRoute"
+      :result="summary.result"
+      :time-format="timeFormat"
+      :timezone="timezone"
+      :wfStatus="summary.wfStatus"
+      :workflow="summary.workflow"
+      @onNotification="onNotification"
+    />
+    <router-view
+      name="history"
+      :baseAPIURL="baseAPIURL"
+      :events="historyEvents"
+      :loading="history.loading"
+      :timelineEvents="historyTimelineEvents"
+      :workflow-history-event-highlight-list="workflowHistoryEventHighlightList"
+      :workflow-history-event-highlight-list-enabled="
+        workflowHistoryEventHighlightListEnabled
+      "
+      @onNotification="onNotification"
+      @onWorkflowHistoryEventParamToggle="onWorkflowHistoryEventParamToggle"
+    />
+    <router-view
+      name="stacktrace"
+      :baseAPIURL="baseAPIURL"
+      :date-format="dateFormat"
+      :time-format="timeFormat"
+      :timezone="timezone"
+      @onNotification="onNotification"
+    />
+    <router-view
+      name="query"
+      :baseAPIURL="baseAPIURL"
+      @onNotification="onNotification"
+    />
+  </section>
+</template>

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -1,31 +1,3 @@
-<template>
-  <section class="query" :class="{ loading }">
-    <header v-if="queries && queries.length">
-      <div class="query-name">
-        <v-select
-          placeholder="Choose a Query"
-          :value="queryName"
-          :options="queries"
-          :on-change="setQuery"
-          :searchable="false"
-        />
-      </div>
-      <a
-        :href="queryName && !running ? '#' : undefined"
-        :class="{ run: true, running }"
-        @click.prevent="run"
-      >
-        Run
-      </a>
-    </header>
-    <pre v-if="queryResult">{{ queryResult }}</pre>
-    <span class="error" v-if="error">{{ error }}</span>
-    <span class="no-queries" v-if="queries && queries.length === 0">
-      No queries registered
-    </span>
-  </section>
-</template>
-
 <script>
 export default {
   data() {
@@ -84,6 +56,34 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="query" :class="{ loading }">
+    <header v-if="queries && queries.length">
+      <div class="query-name">
+        <v-select
+          placeholder="Choose a Query"
+          :value="queryName"
+          :options="queries"
+          :on-change="setQuery"
+          :searchable="false"
+        />
+      </div>
+      <a
+        :href="queryName && !running ? '#' : undefined"
+        :class="{ run: true, running }"
+        @click.prevent="run"
+      >
+        Run
+      </a>
+    </header>
+    <pre v-if="queryResult">{{ queryResult }}</pre>
+    <span class="error" v-if="error">{{ error }}</span>
+    <span class="no-queries" v-if="queries && queries.length === 0">
+      No queries registered
+    </span>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -1,17 +1,3 @@
-<template>
-  <section :class="{ 'stack-trace': true, loading }">
-    <header v-if="stackTraceTimestamp">
-      <span>Stack trace at {{ formattedStackTraceTimestamp }}</span>
-      <a href="#" class="refresh" @click="getStackTrace">Refresh</a>
-    </header>
-
-    <pre v-if="typeof stackTrace === 'string'">{{ stackTrace }}</pre>
-    <span class="error" v-if="stackTrace && stackTrace.error">{{
-      stackTrace.error
-    }}</span>
-  </section>
-</template>
-
 <script>
 import { getDatetimeFormattedString } from '~helpers';
 
@@ -65,6 +51,20 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section :class="{ 'stack-trace': true, loading }">
+    <header v-if="stackTraceTimestamp">
+      <span>Stack trace at {{ formattedStackTraceTimestamp }}</span>
+      <a href="#" class="refresh" @click="getStackTrace">Refresh</a>
+    </header>
+
+    <pre v-if="typeof stackTrace === 'string'">{{ stackTrace }}</pre>
+    <span class="error" v-if="stackTrace && stackTrace.error">{{
+      stackTrace.error
+    }}</span>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,136 +1,3 @@
-<template>
-  <section class="workflow-summary">
-    <aside class="actions">
-      <button-fill
-        color="secondary"
-        :disabled="isTerminateDisabled"
-        :disabled-label="terminateDisabledLabel"
-        label="TERMINATE"
-        @click.prevent="$modal.show('confirm-termination')"
-        v-if="isTerminateShown"
-      />
-    </aside>
-
-    <modal name="confirm-termination">
-      <h3>Are you sure you want to terminate this workflow?</h3>
-      <input v-model="terminationReason" placeholder="Reason" />
-      <footer>
-        <button-fill
-          color="secondary"
-          label="TERMINATE"
-          name="button-terminate"
-          @click.prevent="terminate"
-        />
-
-        <button-fill
-          color="primary"
-          label="CANCEL"
-          name="button-cancel"
-          @click.prevent="$modal.hide('confirm-termination')"
-        />
-      </footer>
-    </modal>
-
-    <dl v-if="workflow">
-      <div v-if="workflow.workflowExecutionInfo.isArchived">
-        <h5>Workflow archived</h5>
-        <p>
-          This workflow has been retrieved from archival. Some summary
-          information may be missing.
-        </p>
-      </div>
-      <div class="workflow-name">
-        <dt>Workflow Name</dt>
-        <dd>{{ workflow.workflowExecutionInfo.type.name }}</dd>
-      </div>
-      <div class="started-at">
-        <dt>Started At</dt>
-        <dd>{{ workflowStartTime }}</dd>
-      </div>
-      <div class="close-time" v-if="workflowCloseTime">
-        <dt>Closed Time</dt>
-        <dd>{{ workflowCloseTime }}</dd>
-      </div>
-      <div
-        class="workflow-status"
-        :data-status="
-          wfStatus !== undefined &&
-            (typeof wfStatus === 'string' ? wfStatus : wfStatus.status)
-        "
-      >
-        <dt>Status</dt>
-        <dd>
-          <bar-loader v-if="wfStatus === 'running'" />
-          <span v-if="typeof wfStatus === 'string'">{{ wfStatus }}</span>
-          <router-link
-            v-if="wfStatus !== undefined && wfStatus.to"
-            :to="wfStatus.to"
-          >
-            {{ wfStatus.text }}
-          </router-link>
-        </dd>
-      </div>
-      <div class="workflow-result" v-if="result">
-        <dt>Result</dt>
-        <dd>
-          <data-viewer :item="result" :title="workflowId + ' Result'" />
-        </dd>
-      </div>
-      <div class="workflow-id">
-        <dt>Workflow Id</dt>
-        <dd>{{ workflowId }}</dd>
-      </div>
-      <div class="run-id">
-        <dt>Run Id</dt>
-        <dd>{{ runId }}</dd>
-      </div>
-      <div class="parent-workflow" v-if="parentWorkflowRoute">
-        <dt>Parent Workflow</dt>
-        <dd>
-          <router-link :to="parentWorkflowRoute.to">
-            {{ parentWorkflowRoute.text }}
-          </router-link>
-        </dd>
-      </div>
-      <div class="task-list">
-        <dt>Task List</dt>
-        <dd>
-          <router-link
-            :to="{
-              name: 'task-list',
-              params: {
-                taskList: workflow.executionConfiguration.taskList.name,
-              },
-            }"
-          >
-            {{ workflow.executionConfiguration.taskList.name }}
-          </router-link>
-        </dd>
-      </div>
-      <div class="history-length">
-        <dt>History Events</dt>
-        <dd>{{ workflow.workflowExecutionInfo.historyLength }}</dd>
-      </div>
-      <div class="workflow-input">
-        <dt>Input</dt>
-        <dd>
-          <data-viewer
-            v-if="input !== undefined"
-            :item="input"
-            :title="workflowId + ' Input'"
-          />
-        </dd>
-      </div>
-      <div class="pending-activities" v-if="workflow.pendingActivities">
-        <dt>Pending Activities</dt>
-        <dd v-for="pa in workflow.pendingActivities" :key="pa.activityID">
-          <detail-list :item="pa" />
-        </dd>
-      </div>
-    </dl>
-  </section>
-</template>
-
 <script>
 import { TERMINATE_DEFAULT_ERROR_MESSAGE } from './constants';
 import { NOTIFICATION_TYPE_ERROR, NOTIFICATION_TYPE_SUCCESS } from '~constants';
@@ -267,6 +134,139 @@ export default {
   },
 };
 </script>
+
+<template>
+  <section class="workflow-summary">
+    <aside class="actions">
+      <button-fill
+        color="secondary"
+        :disabled="isTerminateDisabled"
+        :disabled-label="terminateDisabledLabel"
+        label="TERMINATE"
+        @click.prevent="$modal.show('confirm-termination')"
+        v-if="isTerminateShown"
+      />
+    </aside>
+
+    <modal name="confirm-termination">
+      <h3>Are you sure you want to terminate this workflow?</h3>
+      <input v-model="terminationReason" placeholder="Reason" />
+      <footer>
+        <button-fill
+          color="secondary"
+          label="TERMINATE"
+          name="button-terminate"
+          @click.prevent="terminate"
+        />
+
+        <button-fill
+          color="primary"
+          label="CANCEL"
+          name="button-cancel"
+          @click.prevent="$modal.hide('confirm-termination')"
+        />
+      </footer>
+    </modal>
+
+    <dl v-if="workflow">
+      <div v-if="workflow.workflowExecutionInfo.isArchived">
+        <h5>Workflow archived</h5>
+        <p>
+          This workflow has been retrieved from archival. Some summary
+          information may be missing.
+        </p>
+      </div>
+      <div class="workflow-name">
+        <dt>Workflow Name</dt>
+        <dd>{{ workflow.workflowExecutionInfo.type.name }}</dd>
+      </div>
+      <div class="started-at">
+        <dt>Started At</dt>
+        <dd>{{ workflowStartTime }}</dd>
+      </div>
+      <div class="close-time" v-if="workflowCloseTime">
+        <dt>Closed Time</dt>
+        <dd>{{ workflowCloseTime }}</dd>
+      </div>
+      <div
+        class="workflow-status"
+        :data-status="
+          wfStatus !== undefined &&
+            (typeof wfStatus === 'string' ? wfStatus : wfStatus.status)
+        "
+      >
+        <dt>Status</dt>
+        <dd>
+          <bar-loader v-if="wfStatus === 'running'" />
+          <span v-if="typeof wfStatus === 'string'">{{ wfStatus }}</span>
+          <router-link
+            v-if="wfStatus !== undefined && wfStatus.to"
+            :to="wfStatus.to"
+          >
+            {{ wfStatus.text }}
+          </router-link>
+        </dd>
+      </div>
+      <div class="workflow-result" v-if="result">
+        <dt>Result</dt>
+        <dd>
+          <data-viewer :item="result" :title="workflowId + ' Result'" />
+        </dd>
+      </div>
+      <div class="workflow-id">
+        <dt>Workflow Id</dt>
+        <dd>{{ workflowId }}</dd>
+      </div>
+      <div class="run-id">
+        <dt>Run Id</dt>
+        <dd>{{ runId }}</dd>
+      </div>
+      <div class="parent-workflow" v-if="parentWorkflowRoute">
+        <dt>Parent Workflow</dt>
+        <dd>
+          <router-link :to="parentWorkflowRoute.to">
+            {{ parentWorkflowRoute.text }}
+          </router-link>
+        </dd>
+      </div>
+      <div class="task-list">
+        <dt>Task List</dt>
+        <dd>
+          <router-link
+            :to="{
+              name: 'task-list',
+              params: {
+                taskList: workflow.executionConfiguration.taskList.name,
+              },
+            }"
+          >
+            {{ workflow.executionConfiguration.taskList.name }}
+          </router-link>
+        </dd>
+      </div>
+      <div class="history-length">
+        <dt>History Events</dt>
+        <dd>{{ workflow.workflowExecutionInfo.historyLength }}</dd>
+      </div>
+      <div class="workflow-input">
+        <dt>Input</dt>
+        <dd>
+          <data-viewer
+            v-if="input !== undefined"
+            :item="input"
+            :title="workflowId + ' Input'"
+          />
+        </dd>
+      </div>
+      <div class="pending-activities" v-if="workflow.pendingActivities">
+        <dt>Pending Activities</dt>
+        <dd v-for="pa in workflow.pendingActivities" :key="pa.activityID">
+          <detail-list :item="pa" />
+        </dd>
+      </div>
+    </dl>
+  </section>
+</template>
 
 <style lang="stylus">
 @require "../../styles/definitions.styl"


### PR DESCRIPTION
Reordering `<script>` tag to be the first element in a `.vue` file.
Used new lint rule to achieve & enforce this rule (see [eslint-plugin-vue/component-tags-order](https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/component-tags-order.md) for more information).
Also for two of the files (`client/components/loading-spinner.vue` & `client/routes/domain/workflow-archival/components/archival-table.vue`) have created a `<script>` tag as these were missing.
This is needed in order to inject license headers correctly, as this is a limitation of the library (see #220 & https://github.com/Stuk/eslint-plugin-header/pull/32 for more information).

No other changes are included in this PR.

## Screenshots
**Before changes with lint rule**
<img width="704" alt="Screen Shot 2020-11-24 at 9 33 05 AM" src="https://user-images.githubusercontent.com/58960161/100130922-33f9fe80-2e38-11eb-8610-1062e0883c1b.png">

**After changes with lint rule**
<img width="489" alt="Screen Shot 2020-11-24 at 9 33 27 AM" src="https://user-images.githubusercontent.com/58960161/100130957-3f4d2a00-2e38-11eb-94b8-65f132231ef2.png">
