### PR TITLE
Fix/summary display workflow id

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -158,6 +158,7 @@ const routeOpts = {
       path: '/domains/:domain/workflows/:workflowId/:runId',
       component: WorkflowTabs,
       props: ({ params }) => ({
+        displayWorkflowId: params.workflowId,
         domain: params.domain,
         runId: params.runId,
         workflowId: encodeURIComponent(params.workflowId),

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -61,6 +61,7 @@ export default {
   },
   props: [
     'dateFormat',
+    'displayWorkflowId',
     'domain',
     'runId',
     'timeFormat',
@@ -353,6 +354,7 @@ export default {
       name="summary"
       :baseAPIURL="baseAPIURL"
       :date-format="dateFormat"
+      :display-workflow-id="displayWorkflowId"
       :domain="domain"
       :input="summary.input"
       :isWorkflowRunning="summary.isWorkflowRunning"

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -37,6 +37,7 @@ export default {
   props: [
     'baseAPIURL',
     'dateFormat',
+    'displayWorkflowId',
     'domain',
     'input',
     'isWorkflowRunning',
@@ -47,7 +48,6 @@ export default {
     'timezone',
     'wfStatus',
     'workflow',
-    'workflowId',
   ],
   components: {
     'bar-loader': BarLoader,
@@ -231,12 +231,12 @@ export default {
       <div class="workflow-result" v-if="result">
         <dt>Result</dt>
         <dd>
-          <data-viewer :item="result" :title="workflowId + ' Result'" />
+          <data-viewer :item="result" :title="displayWorkflowId + ' Result'" />
         </dd>
       </div>
       <div class="workflow-id">
         <dt>Workflow Id</dt>
-        <dd>{{ workflowId }}</dd>
+        <dd>{{ displayWorkflowId }}</dd>
       </div>
       <div class="run-id">
         <dt>Run Id</dt>
@@ -275,7 +275,7 @@ export default {
           <data-viewer
             v-if="input !== undefined"
             :item="input"
-            :title="workflowId + ' Input'"
+            :title="displayWorkflowId + ' Input'"
           />
         </dd>
       </div>


### PR DESCRIPTION
- Added `displayWorkflowId` to distinguish between encoded id (workflowId) and display id (displayWorkflowId).

## Screenshots
### After
<img width="1680" alt="Screen Shot 2021-02-22 at 12 28 06 PM" src="https://user-images.githubusercontent.com/58960161/108766787-6fc16480-750a-11eb-9705-08ac817fa3e6.png">

### Before
<img width="1677" alt="Screen Shot 2021-02-22 at 12 20 22 PM" src="https://user-images.githubusercontent.com/58960161/108766775-6cc67400-750a-11eb-9d63-3458a8e35cfa.png">
