### PR TITLE
Fix/server lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   globals: {
     module: true,   // hot reloading
     scenario: true, // mocha
+    should: true,   // mocha
   },
   plugins: ['jest', 'import'],
   rules: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf dist",
     "dev": "NODE_ENV=development node server.js",
     "lint": "npm run lint:check -- --fix",
-    "lint:check": "eslint --ext .js,.vue client",
+    "lint:check": "eslint --ext .js,.vue client server",
     "install": "npm run install:idl && npm run install:news",
     "install:idl": "napa && rm -rf server/idl && cp -R node_modules/cadence-idl/thrift server/idl",
     "install:news": "cd news && npm install",

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
-const Koa = require('koa'),
+const path = require('path'),
+  Koa = require('koa'),
   bodyparser = require('koa-bodyparser'),
   send = require('koa-send'),
-  path = require('path'),
   staticRoot = path.join(__dirname, '../dist'),
   app = new Koa(),
   router = require('./routes');
@@ -16,10 +16,14 @@ app.init = function(options) {
       ? options.useWebpack
       : process.env.NODE_ENV !== 'production';
 
+  let koaWebpack;
+  let compiler;
+
   if (useWebpack) {
-    var Webpack = require('webpack'),
-      koaWebpack = require('koa-webpack'),
-      compiler = Webpack(app.webpackConfig);
+    const Webpack = require('webpack');
+
+    koaWebpack = require('koa-webpack');
+    compiler = Webpack(app.webpackConfig);
   }
 
   app
@@ -72,6 +76,7 @@ app.init = function(options) {
             ctx.set('content-type', 'text/html');
             ctx.body = compiler.outputFileSystem.readFileSync(filename);
           } else {
+            // eslint-disable-next-line cup/no-undef
             done = await send(ctx, 'index.html', { root: staticRoot });
           }
         } catch (err) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,72 +1,88 @@
-const
-  Koa = require('koa'),
+const Koa = require('koa'),
   bodyparser = require('koa-bodyparser'),
   send = require('koa-send'),
   path = require('path'),
   staticRoot = path.join(__dirname, '../dist'),
   app = new Koa(),
-  router = require('./routes')
+  router = require('./routes');
 
-app.webpackConfig = require('../webpack.config')
+app.webpackConfig = require('../webpack.config');
 
 app.init = function(options) {
-  options = options || {}
+  options = options || {};
 
-  const useWebpack = 'useWebpack' in options ? options.useWebpack : process.env.NODE_ENV !== 'production'
+  const useWebpack =
+    'useWebpack' in options
+      ? options.useWebpack
+      : process.env.NODE_ENV !== 'production';
+
   if (useWebpack) {
     var Webpack = require('webpack'),
-        koaWebpack = require('koa-webpack'),
-        compiler = Webpack(app.webpackConfig)
+      koaWebpack = require('koa-webpack'),
+      compiler = Webpack(app.webpackConfig);
   }
 
-  app.use(async (ctx, next) => {
-    try {
-      await next()
-    } catch (err) {
-      if (options.logErrors !== false && (typeof err.statusCode !== 'number' || err.statusCode >= 500)) {
-        console.error(err)
-      }
-      ctx.status = err.statusCode || err.status || 500
-      ctx.body = { message: err.message }
-    }
-  })
-  .use(bodyparser())
-  .use(require('koa-compress')({
-    filter: contentType => !contentType.startsWith('text/event-stream')
-  }))
-  .use(require('./middleware/tchannel-client'))
-  .use(useWebpack ?
-    koaWebpack({
-      compiler,
-      dev: { stats: { colors: true } },
-      hot: { port: process.env.TEST_RUN ? 8082 : 8081 }
-    }) :
-    require('koa-static')(staticRoot))
-  .use(router.routes())
-  .use(router.allowedMethods())
-  .use(async function (ctx, next) {
-    if (['HEAD', 'GET'].includes(ctx.method) && !ctx.path.startsWith('/api')) {
+  app
+    .use(async (ctx, next) => {
       try {
-        ctx.set('X-Content-Type-Options', 'nosniff')
-        ctx.set('X-Frame-Options', 'SAMEORIGIN')
-        ctx.set('X-XSS-Protection', '1; mode=block')
-
-        if (useWebpack) {
-          var filename = path.join(compiler.outputPath, 'index.html')
-          ctx.set('content-type', 'text/html')
-          ctx.body = compiler.outputFileSystem.readFileSync(filename)
-        } else {
-          done = await send(ctx, 'index.html', { root: staticRoot })
-        }
+        await next();
       } catch (err) {
-        if (err.status !== 404) {
-          throw err
+        if (
+          options.logErrors !== false &&
+          (typeof err.statusCode !== 'number' || err.statusCode >= 500)
+        ) {
+          console.error(err);
+        }
+
+        ctx.status = err.statusCode || err.status || 500;
+        ctx.body = { message: err.message };
+      }
+    })
+    .use(bodyparser())
+    .use(
+      require('koa-compress')({
+        filter: contentType => !contentType.startsWith('text/event-stream'),
+      })
+    )
+    .use(require('./middleware/tchannel-client'))
+    .use(
+      useWebpack
+        ? koaWebpack({
+            compiler,
+            dev: { stats: { colors: true } },
+            hot: { port: process.env.TEST_RUN ? 8082 : 8081 },
+          })
+        : require('koa-static')(staticRoot)
+    )
+    .use(router.routes())
+    .use(router.allowedMethods())
+    .use(async function(ctx, next) {
+      if (
+        ['HEAD', 'GET'].includes(ctx.method) &&
+        !ctx.path.startsWith('/api')
+      ) {
+        try {
+          ctx.set('X-Content-Type-Options', 'nosniff');
+          ctx.set('X-Frame-Options', 'SAMEORIGIN');
+          ctx.set('X-XSS-Protection', '1; mode=block');
+
+          if (useWebpack) {
+            const filename = path.join(compiler.outputPath, 'index.html');
+
+            ctx.set('content-type', 'text/html');
+            ctx.body = compiler.outputFileSystem.readFileSync(filename);
+          } else {
+            done = await send(ctx, 'index.html', { root: staticRoot });
+          }
+        } catch (err) {
+          if (err.status !== 404) {
+            throw err;
+          }
         }
       }
-    }
-  })
+    });
 
-  return app
-}
+  return app;
+};
 
-module.exports = app
+module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,7 @@ app.init = function(options) {
             ctx.set('content-type', 'text/html');
             ctx.body = compiler.outputFileSystem.readFileSync(filename);
           } else {
-            await send(ctx, 'index.html', { root: staticRoot })
+            await send(ctx, 'index.html', { root: staticRoot });
           }
         } catch (err) {
           if (err.status !== 404) {

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -1,7 +1,6 @@
-'use strict'
+'use strict';
 
-const
-  TChannelAsThrift = require('tchannel/as/thrift'),
+const TChannelAsThrift = require('tchannel/as/thrift'),
   TChannel = require('tchannel'),
   path = require('path'),
   Long = require('long'),
@@ -11,96 +10,115 @@ const
   isIPv4 = require('is-ipv4-node');
 
 function uiTransform(item) {
-  if (!item || typeof item !== 'object') return item
+  if (!item || typeof item !== 'object') {
+    return item;
+  }
 
   Object.entries(item).forEach(([subkey, subvalue]) => {
     if (subvalue && typeof subvalue.unsigned === 'boolean') {
-      item[subkey] = Long.fromValue(subvalue).toNumber()
-      var m = moment(item[subkey] / 1000000)
+      item[subkey] = Long.fromValue(subvalue).toNumber();
+      const m = moment(item[subkey] / 1000000);
+
       if (m.isValid() && m.isAfter('2017-01-01')) {
-        item[subkey] = m.toISOString()
+        item[subkey] = m.toISOString();
       }
     } else if (Buffer.isBuffer(subvalue)) {
       if (subkey === 'nextPageToken') {
-        item.nextPageToken = subvalue.toString('base64')
-        return
+        item.nextPageToken = subvalue.toString('base64');
+
+        return;
       }
 
-      let stringval = subvalue.toString('utf8')
+      const stringval = subvalue.toString('utf8');
+
       try {
         // most of Cadence's uses of buffer is just line-delimited JSON.
-        item[subkey] = stringval.split('\n').filter(x => x).map(JSON.parse)
-        if (item[subkey].length === 1) {
-          item[subkey] = item[subkey][0]
-        }
-      } catch(e) {
-        item[`${subkey}_base64`] = subvalue.toString('base64')
         item[subkey] = stringval
+          .split('\n')
+          .filter(x => x)
+          .map(JSON.parse);
+
+        if (item[subkey].length === 1) {
+          item[subkey] = item[subkey][0];
+        }
+      } catch (e) {
+        item[`${subkey}_base64`] = subvalue.toString('base64');
+        item[subkey] = stringval;
       }
     } else if (Array.isArray(subvalue)) {
-      subvalue.forEach(uiTransform)
+      subvalue.forEach(uiTransform);
     } else if (subvalue && typeof subvalue === 'object') {
-      uiTransform(subvalue)
+      uiTransform(subvalue);
     }
-  })
-  return item
+  });
+
+  return item;
 }
 
 function cliTransform(item) {
-  if (!item || typeof item !== 'object') return item
+  if (!item || typeof item !== 'object') {
+    return item;
+  }
 
   Object.entries(item).forEach(([subkey, subvalue]) => {
     if (subvalue && typeof subvalue.unsigned === 'boolean') {
-      item[subkey] = new losslessJSON.LosslessNumber(Long.fromValue(subvalue).toString())
+      item[subkey] = new losslessJSON.LosslessNumber(
+        Long.fromValue(subvalue).toString()
+      );
     } else if (Buffer.isBuffer(subvalue)) {
-      item[subkey] = subvalue.toString('base64')
+      item[subkey] = subvalue.toString('base64');
     } else if (Array.isArray(subvalue)) {
-      subvalue.forEach(cliTransform)
+      subvalue.forEach(cliTransform);
     } else if (subvalue && typeof subvalue === 'object') {
-      cliTransform(subvalue)
+      cliTransform(subvalue);
     } else if (subvalue === null || subvalue === undefined) {
-      delete item[subkey]
+      delete item[subkey];
     }
-  })
-  return item
+  });
+
+  return item;
 }
 
-const lookupAsync = host => new Promise(function (resolve, reject) {
-  dns.lookup(host, { family: 4 }, function (err, ip) {
-    if (err) {
-      reject(err)
-    } else {
-      resolve(ip)
-    }
-  })
-})
+const lookupAsync = host =>
+  new Promise(function(resolve, reject) {
+    dns.lookup(host, { family: 4 }, function(err, ip) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(ip);
+      }
+    });
+  });
 
-const peers = process.env.CADENCE_TCHANNEL_PEERS ?
-  process.env.CADENCE_TCHANNEL_PEERS.split(',') :
-  ['127.0.0.1:7933']
+const peers = process.env.CADENCE_TCHANNEL_PEERS
+  ? process.env.CADENCE_TCHANNEL_PEERS.split(',')
+  : ['127.0.0.1:7933'];
 
 async function makeChannel(client) {
-  var ipPeers = await Promise.all(peers.map(peer => {
-    var [host, port] = peer.split(':')
-    if (!isIPv4(host)) {
-      return lookupAsync(host).then(ip => [ip, port].join(':'))
-    } else {
-      return peer
-    }
-  }));
+  const ipPeers = await Promise.all(
+    peers.map(peer => {
+      const [host, port] = peer.split(':');
+
+      if (!isIPv4(host)) {
+        return lookupAsync(host).then(ip => [ip, port].join(':'));
+      } else {
+        return peer;
+      }
+    })
+  );
 
   const cadenceChannel = client.makeSubChannel({
     serviceName: 'cadence-frontend',
     peers: ipPeers,
     requestDefaults: {
       hasNoParent: true,
-      headers: { 'as': 'raw', 'cn': 'cadence-web' },
-    }
+      headers: { as: 'raw', cn: 'cadence-web' },
+    },
   });
 
   const tchannelAsThrift = TChannelAsThrift({
     channel: cadenceChannel,
-    entryPoint: path.join(__dirname, '../idl/cadence.thrift')
+    entryPoint: path.join(__dirname, '../idl/cadence.thrift'),
   });
 
   return tchannelAsThrift;
@@ -112,83 +130,136 @@ module.exports = async function(ctx, next) {
   const { authTokenHeaders = {} } = ctx;
 
   function req(method, reqName, bodyTransform, resTransform) {
-    return (body) => new Promise(function(resolve, reject) {
-      try {
-        channel.request({
-          serviceName: process.env.CADENCE_TCHANNEL_SERVICE || 'cadence-frontend',
-          timeout: 1000 * 60 * 5,
-          retryFlags: { onConnectionError: true },
-          retryLimit: Number(process.env.CADENCE_TCHANNEL_RETRY_LIMIT || 3)
-        }).send(
-          `WorkflowService::${method}`,
-          {
-            ...authTokenHeaders,
-          },
-          {
-            [`${reqName ? reqName + 'R' : 'r'}equest`]: typeof bodyTransform === 'function' ? bodyTransform(body) : body
-          },
-          function (err, res) {
-            try {
-              if (err) {
-                reject(err)
-              } else if (res.ok) {
-                resolve((resTransform || uiTransform)(res.body))
-              } else {
-                ctx.throw(res.typeName === 'entityNotExistError' ? 404 : 400, null, res.body || res)
+    return body =>
+      new Promise(function(resolve, reject) {
+        try {
+          channel
+            .request({
+              serviceName:
+                process.env.CADENCE_TCHANNEL_SERVICE || 'cadence-frontend',
+              timeout: 1000 * 60 * 5,
+              retryFlags: { onConnectionError: true },
+              retryLimit: Number(process.env.CADENCE_TCHANNEL_RETRY_LIMIT || 3),
+            })
+            .send(
+              `WorkflowService::${method}`,
+              {
+                ...authTokenHeaders,
+              },
+              {
+                [`${reqName ? reqName + 'R' : 'r'}equest`]:
+                  typeof bodyTransform === 'function'
+                    ? bodyTransform(body)
+                    : body,
+              },
+              function(err, res) {
+                try {
+                  if (err) {
+                    reject(err);
+                  } else if (res.ok) {
+                    resolve((resTransform || uiTransform)(res.body));
+                  } else {
+                    ctx.throw(
+                      res.typeName === 'entityNotExistError' ? 404 : 400,
+                      null,
+                      res.body || res
+                    );
+                  }
+                } catch (e) {
+                  reject(e);
+                }
               }
-            } catch (e) {
-              reject(e)
-            }
-          }
-        )
-      } catch(e) {
-        reject(e)
-      }
-    })
+            );
+        } catch (e) {
+          reject(e);
+        }
+      });
   }
 
-  const withDomainPaging = body => Object.assign({
-    domain: ctx.params.domain,
-    maximumPageSize: 100
-  }, body),
-  withWorkflowExecution = body => Object.assign({
-    domain: ctx.params.domain,
-    execution: {
-      workflowId: ctx.params.workflowId,
-      runId: ctx.params.runId
-    },
-  }, body),
-  withVerboseWorkflowExecution = body => Object.assign({
-    domain: ctx.params.domain,
-    workflowExecution: {
-      workflowId: ctx.params.workflowId,
-      runId: ctx.params.runId
-    },
-  }, body),
-  withDomainAndWorkflowExecution = b => Object.assign(withDomainPaging(b), withWorkflowExecution(b))
+  const withDomainPaging = body =>
+      Object.assign(
+        {
+          domain: ctx.params.domain,
+          maximumPageSize: 100,
+        },
+        body
+      ),
+    withWorkflowExecution = body =>
+      Object.assign(
+        {
+          domain: ctx.params.domain,
+          execution: {
+            workflowId: ctx.params.workflowId,
+            runId: ctx.params.runId,
+          },
+        },
+        body
+      ),
+    withVerboseWorkflowExecution = body =>
+      Object.assign(
+        {
+          domain: ctx.params.domain,
+          workflowExecution: {
+            workflowId: ctx.params.workflowId,
+            runId: ctx.params.runId,
+          },
+        },
+        body
+      ),
+    withDomainAndWorkflowExecution = b =>
+      Object.assign(withDomainPaging(b), withWorkflowExecution(b));
 
   ctx.cadence = {
-    archivedWorkflows: req('ListArchivedWorkflowExecutions', 'list', withDomainPaging),
-    closedWorkflows: req('ListClosedWorkflowExecutions', 'list', withDomainPaging),
+    archivedWorkflows: req(
+      'ListArchivedWorkflowExecutions',
+      'list',
+      withDomainPaging
+    ),
+    closedWorkflows: req(
+      'ListClosedWorkflowExecutions',
+      'list',
+      withDomainPaging
+    ),
     describeDomain: req('DescribeDomain', 'describe'),
     describeTaskList: req('DescribeTaskList'),
-    describeWorkflow: req('DescribeWorkflowExecution', 'describe', withWorkflowExecution),
-    exportHistory: req('GetWorkflowExecutionHistory', 'get', withDomainAndWorkflowExecution, cliTransform),
-    getHistory: req('GetWorkflowExecutionHistory', 'get', withDomainAndWorkflowExecution),
+    describeWorkflow: req(
+      'DescribeWorkflowExecution',
+      'describe',
+      withWorkflowExecution
+    ),
+    exportHistory: req(
+      'GetWorkflowExecutionHistory',
+      'get',
+      withDomainAndWorkflowExecution,
+      cliTransform
+    ),
+    getHistory: req(
+      'GetWorkflowExecutionHistory',
+      'get',
+      withDomainAndWorkflowExecution
+    ),
     listDomains: req('ListDomains', 'list'),
     listTaskListPartitions: req('ListTaskListPartitions'),
     listWorkflows: req('ListWorkflowExecutions', 'list', withDomainPaging),
     openWorkflows: req('ListOpenWorkflowExecutions', 'list', withDomainPaging),
     queryWorkflow: req('QueryWorkflow', 'query', withWorkflowExecution),
-    signalWorkflow: req('SignalWorkflowExecution', 'signal', withVerboseWorkflowExecution),
-    terminateWorkflow: req('TerminateWorkflowExecution', 'terminate', withVerboseWorkflowExecution),
+    signalWorkflow: req(
+      'SignalWorkflowExecution',
+      'signal',
+      withVerboseWorkflowExecution
+    ),
+    terminateWorkflow: req(
+      'TerminateWorkflowExecution',
+      'terminate',
+      withVerboseWorkflowExecution
+    ),
   };
 
   try {
-    await next()
-    client.close()
+    await next();
+    client.close();
   } catch (e) {
-    client.close()
-    throw e
+    client.close();
+    throw e;
   }
-}
+};

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const TChannelAsThrift = require('tchannel/as/thrift'),
+const path = require('path'),
+  dns = require('dns'),
+  TChannelAsThrift = require('tchannel/as/thrift'),
   TChannel = require('tchannel'),
-  path = require('path'),
   Long = require('long'),
   losslessJSON = require('lossless-json'),
   moment = require('moment'),
-  dns = require('dns'),
   isIPv4 = require('is-ipv4-node');
 
 function uiTransform(item) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,40 +1,44 @@
-const
-  Router = require('koa-router'),
+const Router = require('koa-router'),
   router = new Router(),
   moment = require('moment'),
   Long = require('long'),
   losslessJSON = require('lossless-json'),
   featureFlags = require('./feature-flags.json');
-  momentToLong = m => Long.fromValue(m.unix()).mul(1000000000)
 
-router.get('/api/domains', async function (ctx) {
+momentToLong = m => Long.fromValue(m.unix()).mul(1000000000);
+
+router.get('/api/domains', async function(ctx) {
   ctx.body = await ctx.cadence.listDomains({
     pageSize: 50,
-    nextPageToken: ctx.query.nextPageToken ? Buffer.from(ctx.query.nextPageToken, 'base64') : undefined
-  })
-})
+    nextPageToken: ctx.query.nextPageToken
+      ? Buffer.from(ctx.query.nextPageToken, 'base64')
+      : undefined,
+  });
+});
 
-router.get('/api/domains/:domain', async function (ctx) {
-  ctx.body = await ctx.cadence.describeDomain({ name: ctx.params.domain })
-})
+router.get('/api/domains/:domain', async function(ctx) {
+  ctx.body = await ctx.cadence.describeDomain({ name: ctx.params.domain });
+});
 
 async function listWorkflows(state, ctx) {
-  var q = ctx.query || {},
-      startTime = moment(q.startTime || NaN),
-      endTime = moment(q.endTime || NaN)
+  const q = ctx.query || {},
+    startTime = moment(q.startTime || NaN),
+    endTime = moment(q.endTime || NaN);
 
-  ctx.assert(startTime.isValid() && endTime.isValid(), 400)
+  ctx.assert(startTime.isValid() && endTime.isValid(), 400);
 
   ctx.body = await ctx.cadence[state + 'Workflows']({
     StartTimeFilter: {
       earliestTime: momentToLong(startTime),
-      latestTime: momentToLong(endTime)
+      latestTime: momentToLong(endTime),
     },
     typeFilter: q.workflowName ? { name: q.workflowName } : undefined,
     executionFilter: q.workflowId ? { workflowId: q.workflowId } : undefined,
     statusFilter: q.status || undefined,
-    nextPageToken: q.nextPageToken ? Buffer.from(q.nextPageToken, 'base64') : undefined
-  })
+    nextPageToken: q.nextPageToken
+      ? Buffer.from(q.nextPageToken, 'base64')
+      : undefined,
+  });
 }
 
 /**
@@ -52,7 +56,7 @@ async function listWorkflows(state, ctx) {
  *  };
  * })
  */
-router.get('/api/domains/:domain/authorization', async function (ctx, next) {
+router.get('/api/domains/:domain/authorization', async function(ctx, next) {
   ctx.body = {
     authorization: true,
   };
@@ -60,18 +64,31 @@ router.get('/api/domains/:domain/authorization', async function (ctx, next) {
   next();
 });
 
-router.get('/api/domains/:domain/workflows/open', listWorkflows.bind(null, 'open'))
-router.get('/api/domains/:domain/workflows/closed', listWorkflows.bind(null, 'closed'))
+router.get(
+  '/api/domains/:domain/workflows/open',
+  listWorkflows.bind(null, 'open')
+);
+router.get(
+  '/api/domains/:domain/workflows/closed',
+  listWorkflows.bind(null, 'closed')
+);
 
-const buildQueryString = (startTime, endTime, { status, workflowId, workflowName }) => ([
-  `CloseTime >= "${startTime.toISOString()}"`,
-  `CloseTime <= "${endTime.toISOString()}"`,
-  status && `CloseStatus = "${status}"`,
-  workflowId && `WorkflowID = "${workflowId}"`,
-  workflowName && `WorkflowType = "${workflowName}"`,
-].filter((subQuery) => !!subQuery).join(' and '));
+const buildQueryString = (
+  startTime,
+  endTime,
+  { status, workflowId, workflowName }
+) =>
+  [
+    `CloseTime >= "${startTime.toISOString()}"`,
+    `CloseTime <= "${endTime.toISOString()}"`,
+    status && `CloseStatus = "${status}"`,
+    workflowId && `WorkflowID = "${workflowId}"`,
+    workflowName && `WorkflowType = "${workflowName}"`,
+  ]
+    .filter(subQuery => !!subQuery)
+    .join(' and ');
 
-router.get('/api/domains/:domain/workflows/archived', async function (ctx) {
+router.get('/api/domains/:domain/workflows/archived', async function(ctx) {
   const { nextPageToken, ...query } = ctx.query || {};
   let queryString;
 
@@ -85,119 +102,169 @@ router.get('/api/domains/:domain/workflows/archived', async function (ctx) {
     queryString = buildQueryString(startTime, endTime, query);
   }
 
-  ctx.body = await ctx.cadence['archivedWorkflows']({
+  ctx.body = await ctx.cadence.archivedWorkflows({
     query: queryString,
-    nextPageToken: nextPageToken ? Buffer.from(nextPageToken, 'base64') : undefined
+    nextPageToken: nextPageToken
+      ? Buffer.from(nextPageToken, 'base64')
+      : undefined,
   });
 });
 
-router.get('/api/domains/:domain/workflows/list', async function (ctx) {
-  var q = ctx.query || {}
-  ctx.body = await ctx.cadence['listWorkflows']({
-    query: q.queryString || undefined,
-    nextPageToken: q.nextPageToken ? Buffer.from(q.nextPageToken, 'base64') : undefined
-  })
-})
+router.get('/api/domains/:domain/workflows/list', async function(ctx) {
+  const q = ctx.query || {};
 
-const mapHistoryResponse = (history) => {
+  ctx.body = await ctx.cadence.listWorkflows({
+    query: q.queryString || undefined,
+    nextPageToken: q.nextPageToken
+      ? Buffer.from(q.nextPageToken, 'base64')
+      : undefined,
+  });
+});
+
+const mapHistoryResponse = history => {
   if (Array.isArray(history && history.events)) {
     return history.events.map(e => {
-      var attr = e.eventType ?
-        e.eventType.charAt(0).toLowerCase() + e.eventType.slice(1) + 'EventAttributes' : '';
+      const attr = e.eventType
+        ? e.eventType.charAt(0).toLowerCase() +
+          e.eventType.slice(1) +
+          'EventAttributes'
+        : '';
+
       if (e[attr]) {
-        var details = JSON.parse(
-          JSON.stringify(e[attr]), function replacer(key, value) {
-            if (value && value.type && value.type === 'Buffer') {
-              return Buffer.from(value).toString().replace(/["]/g, '').trim();
-            }
-            return value;
+        var details = JSON.parse(JSON.stringify(e[attr]), function replacer(
+          key,
+          value
+        ) {
+          if (value && value.type && value.type === 'Buffer') {
+            return Buffer.from(value)
+              .toString()
+              .replace(/["]/g, '')
+              .trim();
           }
-        );
+
+          return value;
+        });
       }
 
       return {
         timestamp: e.timestamp,
         eventType: e.eventType,
         eventId: e.eventId,
-        details
-      }
-    })
+        details,
+      };
+    });
   }
-}
+};
 
-router.get('/api/domains/:domain/workflows/:workflowId/:runId/history', async function (ctx) {
-  var q = ctx.query || {}
-  ctx.body = await ctx.cadence.getHistory({
-    nextPageToken: q.nextPageToken ? Buffer.from(q.nextPageToken, 'base64') : undefined,
-    waitForNewEvent: 'waitForNewEvent' in q ? true : undefined
-  })
+router.get(
+  '/api/domains/:domain/workflows/:workflowId/:runId/history',
+  async function(ctx) {
+    const q = ctx.query || {};
 
-  ctx.body.history.events = mapHistoryResponse(ctx.body.history);
-})
+    ctx.body = await ctx.cadence.getHistory({
+      nextPageToken: q.nextPageToken
+        ? Buffer.from(q.nextPageToken, 'base64')
+        : undefined,
+      waitForNewEvent: 'waitForNewEvent' in q ? true : undefined,
+    });
 
-router.get('/api/domains/:domain/workflows/:workflowId/:runId/export', async function (ctx) {
-  var nextPageToken
+    ctx.body.history.events = mapHistoryResponse(ctx.body.history);
+  }
+);
 
-  do {
-    var page = await ctx.cadence.exportHistory({ nextPageToken })
-    if (!nextPageToken) {
-      ctx.status = 200
+router.get(
+  '/api/domains/:domain/workflows/:workflowId/:runId/export',
+  async function(ctx) {
+    let nextPageToken;
+
+    do {
+      const page = await ctx.cadence.exportHistory({ nextPageToken });
+
+      if (!nextPageToken) {
+        ctx.status = 200;
+      }
+
+      ctx.res.write(
+        (nextPageToken ? ',' : '[') +
+          page.history.events.map(losslessJSON.stringify).join(',')
+      );
+      nextPageToken =
+        page.nextPageToken && Buffer.from(page.nextPageToken, 'base64');
+    } while (nextPageToken);
+
+    ctx.res.write(']');
+    ctx.body = '';
+  }
+);
+
+router.get(
+  '/api/domains/:domain/workflows/:workflowId/:runId/query',
+  async function(ctx) {
+    // workaround implementation until https://github.com/uber/cadence/issues/382 is resolved
+    try {
+      await ctx.cadence.queryWorkflow({
+        query: {
+          queryType: '__cadence_web_list',
+        },
+      });
+
+      ctx.throw(500);
+    } catch (e) {
+      ctx.body = ((e.message || '').match(
+        /(KnownQueryTypes|knownTypes)=\[(.*)\]/
+      ) || [null, null, ''])[2]
+        .split(/, | /)
+        .filter(q => q);
     }
-    ctx.res.write((nextPageToken ? ',' : '[') + page.history.events.map(losslessJSON.stringify).join(','))
-    nextPageToken = page.nextPageToken && Buffer.from(page.nextPageToken, 'base64')
-  } while (nextPageToken)
+  }
+);
 
-  ctx.res.write(']')
-  ctx.body = ''
-})
-
-router.get('/api/domains/:domain/workflows/:workflowId/:runId/query', async function (ctx) {
-  // workaround implementation until https://github.com/uber/cadence/issues/382 is resolved
-  try {
-    await ctx.cadence.queryWorkflow({
+router.post(
+  '/api/domains/:domain/workflows/:workflowId/:runId/query/:queryType',
+  async function(ctx) {
+    ctx.body = await ctx.cadence.queryWorkflow({
       query: {
-        queryType: '__cadence_web_list'
-      }
-    })
-
-    ctx.throw(500)
-  } catch(e) {
-    ctx.body = ((e.message || '')
-      .match(/(KnownQueryTypes|knownTypes)=\[(.*)\]/) || [null, null, ''])[2]
-      .split(/, | /)
-      .filter(q => q)
+        queryType: ctx.params.queryType,
+      },
+    });
   }
-})
+);
 
-router.post('/api/domains/:domain/workflows/:workflowId/:runId/query/:queryType', async function (ctx) {
-  ctx.body = await ctx.cadence.queryWorkflow({
-    query: {
-      queryType: ctx.params.queryType
-    }
-  })
-})
+router.post(
+  '/api/domains/:domain/workflows/:workflowId/:runId/terminate',
+  async function(ctx) {
+    ctx.body = await ctx.cadence.terminateWorkflow({
+      reason: ctx.request.body && ctx.request.body.reason,
+    });
+  }
+);
 
-router.post('/api/domains/:domain/workflows/:workflowId/:runId/terminate', async function (ctx) {
-  ctx.body = await ctx.cadence.terminateWorkflow({
-    reason: ctx.request.body && ctx.request.body.reason
-  })
-})
+router.post(
+  '/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal',
+  async function(ctx) {
+    ctx.body = await ctx.cadence.signalWorkflow({
+      signalName: ctx.params.signal,
+    });
+  }
+);
 
-router.post('/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal', async function (ctx) {
-  ctx.body = await ctx.cadence.signalWorkflow({ signalName: ctx.params.signal })
-})
-
-router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (ctx) {
+router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function(
+  ctx
+) {
   try {
     const describeResponse = await ctx.cadence.describeWorkflow();
 
     if (describeResponse.workflowExecutionInfo) {
       describeResponse.workflowExecutionInfo.closeEvent = null;
+
       if (describeResponse.workflowExecutionInfo.closeStatus) {
         const closeEventResponse = await ctx.cadence.getHistory({
           HistoryEventFilterType: 'CLOSE_EVENT',
         });
-        describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(closeEventResponse.history)[0];
+
+        describeResponse.workflowExecutionInfo.closeEvent = mapHistoryResponse(
+          closeEventResponse.history
+        )[0];
       }
     }
 
@@ -208,7 +275,9 @@ router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (
     }
 
     const archivedHistoryResponse = await ctx.cadence.getHistory();
-    const archivedHistoryEvents = mapHistoryResponse(archivedHistoryResponse.history);
+    const archivedHistoryEvents = mapHistoryResponse(
+      archivedHistoryResponse.history
+    );
 
     if (!archivedHistoryEvents.length) {
       throw error;
@@ -242,46 +311,64 @@ router.get('/api/domains/:domain/workflows/:workflowId/:runId', async function (
         type,
       },
       pendingActivities: null,
-      pendingChildren: null
+      pendingChildren: null,
     };
-  };
+  }
 });
 
-router.get('/api/domains/:domain/task-lists/:taskList/pollers', async function (ctx) {
-  const descTaskList = async (taskListType) => (await ctx.cadence.describeTaskList({
-    domain: ctx.params.domain,
-    taskList: { name: ctx.params.taskList },
-    taskListType
-  })).pollers || [];
+router.get('/api/domains/:domain/task-lists/:taskList/pollers', async function(
+  ctx
+) {
+  const descTaskList = async taskListType =>
+    (
+      await ctx.cadence.describeTaskList({
+        domain: ctx.params.domain,
+        taskList: { name: ctx.params.taskList },
+        taskListType,
+      })
+    ).pollers || [];
 
   const r = type => (o, poller) => {
-    let i = o[poller.identity] || {}
+    const i = o[poller.identity] || {};
+
     o[poller.identity] = {
-      lastAccessTime: !i.lastAccessTime || i.lastAccessTime < poller.lastAccessTime ?
-        poller.lastAccessTime : i.lastAccessTime,
-      taskListTypes: i.taskListTypes ? i.taskListTypes.concat([type]) : [type]
-    }
-    return o
-  }
+      lastAccessTime:
+        !i.lastAccessTime || i.lastAccessTime < poller.lastAccessTime
+          ? poller.lastAccessTime
+          : i.lastAccessTime,
+      taskListTypes: i.taskListTypes ? i.taskListTypes.concat([type]) : [type],
+    };
+
+    return o;
+  };
 
   const activityL = await descTaskList('Activity'),
     decisionL = await descTaskList('Decision');
 
-  ctx.body = activityL.reduce(r('activity'), decisionL.reduce(r('decision'), {}))
-})
-
-router.get('/api/domains/:domain/task-lists/:taskList/partitions', async function (ctx) {
-  const { domain, taskList } = ctx.params;
-  ctx.body = await ctx.cadence.listTaskListPartitions({
-    domain,
-    taskList: { name: taskList },
-  });
+  ctx.body = activityL.reduce(
+    r('activity'),
+    decisionL.reduce(r('decision'), {})
+  );
 });
 
+router.get(
+  '/api/domains/:domain/task-lists/:taskList/partitions',
+  async function(ctx) {
+    const { domain, taskList } = ctx.params;
+
+    ctx.body = await ctx.cadence.listTaskListPartitions({
+      domain,
+      taskList: { name: taskList },
+    });
+  }
+);
+
 router.get('/api/feature-flags/:key', (ctx, next) => {
-  const { params: { key } } = ctx;
-  const featureFlag = featureFlags.find((featureFlag) => featureFlag.key === key);
-  const value = featureFlag && featureFlag.value || false;
+  const {
+    params: { key },
+  } = ctx;
+  const featureFlag = featureFlags.find(featureFlag => featureFlag.key === key);
+  const value = (featureFlag && featureFlag.value) || false;
 
   ctx.body = {
     key,
@@ -291,6 +378,6 @@ router.get('/api/feature-flags/:key', (ctx, next) => {
   next();
 });
 
-router.get('/health', ctx => ctx.body = 'OK')
+router.get('/health', ctx => (ctx.body = 'OK'));
 
-module.exports = router
+module.exports = router;

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -1,42 +1,44 @@
-const
-  supertest = require('supertest'),
+const supertest = require('supertest'),
   TChannel = require('tchannel'),
   TChannelAsThrift = require('tchannel/as/thrift'),
   Long = require('long'),
-  path = require('path')
+  path = require('path');
 
-var tchanServer, currTest, client, app
+let tchanServer, currTest, client, app;
 
-global.should = require('chai').should()
-global.dateToLong = d => Long.fromValue(Number(new Date(d))).mul(1000000)
+global.should = require('chai').should();
+
+global.dateToLong = d => Long.fromValue(Number(new Date(d))).mul(1000000);
 
 before(function(done) {
-  tchanServer = new TChannel({ serviceName: 'cadence-frontend' })
+  tchanServer = new TChannel({ serviceName: 'cadence-frontend' });
 
-  client = new TChannel()
-  var cadenceChan = client.makeSubChannel({
-    serviceName: 'cadence-frontend'
-  })
-  var tchan = TChannelAsThrift({
+  client = new TChannel();
+  const cadenceChan = client.makeSubChannel({
+    serviceName: 'cadence-frontend',
+  });
+  const tchan = TChannelAsThrift({
     channel: cadenceChan,
-    entryPoint: path.join(__dirname, '../idl/cadence.thrift')
-  })
+    entryPoint: path.join(__dirname, '../idl/cadence.thrift'),
+  });
 
   const handler = (ctx, req, head, body, cb) => {
-    var mockName = req.endpoint.replace('WorkflowService::', '')
+    const mockName = req.endpoint.replace('WorkflowService::', '');
+
     if (!currTest[mockName]) {
-      throw new Error(`unexpected request to ${req.endpoint}`)
+      throw new Error(`unexpected request to ${req.endpoint}`);
     }
 
-    var body = currTest[mockName](body, req)
+    var body = currTest[mockName](body, req);
+
     if (body instanceof Error) {
-      cb(body)
+      cb(body);
     } else if (body && body.ok === false) {
-      cb(null, body)
+      cb(null, body);
     } else {
-      cb(null, { ok: true, head, body })
+      cb(null, { ok: true, head, body });
     }
-  }
+  };
 
   [
     'ListOpenWorkflowExecutions',
@@ -48,22 +50,26 @@ before(function(done) {
     'SignalWorkflowExecution',
     'ListDomains',
     'DescribeDomain',
-    'DescribeTaskList'
-  ].forEach(endpoint => tchan.register(tchanServer, 'WorkflowService::' + endpoint, {}, handler))
+    'DescribeTaskList',
+  ].forEach(endpoint =>
+    tchan.register(tchanServer, 'WorkflowService::' + endpoint, {}, handler)
+  );
 
-  process.env.CADENCE_TCHANNEL_PEERS = '127.0.0.1:11343'
-  tchanServer.listen(11343, '127.0.0.1', () => done())
+  process.env.CADENCE_TCHANNEL_PEERS = '127.0.0.1:11343';
+  tchanServer.listen(11343, '127.0.0.1', () => done());
 
-  app = require('../').init({ useWebpack: false, logErrors: false }).listen()
-  global.request = supertest.bind(supertest, app)
-})
+  app = require('../')
+    .init({ useWebpack: false, logErrors: false })
+    .listen();
+  global.request = supertest.bind(supertest, app);
+});
 
 after(function() {
-  app.close()
-  tchanServer.close()
-  client.close()
-})
+  app.close();
+  tchanServer.close();
+  client.close();
+});
 
 beforeEach(function() {
-  currTest = this.currentTest
-})
+  currTest = this.currentTest;
+});

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -1,8 +1,8 @@
-const supertest = require('supertest'),
+const path = require('path'),
+  supertest = require('supertest'),
   TChannel = require('tchannel'),
   TChannelAsThrift = require('tchannel/as/thrift'),
-  Long = require('long'),
-  path = require('path');
+  Long = require('long');
 
 let tchanServer, currTest, client, app;
 
@@ -29,14 +29,14 @@ before(function(done) {
       throw new Error(`unexpected request to ${req.endpoint}`);
     }
 
-    var body = currTest[mockName](body, req);
+    const bodyMock = currTest[mockName](body, req);
 
-    if (body instanceof Error) {
-      cb(body);
-    } else if (body && body.ok === false) {
-      cb(null, body);
+    if (bodyMock instanceof Error) {
+      cb(bodyMock);
+    } else if (bodyMock && bodyMock.ok === false) {
+      cb(null, bodyMock);
     } else {
-      cb(null, { ok: true, head, body });
+      cb(null, { ok: true, head, body: bodyMock });
     }
   };
 

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -1,44 +1,47 @@
 describe('Describe Domain', function() {
   it('should list domains', async function() {
-    const domains = [{
-      domainInfo: {
-        name: 'ci-test-domain',
-        status: 'REGISTERED',
-        description: 'domain for running CI tests',
-        ownerEmail: 'cadence-dev@uber.com',
-        data: null,
-        uuid: null
+    const domains = [
+      {
+        domainInfo: {
+          name: 'ci-test-domain',
+          status: 'REGISTERED',
+          description: 'domain for running CI tests',
+          ownerEmail: 'cadence-dev@uber.com',
+          data: null,
+          uuid: null,
+        },
+        isGlobalDomain: false,
+        failoverVersion: 0,
+        configuration: {
+          badBinaries: null,
+          emitMetric: false,
+          historyArchivalStatus: null,
+          historyArchivalURI: null,
+          visibilityArchivalStatus: null,
+          visibilityArchivalURI: null,
+          workflowExecutionRetentionPeriodInDays: 14,
+        },
+        replicationConfiguration: {
+          activeClusterName: 'ci-cluster',
+          clusters: [],
+        },
       },
-      isGlobalDomain: false,
-      failoverVersion: 0,
-      configuration: {
-        badBinaries: null,
-        emitMetric: false,
-        historyArchivalStatus: null,
-        historyArchivalURI: null,
-        visibilityArchivalStatus: null,
-        visibilityArchivalURI: null,
-        workflowExecutionRetentionPeriodInDays: 14
-      },
-      replicationConfiguration: {
-        activeClusterName: 'ci-cluster',
-        clusters: []
-      }
-    }]
+    ];
 
     this.test.ListDomains = ({ listRequest }) => {
-      should.not.exist(listRequest.nextPageToken)
-      return { domains }
-    }
+      should.not.exist(listRequest.nextPageToken);
+
+      return { domains };
+    };
 
     return request()
       .get('/api/domains')
       .expect(200)
       .expect('Content-Type', /json/)
-      .expect({ domains, nextPageToken: null })
-  })
+      .expect({ domains, nextPageToken: null });
+  });
 
-  it('should describe the domain', async function () {
+  it('should describe the domain', async function() {
     const domainDesc = {
       domainInfo: {
         name: 'test-domain',
@@ -46,7 +49,7 @@ describe('Describe Domain', function() {
         description: 'ci test domain',
         ownerEmail: null,
         data: {},
-        uuid: null
+        uuid: null,
       },
       failoverVersion: 0,
       isGlobalDomain: true,
@@ -57,39 +60,40 @@ describe('Describe Domain', function() {
         historyArchivalStatus: null,
         historyArchivalURI: null,
         visibilityArchivalStatus: null,
-        visibilityArchivalURI: null
+        visibilityArchivalURI: null,
       },
       replicationConfiguration: {
         activeClusterName: 'ci-cluster',
-        clusters: null
-      }
-    }
+        clusters: null,
+      },
+    };
 
     this.test.DescribeDomain = ({ describeRequest }) => {
-      describeRequest.name.should.equal('test-domain')
-      return domainDesc
-    }
+      describeRequest.name.should.equal('test-domain');
+
+      return domainDesc;
+    };
 
     return request()
       .get('/api/domains/test-domain')
       .expect(200)
       .expect('Content-Type', /json/)
-      .expect(domainDesc)
-  })
+      .expect(domainDesc);
+  });
 
-  it('should return 404 if the domain is not found', async function () {
+  it('should return 404 if the domain is not found', async function() {
     this.test.DescribeDomain = ({ describeRequest }) => ({
       ok: false,
-      body: { message: `domain "${describeRequest.name}" does not exist`},
-      typeName: 'entityNotExistError'
-    })
+      body: { message: `domain "${describeRequest.name}" does not exist` },
+      typeName: 'entityNotExistError',
+    });
 
     return request()
       .get('/api/domains/nonexistant')
       .expect(404)
       .expect('Content-Type', /json/)
       .expect({
-        message: 'domain "nonexistant" does not exist'
-      })
-  })
-})
+        message: 'domain "nonexistant" does not exist',
+      });
+  });
+});

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -1,92 +1,104 @@
 const Long = require('long'),
-
-wfHistoryThrift = [{
-  eventId: new Long(1),
-  timestamp: new Long(800610625, 351737684, false),
-  eventType: 'WorkflowExecutionStarted',
-  workflowExecutionStartedEventAttributes: {
-    attempt: null,
-    workflowType: {
-      name: 'github.com/uber/cadence/demo'
+  wfHistoryThrift = [
+    {
+      eventId: new Long(1),
+      timestamp: new Long(800610625, 351737684, false),
+      eventType: 'WorkflowExecutionStarted',
+      workflowExecutionStartedEventAttributes: {
+        attempt: null,
+        workflowType: {
+          name: 'github.com/uber/cadence/demo',
+        },
+        taskList: {
+          name: 'ci-task-queue',
+          kind: null,
+        },
+        identity: null,
+        input: Buffer.from(
+          JSON.stringify({
+            emails: ['jane@example.com', 'bob@example.com'],
+            includeFooter: true,
+          })
+        ),
+        expirationTimestamp: null,
+        continuedExecutionRunId: null,
+        continuedFailureDetails: null,
+        continuedFailureReason: null,
+        cronSchedule: null,
+        firstDecisionTaskBackoffSeconds: null,
+        firstExecutionRunId: null,
+        header: null,
+        initiator: null,
+        lastCompletionResult: null,
+        memo: null,
+        originalExecutionRunId: null,
+        parentInitiatedEventId: null,
+        parentWorkflowDomain: null,
+        parentWorkflowExecution: null,
+        prevAutoResetPoints: null,
+        retryPolicy: null,
+        searchAttributes: null,
+        taskStartToCloseTimeoutSeconds: 30,
+        executionStartToCloseTimeoutSeconds: 1080,
+      },
     },
-    taskList: {
-      name: 'ci-task-queue',
-      kind: null
+    {
+      eventId: new Long(2),
+      timestamp: new Long(800610625, 351737684, false),
+      eventType: 'DecisionTaskScheduled',
+      decisionTaskScheduledEventAttributes: {
+        startToCloseTimeoutSeconds: 180,
+        attempt: 1,
+        taskList: {
+          name: 'canary-task-queue',
+          kind: null,
+        },
+      },
     },
-    identity: null,
-    input: Buffer.from(JSON.stringify({
-      emails: ['jane@example.com', 'bob@example.com'],
-      includeFooter: true
-    })),
-    expirationTimestamp: null,
-    continuedExecutionRunId: null,
-    continuedFailureDetails: null,
-    continuedFailureReason: null,
-    cronSchedule: null,
-    firstDecisionTaskBackoffSeconds: null,
-    firstExecutionRunId: null,
-    header: null,
-    initiator: null,
-    lastCompletionResult: null,
-    memo: null,
-    originalExecutionRunId: null,
-    parentInitiatedEventId: null,
-    parentWorkflowDomain: null,
-    parentWorkflowExecution: null,
-    prevAutoResetPoints: null,
-    retryPolicy: null,
-    searchAttributes: null,
-    taskStartToCloseTimeoutSeconds: 30,
-    executionStartToCloseTimeoutSeconds: 1080
-  }
-}, {
-  eventId: new Long(2),
-  timestamp: new Long(800610625, 351737684, false),
-  eventType: 'DecisionTaskScheduled',
-  decisionTaskScheduledEventAttributes: {
-    startToCloseTimeoutSeconds: 180,
-    attempt: 1,
-    taskList: {
-      name: 'canary-task-queue',
-      kind: null
-    }
-  }
-}, {
-  eventId: new Long(3),
-  timestamp: new Long(800610625, 351737688, false),
-  eventType: 'DecisionTaskStarted',
-  decisionTaskStartedEventAttributes: {
-    identity: 'box1@ci-task-queue',
-    requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
-    scheduledEventId: new Long(2)
-  }
-}],
-
-wfHistoryJson = [{
-  eventId: 1,
-  timestamp: '2017-11-14T23:24:10.351Z',
-  eventType: 'WorkflowExecutionStarted',
-  details: Object.assign({}, wfHistoryThrift[0].workflowExecutionStartedEventAttributes, {
-    input: {
-      emails: ['jane@example.com', 'bob@example.com'],
-      includeFooter: true
-    }
-  })
-}, {
-  eventId: 2,
-  timestamp: '2017-11-14T23:24:10.351Z',
-  eventType: 'DecisionTaskScheduled',
-  details: wfHistoryThrift[1].decisionTaskScheduledEventAttributes
-}, {
-  eventId: 3,
-  timestamp: '2017-11-14T23:24:27.531Z',
-  eventType: 'DecisionTaskStarted',
-  details: {
-    identity: 'box1@ci-task-queue',
-    requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
-    scheduledEventId: 2,
-  }
-}]
+    {
+      eventId: new Long(3),
+      timestamp: new Long(800610625, 351737688, false),
+      eventType: 'DecisionTaskStarted',
+      decisionTaskStartedEventAttributes: {
+        identity: 'box1@ci-task-queue',
+        requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
+        scheduledEventId: new Long(2),
+      },
+    },
+  ],
+  wfHistoryJson = [
+    {
+      eventId: 1,
+      timestamp: '2017-11-14T23:24:10.351Z',
+      eventType: 'WorkflowExecutionStarted',
+      details: Object.assign(
+        {},
+        wfHistoryThrift[0].workflowExecutionStartedEventAttributes,
+        {
+          input: {
+            emails: ['jane@example.com', 'bob@example.com'],
+            includeFooter: true,
+          },
+        }
+      ),
+    },
+    {
+      eventId: 2,
+      timestamp: '2017-11-14T23:24:10.351Z',
+      eventType: 'DecisionTaskScheduled',
+      details: wfHistoryThrift[1].decisionTaskScheduledEventAttributes,
+    },
+    {
+      eventId: 3,
+      timestamp: '2017-11-14T23:24:27.531Z',
+      eventType: 'DecisionTaskStarted',
+      details: {
+        identity: 'box1@ci-task-queue',
+        requestId: 'fafa095d-b4ca-423a-a812-223e62b5ccf8',
+        scheduledEventId: 2,
+      },
+    },
+  ];
 
 describe('Workflow History', function() {
   it('should forward the request to the cadence frontend with workflowId and runId', function() {
@@ -96,38 +108,40 @@ describe('Workflow History', function() {
         domain: 'canary',
         execution: {
           workflowId: 'ci/demo',
-          runId: 'run1'
+          runId: 'run1',
         },
         maximumPageSize: 100,
         nextPageToken: null,
         skipArchival: null,
-        waitForNewEvent: null
-      })
+        waitForNewEvent: null,
+      });
 
       return {
         history: { events: wfHistoryThrift },
-        nextPageToken: new Buffer('page2')
-      }
-    }
+        nextPageToken: new Buffer('page2'),
+      };
+    };
 
     return request()
       .get('/api/domains/canary/workflows/ci%2Fdemo/run1/history')
       .expect(200)
-      .expect('Content-Type', /json/)
-  })
+      .expect('Content-Type', /json/);
+  });
 
   it('should forward the nextPageToken', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
-      getRequest.nextPageToken.toString().should.equal('page2')
+      getRequest.nextPageToken.toString().should.equal('page2');
 
       return {
         history: { events: [] },
         nextPageToken: new Buffer('page3'),
-      }
-    }
+      };
+    };
 
     return request()
-      .get('/api/domains/canary/workflows/ci%2Fdemo/run1/history?nextPageToken=cGFnZTI%3D')
+      .get(
+        '/api/domains/canary/workflows/ci%2Fdemo/run1/history?nextPageToken=cGFnZTI%3D'
+      )
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
@@ -135,30 +149,36 @@ describe('Workflow History', function() {
         history: { events: [] },
         nextPageToken: 'cGFnZTM=',
         rawHistory: null,
-      })
-  })
+      });
+  });
 
   it('should support long polling by forwarding the waitForNewEvent flag', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
-      getRequest.waitForNewEvent.should.be.true
-      return { history: { events: [{ eventId: 1 }] } }
-    }
+      getRequest.waitForNewEvent.should.be.true;
+
+      return { history: { events: [{ eventId: 1 }] } };
+    };
 
     return request()
-      .get('/api/domains/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent=true')
+      .get(
+        '/api/domains/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent=true'
+      )
       .expect(200)
       .expect('Content-Type', /json/)
-      .then(() =>  request()
-        .get('/api/domains/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent')
-        .expect(200)
-      )
-  })
+      .then(() =>
+        request()
+          .get(
+            '/api/domains/canary/workflows/ci%2Fdemo/run1/history?waitForNewEvent'
+          )
+          .expect(200)
+      );
+  });
 
   it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => ({
       history: { events: wfHistoryThrift },
       nextPageToken: new Buffer('page2'),
-    })
+    });
 
     return request()
       .get('/api/domains/canary/workflows/ci%2Fdemo/run1/history')
@@ -168,44 +188,48 @@ describe('Workflow History', function() {
         history: { events: wfHistoryJson },
         nextPageToken: 'cGFnZTI=',
         rawHistory: null,
-      })
-  })
+      });
+  });
 
   describe('Export', function() {
-    const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`
+    const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`;
 
     it('should be able to export history in a format compatible with the CLI', function() {
       this.test.GetWorkflowExecutionHistory = ({ getRequest }) => ({
-        history: { events: wfHistoryThrift }
-      })
+        history: { events: wfHistoryThrift },
+      });
 
       return request()
         .get('/api/domains/canary/workflows/ci%2Fdemo/run1/export')
         .expect(200)
-        .expect(wfHistoryCliJson)
-    })
+        .expect(wfHistoryCliJson);
+    });
 
     it('should page through all responses', async function() {
-      var calls = 0
+      let calls = 0;
+
       this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
         if (calls > 0) {
-          getRequest.nextPageToken.should.be.ok
+          getRequest.nextPageToken.should.be.ok;
         } else {
-          should.not.exist(getRequest.nextPageToken)
+          should.not.exist(getRequest.nextPageToken);
         }
-        var resp = {
-          history: { events: [wfHistoryThrift[calls]] }
-        }
+
+        const resp = {
+          history: { events: [wfHistoryThrift[calls]] },
+        };
+
         if (++calls < wfHistoryThrift.length) {
-          resp.nextPageToken = new Buffer('page' + calls)
+          resp.nextPageToken = new Buffer('page' + calls);
         }
-        return resp
-      }
+
+        return resp;
+      };
 
       return request()
         .get('/api/domains/canary/workflows/ci%2Fdemo/run1/export')
         .expect(200)
-        .expect(wfHistoryCliJson)
-    })
-  })
-})
+        .expect(wfHistoryCliJson);
+    });
+  });
+});

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -50,8 +50,6 @@ describe('Query Workflow', function() {
       });
   });
 
-  it('should forward the body as the query input');
-
   it('should turn bad requests into 400s', async function() {
     this.test.QueryWorkflow = () => ({
       ok: false,

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -1,41 +1,43 @@
 describe('Query Workflow', function() {
-  it('should list workflows using a temporary hack of parsing out the available workflows from a NotFoundError', async function () {
-    this.timeout(50000)
+  it('should list workflows using a temporary hack of parsing out the available workflows from a NotFoundError', async function() {
+    this.timeout(50000);
     this.test.QueryWorkflow = ({ queryRequest }) => {
-      queryRequest.query.queryType.should.equal('__cadence_web_list')
+      queryRequest.query.queryType.should.equal('__cadence_web_list');
 
       return {
         ok: false,
-        body: { message: '__cadence_web_list not found. KnownQueryTypes=[foo bar ]' },
-        typeName: 'badRequestError'
-      }
-    }
+        body: {
+          message: '__cadence_web_list not found. KnownQueryTypes=[foo bar ]',
+        },
+        typeName: 'badRequestError',
+      };
+    };
 
     return request(global.app)
       .get('/api/domains/canary/workflows/ci%2Fdemo/run1/query')
       .expect(200)
       .expect('Content-Type', /json/)
-      .expect(['foo', 'bar'])
-  })
+      .expect(['foo', 'bar']);
+  });
 
-  it('should forward the query to the workflow', async function () {
+  it('should forward the query to the workflow', async function() {
     this.test.QueryWorkflow = ({ queryRequest }) => {
       queryRequest.should.deep.equal({
         domain: 'canary',
         execution: {
           workflowId: 'ci/demo',
-          runId: 'run1'
+          runId: 'run1',
         },
         query: {
           queryType: 'state',
-          queryArgs: null
+          queryArgs: null,
         },
         queryConsistencyLevel: null,
         queryRejectCondition: null,
-      })
+      });
 
-      return { queryResult: Buffer.from('foobar') }
-    }
+      return { queryResult: Buffer.from('foobar') };
+    };
 
     return request(global.app)
       .post('/api/domains/canary/workflows/ci%2Fdemo/run1/query/state')
@@ -44,25 +46,25 @@ describe('Query Workflow', function() {
       .expect({
         queryRejected: null,
         queryResult: 'foobar',
-        queryResult_base64: Buffer.from('foobar').toString('base64')
-      })
-  })
+        queryResult_base64: Buffer.from('foobar').toString('base64'),
+      });
+  });
 
-  it('should forward the body as the query input')
+  it('should forward the body as the query input');
 
-  it('should turn bad requests into 400s', async function () {
+  it('should turn bad requests into 400s', async function() {
     this.test.QueryWorkflow = () => ({
       ok: false,
       body: { message: 'that does not make sense' },
-      typeName: 'badRequestError'
-    })
+      typeName: 'badRequestError',
+    });
 
     return request(global.app)
       .post('/api/domains/canary/workflows/ci%2Fdemo/run1/query/state')
       .expect(400)
       .expect('Content-Type', /json/)
       .expect({
-        message: 'that does not make sense'
-      })
-  })
-})
+        message: 'that does not make sense',
+      });
+  });
+});

--- a/server/test/task-list.test.js
+++ b/server/test/task-list.test.js
@@ -1,25 +1,34 @@
 describe('Task List Pollers', function() {
   it('should aggregate decision and activity pollers together by instance', function() {
     this.test.DescribeTaskList = ({ request }) => {
-      request.domain.should.equal('canary')
-      request.taskList.name.should.equal('demo-task-list')
+      request.domain.should.equal('canary');
+      request.taskList.name.should.equal('demo-task-list');
 
       return {
-        pollers: request.taskListType === 'Activity' ? [{
-          identity: '100@node1@demo-task-list',
-          lastAccessTime: dateToLong('2018-03-22T20:21:40.000Z')
-        }, {
-          identity: '102@node3@demo-task-list',
-          lastAccessTime: dateToLong('2018-03-22T20:21:32.000Z')
-        }] : [{
-          identity: '100@node1@demo-task-list',
-          lastAccessTime: dateToLong('2018-03-22T20:20:40.000Z')
-        }, {
-          identity: '101@node2@demo-task-list',
-          lastAccessTime: dateToLong('2018-03-22T20:22:05.000Z')
-        }]
-      }
-    }
+        pollers:
+          request.taskListType === 'Activity'
+            ? [
+                {
+                  identity: '100@node1@demo-task-list',
+                  lastAccessTime: dateToLong('2018-03-22T20:21:40.000Z'),
+                },
+                {
+                  identity: '102@node3@demo-task-list',
+                  lastAccessTime: dateToLong('2018-03-22T20:21:32.000Z'),
+                },
+              ]
+            : [
+                {
+                  identity: '100@node1@demo-task-list',
+                  lastAccessTime: dateToLong('2018-03-22T20:20:40.000Z'),
+                },
+                {
+                  identity: '101@node2@demo-task-list',
+                  lastAccessTime: dateToLong('2018-03-22T20:22:05.000Z'),
+                },
+              ],
+      };
+    };
 
     return request()
       .get('/api/domains/canary/task-lists/demo-task-list/pollers')
@@ -28,16 +37,16 @@ describe('Task List Pollers', function() {
       .expect({
         '100@node1@demo-task-list': {
           lastAccessTime: '2018-03-22T20:21:40.000Z',
-          taskListTypes: ['decision', 'activity']
+          taskListTypes: ['decision', 'activity'],
         },
         '101@node2@demo-task-list': {
           lastAccessTime: '2018-03-22T20:22:05.000Z',
-          taskListTypes: ['decision']
+          taskListTypes: ['decision'],
         },
         '102@node3@demo-task-list': {
           lastAccessTime: '2018-03-22T20:21:32.000Z',
-          taskListTypes: ['activity']
+          taskListTypes: ['activity'],
         },
-      })
-  })
-})
+      });
+  });
+});

--- a/server/test/workflow-execution.test.js
+++ b/server/test/workflow-execution.test.js
@@ -1,13 +1,13 @@
 describe('Workflow Execution', function() {
-  it('should describe the workflow', async function () {
+  it('should describe the workflow', async function() {
     this.test.DescribeWorkflowExecution = ({ describeRequest }) => {
       return {
         executionConfiguration: {
           taskList: { name: 'ci-task-list' },
-          taskStartToCloseTimeoutSeconds: 10
-        }
-      }
-    }
+          taskStartToCloseTimeoutSeconds: 10,
+        },
+      };
+    };
 
     return request()
       .get('/api/domains/canary/workflows/ci%2Fdemo/run1')
@@ -17,45 +17,49 @@ describe('Workflow Execution', function() {
         executionConfiguration: {
           taskList: {
             name: 'ci-task-list',
-            kind: null
+            kind: null,
           },
           taskStartToCloseTimeoutSeconds: 10,
-          executionStartToCloseTimeoutSeconds: null
+          executionStartToCloseTimeoutSeconds: null,
         },
         workflowExecutionInfo: null,
         pendingChildren: null,
-        pendingActivities: null
-      })
-  })
+        pendingActivities: null,
+      });
+  });
 
   it('should terminate a workflow', async function() {
-    let reason
+    let reason;
+
     this.test.TerminateWorkflowExecution = ({ terminateRequest }) => {
-      terminateRequest.workflowExecution.workflowId.should.equal('ci/demo')
-      terminateRequest.workflowExecution.runId.should.equal('run1')
-      reason = terminateRequest.reason
-      return {}
-    }
+      terminateRequest.workflowExecution.workflowId.should.equal('ci/demo');
+      terminateRequest.workflowExecution.runId.should.equal('run1');
+      reason = terminateRequest.reason;
+
+      return {};
+    };
 
     return request()
       .post('/api/domains/canary/workflows/ci%2Fdemo/run1/terminate')
       .send({ reason: 'example reason' })
       .expect(204)
-      .expect(() => reason.should.equal('example reason'))
-  })
+      .expect(() => reason.should.equal('example reason'));
+  });
 
   it('should signal a workflow without input', async function() {
-    let signal
+    let signal;
+
     this.test.SignalWorkflowExecution = ({ signalRequest }) => {
-      signalRequest.workflowExecution.workflowId.should.equal('ci/demo')
-      signalRequest.workflowExecution.runId.should.equal('run2')
-      signal = signalRequest.signalName
-      return {}
-    }
+      signalRequest.workflowExecution.workflowId.should.equal('ci/demo');
+      signalRequest.workflowExecution.runId.should.equal('run2');
+      signal = signalRequest.signalName;
+
+      return {};
+    };
 
     return request()
       .post('/api/domains/canary/workflows/ci%2Fdemo/run2/signal/firealarm')
       .expect(204)
-      .expect(() => signal.should.equal('firealarm'))
-  })
-})
+      .expect(() => signal.should.equal('firealarm'));
+  });
+});

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -1,106 +1,128 @@
 describe('Listing Workflows', function() {
   const demoExecThrift = {
-    execution: {
-      workflowId: 'demo',
-      runId: 'd92bb92c-5f49-487f-80a8-f8f375ba55a8'
+      execution: {
+        workflowId: 'demo',
+        runId: 'd92bb92c-5f49-487f-80a8-f8f375ba55a8',
+      },
+      type: {
+        name: 'github.com/uber/cadence/demo.cronWorkflow',
+      },
+      startTime: dateToLong('2017-11-10T21:30:00.000Z'),
+      closeTime: null,
+      closeStatus: null,
+      historyLength: null,
+      autoResetPoints: null,
+      executionTime: null,
+      memo: null,
+      parentDomainId: null,
+      parentExecution: null,
+      searchAttributes: null,
     },
-    type: {
-      name: 'github.com/uber/cadence/demo.cronWorkflow'
-    },
-    startTime: dateToLong('2017-11-10T21:30:00.000Z'),
-    closeTime: null,
-    closeStatus: null,
-    historyLength: null,
-    autoResetPoints: null,
-    executionTime: null,
-    memo: null,
-    parentDomainId: null,
-    parentExecution: null,
-    searchAttributes: null
-  },
-  demoExecJson = Object.assign({}, demoExecThrift, {
-    startTime: '2017-11-10T21:30:00.000Z',
-    taskList: null,
-  })
+    demoExecJson = Object.assign({}, demoExecThrift, {
+      startTime: '2017-11-10T21:30:00.000Z',
+      taskList: null,
+    });
 
   it('should list open workflows', function() {
     this.test.ListOpenWorkflowExecutions = ({ listRequest }) => {
-      listRequest.domain.should.equal('canary')
-      listRequest.StartTimeFilter.earliestTime.div(1000000000).toNumber().should.equal(1510488000)
-      listRequest.StartTimeFilter.latestTime.div(1000000000).toNumber().should.equal(1510583400)
-      should.not.exist(listRequest.executionFilter)
-      should.not.exist(listRequest.typeFilter)
+      listRequest.domain.should.equal('canary');
+      listRequest.StartTimeFilter.earliestTime
+        .div(1000000000)
+        .toNumber()
+        .should.equal(1510488000);
+      listRequest.StartTimeFilter.latestTime
+        .div(1000000000)
+        .toNumber()
+        .should.equal(1510583400);
+      should.not.exist(listRequest.executionFilter);
+      should.not.exist(listRequest.typeFilter);
+
       return {
         executions: [demoExecThrift],
-        nextPageToken: new Buffer('{"IsWorkflowRunning":true,NextEventId:37}')
-      }
-    }
+        nextPageToken: new Buffer('{"IsWorkflowRunning":true,NextEventId:37}'),
+      };
+    };
 
     return request()
-      .get('/api/domains/canary/workflows/open?startTime=2017-11-12T12:00:00Z&endTime=2017-11-13T14:30:00Z')
+      .get(
+        '/api/domains/canary/workflows/open?startTime=2017-11-12T12:00:00Z&endTime=2017-11-13T14:30:00Z'
+      )
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
         executions: [demoExecJson],
-        nextPageToken: 'eyJJc1dvcmtmbG93UnVubmluZyI6dHJ1ZSxOZXh0RXZlbnRJZDozN30='
-      })
-  })
+        nextPageToken:
+          'eyJJc1dvcmtmbG93UnVubmluZyI6dHJ1ZSxOZXh0RXZlbnRJZDozN30=',
+      });
+  });
 
   it('should list closed workflows', function() {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
-      listRequest.domain.should.equal('canary')
-      listRequest.StartTimeFilter.earliestTime.div(1000000000).toNumber().should.equal(1510488000)
-      listRequest.StartTimeFilter.latestTime.div(1000000000).toNumber().should.equal(1510583400)
-      should.not.exist(listRequest.executionFilter)
-      should.not.exist(listRequest.typeFilter)
+      listRequest.domain.should.equal('canary');
+      listRequest.StartTimeFilter.earliestTime
+        .div(1000000000)
+        .toNumber()
+        .should.equal(1510488000);
+      listRequest.StartTimeFilter.latestTime
+        .div(1000000000)
+        .toNumber()
+        .should.equal(1510583400);
+      should.not.exist(listRequest.executionFilter);
+      should.not.exist(listRequest.typeFilter);
+
       return {
         executions: [demoExecThrift],
-        nextPageToken: new Buffer('{"IsWorkflowRunning":false}')
-      }
-    }
+        nextPageToken: new Buffer('{"IsWorkflowRunning":false}'),
+      };
+    };
 
     return request()
-      .get('/api/domains/canary/workflows/closed?startTime=2017-11-12T12:00:00Z&endTime=2017-11-13T14:30:00Z')
+      .get(
+        '/api/domains/canary/workflows/closed?startTime=2017-11-12T12:00:00Z&endTime=2017-11-13T14:30:00Z'
+      )
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
         executions: [demoExecJson],
-        nextPageToken: 'eyJJc1dvcmtmbG93UnVubmluZyI6ZmFsc2V9'
-      })
-  })
+        nextPageToken: 'eyJJc1dvcmtmbG93UnVubmluZyI6ZmFsc2V9',
+      });
+  });
 
   it('should forward the next page token along', function() {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
-      listRequest.nextPageToken.toString().should.equal('page1')
+      listRequest.nextPageToken.toString().should.equal('page1');
+
       return {
         executions: [],
-        nextPageToken: new Buffer('page2')
-      }
-    }
+        nextPageToken: new Buffer('page2'),
+      };
+    };
 
     return request()
-      .get('/api/domains/canary/workflows/closed?startTime=2017-11-01&endTime=2017-11-13T22:27:17.551Z&nextPageToken=cGFnZTE=')
+      .get(
+        '/api/domains/canary/workflows/closed?startTime=2017-11-01&endTime=2017-11-13T22:27:17.551Z&nextPageToken=cGFnZTE='
+      )
       .expect(200)
       .expect('Content-Type', /json/)
       .expect({
         executions: [],
-        nextPageToken: 'cGFnZTI='
-      })
-  })
+        nextPageToken: 'cGFnZTI=',
+      });
+  });
 
   it('should return 404 if another state of workflows is queried', function() {
     return request()
       .get('/api/domains/canary/workflows/failed')
-      .expect(404)
-  })
+      .expect(404);
+  });
 
   it('should return 400 if startTime or endTime are missing', async function() {
     await request()
       .get('/api/domains/canary/workflows/open?startTime=2017-11-01')
-      .expect(400)
+      .expect(400);
 
     return request()
       .get('/api/domains/canary/workflows/closed?endTime=2017-11-01')
-      .expect(400)
-  })
-})
+      .expect(400);
+  });
+});


### PR DESCRIPTION
Currently lint rules is only enforced on the client folder in cadence-web. This PR is to add the server folder to the lint rules and submit all lint auto-fixes. No manual lint fixes are here as they have been completed in #225.