### PR TITLE
fix/infinite fetching open workflows

### DIFF
--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -214,7 +214,7 @@ export default {
       let workflows = [];
       let nextPageToken = '';
 
-      if (queryWithStatus.nextPageToken === '') {
+      if ([null, ''].includes(queryWithStatus.nextPageToken)) {
         return { workflows, nextPageToken };
       }
 


### PR DESCRIPTION
While testing v3.22.0 release in staging environment, found a bug where scrolling a list of open & closed workflows would continue to request open workflows even when there are no more to fetch. This is because of a recent change to Cadence server which now returns nextPageToken as null (instead of empty string). This now invalidates the check of empty string to stop pagination from fetching more data. I have included both in the check now to preserve backwards compatibility for the OS community.

## Screenshots
**After fix:**
<img width="1338" alt="Screen Shot 2021-02-01 at 3 39 24 PM" src="https://user-images.githubusercontent.com/58960161/106531839-dae7c000-64a3-11eb-8666-b4c7fdbd78fa.png">

**Before fix:**
<img width="1339" alt="Screen Shot 2021-02-01 at 3 40 34 PM" src="https://user-images.githubusercontent.com/58960161/106531855-e63aeb80-64a3-11eb-8bc6-9ce45b102fe4.png">