### PR TITLE
Fix/duplicate hidden rows

### DIFF
--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -65,7 +65,7 @@ export default {
     <div class="spacer" />
     <no-results :results="workflows" v-if="!loading" />
     <RecycleScroller
-      key-field="runId"
+      key-field="uniqueId"
       :items="workflows"
       :item-size="56"
       emit-update

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -96,6 +96,7 @@ export default {
       return results.map(result => ({
         workflowId: result.execution.workflowId,
         runId: result.execution.runId,
+        uniqueId: `${result.execution.runId}-${result.closeStatus || 'OPEN'}`,
         workflowName: result.type.name,
         startTime: getDatetimeFormattedString({
           date: result.startTime,


### PR DESCRIPTION
Encountered a bug while testing where an open workflow becomes closed while fetching the closed workflows. This results in an empty row being rendered (see screenshots). The fix is to use a unique id which is unique to both open and closed workflows, even if the workflow has the same run id. This will ensure that both will render correctly.

## Screenshots
**After fix (1st and 3rd row ID duplicated):**
<img width="1680" alt="Screen Shot 2021-02-01 at 12 24 41 PM" src="https://user-images.githubusercontent.com/58960161/106514586-496b5480-6489-11eb-96d6-b35bc1e92685.png">

**Before fix (1st and 3rd row ID duplicated - 1st row hidden because of unique ID conflict):**
<img width="1680" alt="Screen Shot 2021-02-01 at 12 04 40 PM" src="https://user-images.githubusercontent.com/58960161/106514532-36588480-6489-11eb-9bcf-660d5dbd3722.png">