### PR TITLE
Fixing link to docs

### DIFF
--- a/client/routes/help/index.vue
+++ b/client/routes/help/index.vue
@@ -75,7 +75,7 @@ export default {
       <slot name="getting-started" />
       <div v-if="!hideDocs">
         <a
-          href="https://cadenceworkflow.io/docs"
+          href="https://cadenceworkflow.io/docs/cadence"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Since the move of the docs into a separate repository one of the links which referenced it has broken. This is a change to fix the path to make the docs link work again.

## Screenshots
**Before**
<img width="676" alt="Screen Shot 2020-12-02 at 9 49 16 AM" src="https://user-images.githubusercontent.com/58960161/100911813-8e244080-3484-11eb-85c9-e24acaf78d9d.png">

**After**
<img width="1252" alt="Screen Shot 2020-12-02 at 9 49 25 AM" src="https://user-images.githubusercontent.com/58960161/100911839-95e3e500-3484-11eb-9427-aa8004c8ecc8.png">
