### PR TITLE
Fixed license headers to use 2021 for end date

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
            * // Copyright (c) 2020 Uber Technologies Inc.
            *
            * 2. multi-year span
-           * // Copyright (c) 2017-2020 Uber Technologies Inc.
+           * // Copyright (c) 2017-2021 Uber Technologies Inc.
            *
            * 3. new file from another company referenced
            * // Modifications Copyright (c) 2020 Uber Technologies Inc.
@@ -46,7 +46,7 @@ module.exports = {
            *
            *       In this case it will change header:
            *         from:
-           *           Copyright (c) 2017-2020 Uber Technologies Inc.
+           *           Copyright (c) 2017-2021 Uber Technologies Inc.
            *           Copyright (c) 2020 Uber Technologies Inc.
            *         to:
            *           Copyright (c) 2021 Uber Technologies Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/App.vue
+++ b/client/App.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/bar-loader.vue
+++ b/client/components/bar-loader.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/button-fill.vue
+++ b/client/components/button-fill.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/button-icon.vue
+++ b/client/components/button-icon.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/copy.vue
+++ b/client/components/copy.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/data-viewer.vue
+++ b/client/components/data-viewer.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/constants.js
+++ b/client/components/date-range-picker/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/helpers.spec.js
+++ b/client/components/date-range-picker/helpers.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/index.vue
+++ b/client/components/date-range-picker/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/domain-navigation.vue
+++ b/client/components/domain-navigation.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/error-message.vue
+++ b/client/components/error-message.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/feature-flag.vue
+++ b/client/components/feature-flag.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/flex-grid-item.vue
+++ b/client/components/flex-grid-item.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/flex-grid.vue
+++ b/client/components/flex-grid.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/highlight-toggle.vue
+++ b/client/components/highlight-toggle.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/loading-message.vue
+++ b/client/components/loading-message.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/loading-spinner.vue
+++ b/client/components/loading-spinner.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/navigation-bar.vue
+++ b/client/components/navigation-bar.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/navigation-link.vue
+++ b/client/components/navigation-link.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/news-modal.vue
+++ b/client/components/news-modal.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/no-results.vue
+++ b/client/components/no-results.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/notification-bar.vue
+++ b/client/components/notification-bar.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/paged-grid.js
+++ b/client/components/paged-grid.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-date-format.vue
+++ b/client/components/settings-modal/components/settings-date-format.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-footer.vue
+++ b/client/components/settings-modal/components/settings-footer.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-header.vue
+++ b/client/components/settings-modal/components/settings-header.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-list.vue
+++ b/client/components/settings-modal/components/settings-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-toggle.vue
+++ b/client/components/settings-modal/components/settings-toggle.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/components/settings-workflow-history.vue
+++ b/client/components/settings-modal/components/settings-workflow-history.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/constants.js
+++ b/client/components/settings-modal/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-modal/index.vue
+++ b/client/components/settings-modal/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/text-input.vue
+++ b/client/components/text-input.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/constants.js
+++ b/client/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/directives/snapscroll.js
+++ b/client/directives/snapscroll.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/__mocks__/index.js
+++ b/client/helpers/__mocks__/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-datetime-formatted-string.js
+++ b/client/helpers/get-datetime-formatted-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-datetime-formatted-string.spec.js
+++ b/client/helpers/get-datetime-formatted-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-end-time-iso-string.js
+++ b/client/helpers/get-end-time-iso-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-end-time-iso-string.spec.js
+++ b/client/helpers/get-end-time-iso-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-list.js
+++ b/client/helpers/get-environment-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-list.spec.js
+++ b/client/helpers/get-environment-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-location.js
+++ b/client/helpers/get-environment-location.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-location.spec.js
+++ b/client/helpers/get-environment-location.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment.js
+++ b/client/helpers/get-environment.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment.spec.js
+++ b/client/helpers/get-environment.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-error-message.js
+++ b/client/helpers/get-error-message.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-error-message.spec.js
+++ b/client/helpers/get-error-message.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-escaped-forward-slash.js
+++ b/client/helpers/get-escaped-forward-slash.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-escaped-forward-slash.spec.js
+++ b/client/helpers/get-escaped-forward-slash.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-latest-news-items.js
+++ b/client/helpers/get-latest-news-items.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-latest-news-items.spec.js
+++ b/client/helpers/get-latest-news-items.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-query-string-from-object.js
+++ b/client/helpers/get-query-string-from-object.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-query-string-from-object.spec.js
+++ b/client/helpers/get-query-string-from-object.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-start-time-iso-string.js
+++ b/client/helpers/get-start-time-iso-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-start-time-iso-string.spec.js
+++ b/client/helpers/get-start-time-iso-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/http.js
+++ b/client/helpers/http.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/inject-moment-duration-format.js
+++ b/client/helpers/inject-moment-duration-format.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/json-try-parse.js
+++ b/client/helpers/json-try-parse.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/map-domain-description.js
+++ b/client/helpers/map-domain-description.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/map-domain-description.spec.js
+++ b/client/helpers/map-domain-description.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/parse-string-to-boolean.js
+++ b/client/helpers/parse-string-to-boolean.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/parse-string-to-boolean.spec.js
+++ b/client/helpers/parse-string-to-boolean.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/short-name.js
+++ b/client/helpers/short-name.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-add-or-update.js
+++ b/client/helpers/workflow-history-event-highlight-list-add-or-update.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-add-or-update.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-add-or-update.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-find-index-by-id.js
+++ b/client/helpers/workflow-history-event-highlight-list-find-index-by-id.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-find-index-by-id.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-find-index-by-id.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-remove.js
+++ b/client/helpers/workflow-history-event-highlight-list-remove.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-remove.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-remove.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain-list.vue
+++ b/client/routes/domain-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-metrics.vue
+++ b/client/routes/domain/domain-metrics.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-service.js
+++ b/client/routes/domain/domain-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-settings.vue
+++ b/client/routes/domain/domain-settings.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/index.vue
+++ b/client/routes/domain/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/advanced.vue
+++ b/client/routes/domain/workflow-archival/advanced.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/basic.vue
+++ b/client/routes/domain/workflow-archival/basic.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-disabled-messaging/constants.js
+++ b/client/routes/domain/workflow-archival/components/archival-disabled-messaging/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
+++ b/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-table-row.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table-row.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-table.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/index.js
+++ b/client/routes/domain/workflow-archival/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/constants.js
+++ b/client/routes/domain/workflow-archival/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-domain.js
+++ b/client/routes/domain/workflow-archival/helpers/get-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-domain.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-domain.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-history-archival-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-history-archival-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-history-archival-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-history-archival-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-query-params.js
+++ b/client/routes/domain/workflow-archival/helpers/get-query-params.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-query-params.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-query-params.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-range.js
+++ b/client/routes/domain/workflow-archival/helpers/get-range.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-range.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-range.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status-value.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status-value.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status-value.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status-value.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/index.js
+++ b/client/routes/domain/workflow-archival/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.js
+++ b/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/replace-domain.js
+++ b/client/routes/domain/workflow-archival/helpers/replace-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/replace-domain.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/replace-domain.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/update-query-from-range.js
+++ b/client/routes/domain/workflow-archival/helpers/update-query-from-range.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/update-query-from-range.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/update-query-from-range.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/index.vue
+++ b/client/routes/domain/workflow-archival/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/workflow-archival-service.js
+++ b/client/routes/domain/workflow-archival/workflow-archival-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/workflow-archival-service.spec.js
+++ b/client/routes/domain/workflow-archival/workflow-archival-service.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/help/constants.js
+++ b/client/routes/help/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/help/index.vue
+++ b/client/routes/help/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/index.vue
+++ b/client/routes/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-iframe-src.js
+++ b/client/routes/news/helpers/get-iframe-src.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-iframe-src.spec.js
+++ b/client/routes/news/helpers/get-iframe-src.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-updated-iframe-location.js
+++ b/client/routes/news/helpers/get-updated-iframe-location.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-updated-iframe-location.spec.js
+++ b/client/routes/news/helpers/get-updated-iframe-location.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/index.js
+++ b/client/routes/news/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/index.vue
+++ b/client/routes/news/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/components/partition-table.vue
+++ b/client/routes/task-list/components/partition-table.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/index.vue
+++ b/client/routes/task-list/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/metrics.vue
+++ b/client/routes/task-list/metrics.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/partition.vue
+++ b/client/routes/task-list/partition.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/pollers.vue
+++ b/client/routes/task-list/pollers.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/components/event-detail.vue
+++ b/client/routes/workflow/components/event-detail.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/components/timeline.vue
+++ b/client/routes/workflow/components/timeline.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/constants.js
+++ b/client/routes/workflow/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/event-full-transforms.js
+++ b/client/routes/workflow/helpers/event-full-transforms.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/event-full-transforms.spec.js
+++ b/client/routes/workflow/helpers/event-full-transforms.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-details.js
+++ b/client/routes/workflow/helpers/get-event-details.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-details.spec.js
+++ b/client/routes/workflow/helpers/get-event-details.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-full-details.js
+++ b/client/routes/workflow/helpers/get-event-full-details.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-full-details.spec.js
+++ b/client/routes/workflow/helpers/get-event-full-details.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-kvps-highlight.js
+++ b/client/routes/workflow/helpers/get-event-kvps-highlight.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-kvps-highlight.spec.js
+++ b/client/routes/workflow/helpers/get-event-kvps-highlight.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-summary.js
+++ b/client/routes/workflow/helpers/get-event-summary.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-event-summary.spec.js
+++ b/client/routes/workflow/helpers/get-event-summary.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-history-events.js
+++ b/client/routes/workflow/helpers/get-history-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-history-timeline-events.js
+++ b/client/routes/workflow/helpers/get-history-timeline-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-summary-workflow-status.js
+++ b/client/routes/workflow/helpers/get-summary-workflow-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-summary-workflow-status.spec.js
+++ b/client/routes/workflow/helpers/get-summary-workflow-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-summary.js
+++ b/client/routes/workflow/helpers/get-summary.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-time-elapsed-display.js
+++ b/client/routes/workflow/helpers/get-time-elapsed-display.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-time-elapsed-display.spec.js
+++ b/client/routes/workflow/helpers/get-time-elapsed-display.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-time-stamp-display.js
+++ b/client/routes/workflow/helpers/get-time-stamp-display.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-time-stamp-display.spec.js
+++ b/client/routes/workflow/helpers/get-time-stamp-display.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/index.js
+++ b/client/routes/workflow/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/map-timeline-events.js
+++ b/client/routes/workflow/helpers/map-timeline-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/parent-workflow-link.js
+++ b/client/routes/workflow/helpers/parent-workflow-link.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/parent-workflow-link.spec.js
+++ b/client/routes/workflow/helpers/parent-workflow-link.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/summarize-events.js
+++ b/client/routes/workflow/helpers/summarize-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/workflow-link.js
+++ b/client/routes/workflow/helpers/workflow-link.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/services/feature-flag-service.js
+++ b/client/services/feature-flag-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/services/index.js
+++ b/client/services/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/domain-list.test.js
+++ b/client/test/domain-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/domain-settings.test.js
+++ b/client/test/domain-settings.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/help.test.js
+++ b/client/test/help.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/index.js
+++ b/client/test/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/LICENSE_FILE_DOES_NOT_EXIST
+++ b/client/test/lint/license/LICENSE_FILE_DOES_NOT_EXIST
@@ -1,5 +1,5 @@
-Modifications Copyright (c) 2020 Uber Technologies Inc.
-Copyright (c) 2020 Temporal Technologies, Inc.
+Modifications Copyright (c) 2021 Uber Technologies Inc.
+Copyright (c) 2021 Temporal Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/client/test/lint/license/LICENSE_FILE_MODIFIED
+++ b/client/test/lint/license/LICENSE_FILE_MODIFIED
@@ -1,5 +1,5 @@
-Copyright (c) 2017-2020 Uber Technologies Inc.
-Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+Copyright (c) 2017-2021 Uber Technologies Inc.
+Portions of the Software are attributed to Copyright (c) 2021 Temporal Technologies Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/client/test/lint/license/LICENSE_FILE_NEW
+++ b/client/test/lint/license/LICENSE_FILE_NEW
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Uber Technologies Inc.
+Copyright (c) 2021 Uber Technologies Inc.
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/LICENSE_FILE_UNMODIFIED
+++ b/client/test/lint/license/LICENSE_FILE_UNMODIFIED
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2020 Uber Technologies Inc.
+Copyright (c) 2017-2021 Uber Technologies Inc.
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-does-not-exist.vue
+++ b/client/test/lint/license/test-license-file-does-not-exist.vue
@@ -1,6 +1,6 @@
 <script>
-// Modifications Copyright (c) 2020 Uber Technologies Inc.
-// Copyright (c) 2020 Temporal Technologies, Inc.
+// Modifications Copyright (c) 2021 Uber Technologies Inc.
+// Copyright (c) 2021 Temporal Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/client/test/lint/license/test-license-file-modified.vue
+++ b/client/test/lint/license/test-license-file-modified.vue
@@ -1,6 +1,6 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2021 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/client/test/lint/license/test-license-file-new.vue
+++ b/client/test/lint/license/test-license-file-new.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2020 Uber Technologies Inc.
+// Copyright (c) 2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-unmodified.vue
+++ b/client/test/lint/license/test-license-file-unmodified.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/task-list.test.js
+++ b/client/test/task-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/task-list.test.js
+++ b/server/test/task-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/workflow-execution.test.js
+++ b/server/test/workflow-execution.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Copyright (c) 2017-2021 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Since the new year, any new code changes will automatically fail the build. 
This is because the license linter will check against the current year in the header. If this doesn't match, it will fail lint.
To fix this I have updated the date in license headers for each file so that linter can now pass successfully. 