### PR TITLE
Fix/workflow advanced query

### DIFF
--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -290,7 +290,7 @@ export default {
 
       let workflows = [];
 
-      if (this.state !== 'all') {
+      if (this.state !== 'all' || this.criteria.queryString) {
         const query = { ...this.criteria, nextPageToken: this.npt };
 
         if (query.queryString) {

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -52,7 +52,7 @@ export default {
         { value: 'TIMED_OUT', label: 'Timed Out' },
       ],
       maxRetentionDays: undefined,
-      filterMode: 'basic',
+      filterMode: this.$route.query && this.$route.query.queryString ? 'advanced' : 'basic',
     };
   },
   async created() {

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -51,7 +51,10 @@ export default {
         { value: 'TIMED_OUT', label: 'Timed Out' },
       ],
       maxRetentionDays: undefined,
-      filterMode: this.$route.query && this.$route.query.queryString ? 'advanced' : 'basic',
+      filterMode:
+        this.$route.query && this.$route.query.queryString
+          ? 'advanced'
+          : 'basic',
     };
   },
   async created() {
@@ -285,6 +288,7 @@ export default {
 
       if (this.filterMode === 'advanced' && !this.criteria.queryString) {
         this.clearState();
+
         return;
       }
 
@@ -356,10 +360,7 @@ export default {
     setWorkflowFilter(e) {
       const target = e.target || e.testTarget; // test hook since Event.target is readOnly and unsettable
 
-      this.$router.replaceQueryParam(
-        target.getAttribute('name'),
-        target.value
-      );
+      this.$router.replaceQueryParam(target.getAttribute('name'), target.value);
     },
     setStatus(status) {
       if (status) {
@@ -444,8 +445,10 @@ export default {
     },
     toggleFilter() {
       this.clearState();
+
       if (this.filterMode === 'advanced') {
         this.filterMode = 'basic';
+
         if (this.$route.query.queryString) {
           this.$router.replace({
             query: omit(this.$route.query, 'queryString'),

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -22,6 +22,7 @@
 
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
+import omit from 'lodash-es/omit';
 import { DateRangePicker, WorkflowGrid } from '~components';
 import {
   getDatetimeFormattedString,
@@ -430,7 +431,9 @@ export default {
     toggleFilter() {
       if (this.filterMode === 'advanced') {
         this.filterMode = 'basic';
-        this.$route.query.queryString = '';
+        this.$router.replace({
+          query: omit(this.$route.query, 'queryString'),
+        });
       } else {
         this.filterMode = 'advanced';
       }

--- a/client/routes/domain/workflow-list.vue
+++ b/client/routes/domain/workflow-list.vue
@@ -444,9 +444,11 @@ export default {
     },
     toggleFilter() {
       const { query } = this.$route;
+
       this.clearState();
       const filterMode = this.filterMode === 'advanced' ? 'basic' : 'advanced';
-      this.$router.replace({ query: {  ...query, filterMode } });
+
+      this.$router.replace({ query: { ...query, filterMode } });
     },
     onWorkflowGridScroll(startIndex, endIndex) {
       if (!this.npt && !this.nptAlt) {

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -76,6 +76,23 @@ export default {
           .toISOString(),
       },
     ],
+    list: [
+      {
+        execution: {
+          workflowId: 'email-daily-summaries',
+          runId: '51ccc0d1-6ffe-4a7a-a89f-6b5154df86f7',
+        },
+        type: {
+          name: 'github.com/uber/cadence-web/email-daily-summaries-1',
+        },
+        closeStatus: 'COMPLETED',
+        startTime: emailRun1Start.toISOString(),
+        closeTime: moment(timeBasis)
+          .subtract(2, 'minutes')
+          .subtract(1, 'day')
+          .toISOString(),
+      },
+    ],
   },
   history: {
     emailRun1: [

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -250,7 +250,8 @@ Scenario.prototype.withWorkflows = function withWorkflows({
   }
 
   const startTimeDays = startTimeOffset || status === 'open' ? 30 : 21;
-  const url = `/api/domains/${this.domain}/workflows/${status}?${qs.stringify({
+  const baseUrl = `/api/domains/${this.domain}/workflows/${status}`;
+  const queryString = qs.stringify(status === 'list' ? query : {
     startTime: moment()
       .subtract(startTimeDays, 'day')
       .startOf('day')
@@ -259,8 +260,8 @@ Scenario.prototype.withWorkflows = function withWorkflows({
       .endOf('day')
       .toISOString(),
     ...query,
-  })}`;
-
+  });
+  const url = `${baseUrl}?${queryString}`;
   const response = Array.isArray(workflows)
     ? { executions: workflows, nextPageToken: '' }
     : workflows;

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -251,16 +251,20 @@ Scenario.prototype.withWorkflows = function withWorkflows({
 
   const startTimeDays = startTimeOffset || status === 'open' ? 30 : 21;
   const baseUrl = `/api/domains/${this.domain}/workflows/${status}`;
-  const queryString = qs.stringify(status === 'list' ? query : {
-    startTime: moment()
-      .subtract(startTimeDays, 'day')
-      .startOf('day')
-      .toISOString(),
-    endTime: moment()
-      .endOf('day')
-      .toISOString(),
-    ...query,
-  });
+  const queryString = qs.stringify(
+    status === 'list'
+      ? query
+      : {
+          startTime: moment()
+            .subtract(startTimeDays, 'day')
+            .startOf('day')
+            .toISOString(),
+          endTime: moment()
+            .endOf('day')
+            .toISOString(),
+          ...query,
+        }
+  );
   const url = `${baseUrl}?${queryString}`;
   const response = Array.isArray(workflows)
     ? { executions: workflows, nextPageToken: '' }

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -358,10 +358,10 @@ describe('Workflow list', () => {
       .should.have.trimmed.text('Failed');
   });
 
-  it('should call list API when queryString query param is set', async function test() {
+  it('should call list API when filterMode = advanced and queryString query params are set', async function test() {
     const [testEl] = new Scenario(this.test)
       .withDomain('ci-test')
-      .startingAt('/domains/ci-test/workflows?status=FAILED&queryString=demo')
+      .startingAt('/domains/ci-test/workflows?status=FAILED&queryString=demo&filterMode=advanced')
       .withNewsFeed()
       .withWorkflows({
         status: 'list',

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -361,7 +361,9 @@ describe('Workflow list', () => {
   it('should call list API when filterMode = advanced and queryString query params are set', async function test() {
     const [testEl] = new Scenario(this.test)
       .withDomain('ci-test')
-      .startingAt('/domains/ci-test/workflows?status=FAILED&queryString=demo&filterMode=advanced')
+      .startingAt(
+        '/domains/ci-test/workflows?status=FAILED&queryString=demo&filterMode=advanced'
+      )
       .withNewsFeed()
       .withWorkflows({
         status: 'list',

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -357,4 +357,27 @@ describe('Workflow list', () => {
       .querySelector('header.filters .status .selected-tag')
       .should.have.trimmed.text('Failed');
   });
+
+  it('should call list API when queryString query param is set', async function test() {
+    const [testEl] = new Scenario(this.test)
+      .withDomain('ci-test')
+      .startingAt('/domains/ci-test/workflows?status=FAILED&queryString=demo')
+      .withNewsFeed()
+      .withWorkflows({
+        status: 'list',
+        query: {
+          queryString: 'demo',
+        },
+      })
+      .withDomainDescription('ci-test')
+      .go();
+
+    const workflowsEl = await testEl.waitUntilExists(
+      'section.workflow-list.ready'
+    );
+
+    workflowsEl
+      .querySelector('header.filters input[name="queryString"]')
+      .value.should.equal('demo');
+  });
 });


### PR DESCRIPTION
This PR primarily fixes a major issue when trying to use Advanced query in workflow list. This issue was introduced from changes made for the All status feature. The primary issue with the Advanced query screen is it uses parameters from the basic screen and applies it to the API fetch in the advanced screen. As All status fetches open & closed, it no longer calls the list API when using Advanced query so the queryString was ignored on the API.

From doing some testing in this area, there are a few small UX improvements that I have also included which should help in both the basic & advanced screens.

Improvements include (annotated # in code):
1. Text fields no longer try to trim themselves when entering whitespace (spacebar). Unless your copy/pasting, this is extremely annoying to use. The trim will occur when trying to make an API call instead so you effectively get the end result without the annoyance.
2. ~~Switching between Advanced to basic was not clearing queryString correctly, this is now working as intended.~~
3. When copying a link or refreshing the page on the advanced screen would show the basic screen instead (even though the query string is applied). This is now rendering the correct screen on refresh.
4. Removing unused variable in the code (nextPageToken). This uses npt & nptAlt already.
5. When switching between basic & advanced screen, it does not update the list accordingly. This will now clear the list when switching to advanced. It will show the basic list when switching back.
6. Only queryString is used on advanced query. All other query params are dropped when making API request.
7. On clearing queryString (using X on textfield) it will now correctly reset the state.
8. If All status was selected on basic screen and switched to advanced screen, it would try to call open and closed APIs instead of list API.

I have added an integration test which will capture new issues in the future for advanced query screen.