### PR TITLE
Fix/manual server lint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,7 @@
-const
+const path = require('path'),
   Koa = require('koa'),
   bodyparser = require('koa-bodyparser'),
   send = require('koa-send'),
-  path = require('path'),
   staticRoot = path.join(__dirname, '../dist'),
   app = new Koa(),
   router = require('./routes')
@@ -13,10 +12,15 @@ app.init = function(options) {
   options = options || {}
 
   const useWebpack = 'useWebpack' in options ? options.useWebpack : process.env.NODE_ENV !== 'production'
+
+  let koaWebpack;
+  let compiler;
+
   if (useWebpack) {
-    var Webpack = require('webpack'),
-        koaWebpack = require('koa-webpack'),
-        compiler = Webpack(app.webpackConfig)
+    const Webpack = require('webpack');
+
+    koaWebpack = require('koa-webpack');
+    compiler = Webpack(app.webpackConfig);
   }
 
   app.use(async (ctx, next) => {
@@ -56,7 +60,7 @@ app.init = function(options) {
           ctx.set('content-type', 'text/html')
           ctx.body = compiler.outputFileSystem.readFileSync(filename)
         } else {
-          done = await send(ctx, 'index.html', { root: staticRoot })
+          await send(ctx, 'index.html', { root: staticRoot })
         }
       } catch (err) {
         if (err.status !== 404) {

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const
+const path = require('path'),
+  dns = require('dns'),
   TChannelAsThrift = require('tchannel/as/thrift'),
   TChannel = require('tchannel'),
-  path = require('path'),
   Long = require('long'),
   losslessJSON = require('lossless-json'),
   moment = require('moment'),
-  dns = require('dns'),
   isIPv4 = require('is-ipv4-node');
 
 function uiTransform(item) {

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -1,9 +1,8 @@
-const
+const path = require('path'),
   supertest = require('supertest'),
   TChannel = require('tchannel'),
   TChannelAsThrift = require('tchannel/as/thrift'),
-  Long = require('long'),
-  path = require('path')
+  Long = require('long');
 
 var tchanServer, currTest, client, app
 
@@ -28,13 +27,13 @@ before(function(done) {
       throw new Error(`unexpected request to ${req.endpoint}`)
     }
 
-    var body = currTest[mockName](body, req)
-    if (body instanceof Error) {
-      cb(body)
-    } else if (body && body.ok === false) {
-      cb(null, body)
+    const bodyMock = currTest[mockName](body, req)
+    if (bodyMock instanceof Error) {
+      cb(bodyMock)
+    } else if (bodyMock && bodyMock.ok === false) {
+      cb(null, bodyMock)
     } else {
-      cb(null, { ok: true, head, body })
+      cb(null, { ok: true, head, body: bodyMock })
     }
   }
 

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -48,8 +48,6 @@ describe('Query Workflow', function() {
       })
   })
 
-  it('should forward the body as the query input')
-
   it('should turn bad requests into 400s', async function () {
     this.test.QueryWorkflow = () => ({
       ok: false,


### PR DESCRIPTION
Before introducing lint to server folder, I have fixed lint issues which the lint auto-fixer cannot fix by itself. Once this PR has been merged, I will turn on lint to parse server folder and create a PR with all lint auto-fixes which is much safer to sign off (if done all automatically).

Once server folder is linted, we can then inject license headers for all node server src files.
