### PR TITLE
Feature/start workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8513,6 +8513,11 @@
       "resolved": "https://unpm.uberinternal.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://unpm.uberinternal.com/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://unpm.uberinternal.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "koa-static": "^4.0.1",
     "koa-webpack": "^2.0.3",
     "lodash-es": "^4.17.4",
+    "lodash.get": "^4.4.2",
     "long": "^3.2.0",
     "lossless-json": "^1.0.2",
     "moment": "^2.19.1",

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -269,6 +269,11 @@ module.exports = async function(ctx, next) {
       'signal',
       withVerboseWorkflowExecution
     ),
+    startWorkflow: req(
+      'StartWorkflowExecution',
+      'start',
+      withWorkflowExecution
+    ),
     terminateWorkflow: req(
       'TerminateWorkflowExecution',
       'terminate',

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -23,6 +23,7 @@
 
 const path = require('path'),
   dns = require('dns'),
+  get = require('lodash.get'),
   TChannelAsThrift = require('tchannel/as/thrift'),
   TChannel = require('tchannel'),
   Long = require('long'),
@@ -200,7 +201,7 @@ module.exports = async function(ctx, next) {
   const withDomainPaging = body =>
       Object.assign(
         {
-          domain: ctx.params.domain,
+          domain: get(ctx, 'params.domain'),
           maximumPageSize: 100,
         },
         body
@@ -208,10 +209,10 @@ module.exports = async function(ctx, next) {
     withWorkflowExecution = body =>
       Object.assign(
         {
-          domain: ctx.params.domain,
+          domain: get(ctx, 'params.domain'),
           execution: {
-            workflowId: ctx.params.workflowId,
-            runId: ctx.params.runId,
+            workflowId: get(ctx, 'params.workflowId'),
+            runId: get(ctx, 'params.runId'),
           },
         },
         body
@@ -219,10 +220,10 @@ module.exports = async function(ctx, next) {
     withVerboseWorkflowExecution = body =>
       Object.assign(
         {
-          domain: ctx.params.domain,
+          domain: get(ctx, 'params.domain'),
           workflowExecution: {
-            workflowId: ctx.params.workflowId,
-            runId: ctx.params.runId,
+            workflowId: get(ctx, 'params.workflowId'),
+            runId: get(ctx, 'params.runId'),
           },
         },
         body

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -198,52 +198,54 @@ module.exports = async function(ctx, next) {
       });
   }
 
-  const withDomainPaging = body =>
-      Object.assign(
-        {
-          domain: get(ctx, 'params.domain'),
-          maximumPageSize: 100,
-        },
-        body
-      ),
-    withWorkflowExecution = body => {
-      const domain = get(ctx, 'params.domain');
-      const runId = get(ctx, 'params.runId');
-      const workflowId = get(ctx, 'params.workflowId');
+  const withDomainPaging = body => {
+    const { domain } = get(ctx, 'params', {});
 
-      const execution = (workflowId || runId) && {
-        workflowId,
-        runId,
-      };
+    return Object.assign(
+      {
+        domain,
+        maximumPageSize: 100,
+      },
+      body
+    );
+  };
 
-      return Object.assign(
-        {
-          domain,
-          execution,
-        },
-        body,
-      );
-    },
-    withVerboseWorkflowExecution = body => {
-      const domain = get(ctx, 'params.domain');
-      const runId = get(ctx, 'params.runId');
-      const workflowId = get(ctx, 'params.workflowId');
+  const withWorkflowExecution = body => {
+    const { domain, runId, workflowId } = get(ctx, 'params', {});
 
-      const workflowExecution = (workflowId || runId) && {
-        workflowId,
-        runId,
-      };
+    const execution = (workflowId || runId) && {
+      workflowId,
+      runId,
+    };
 
-      return Object.assign(
-        {
-          domain,
-          workflowExecution,
-        },
-        body
-      );
-    },
-    withDomainPagingAndWorkflowExecution = b =>
-      Object.assign(withDomainPaging(b), withWorkflowExecution(b));
+    return Object.assign(
+      {
+        domain,
+        execution,
+      },
+      body,
+    );
+  };
+
+  const withVerboseWorkflowExecution = body => {
+    const { domain, runId, workflowId } = get(ctx, 'params', {});
+
+    const workflowExecution = (workflowId || runId) && {
+      workflowId,
+      runId,
+    };
+
+    return Object.assign(
+      {
+        domain,
+        workflowExecution,
+      },
+      body
+    );
+  };
+
+  const withDomainPagingAndWorkflowExecution = body =>
+    Object.assign(withDomainPaging(body), withWorkflowExecution(body));
 
   ctx.cadence = {
     archivedWorkflows: req(

--- a/server/middleware/tchannel-client.js
+++ b/server/middleware/tchannel-client.js
@@ -153,7 +153,7 @@ module.exports = async function(ctx, next) {
 
   function req(method, reqName, bodyTransform, resTransform) {
     return body =>
-      new Promise(function (resolve, reject) {
+      new Promise(function(resolve, reject) {
         try {
           channel
             .request({
@@ -223,7 +223,7 @@ module.exports = async function(ctx, next) {
         domain,
         execution,
       },
-      body,
+      body
     );
   };
 
@@ -286,10 +286,7 @@ module.exports = async function(ctx, next) {
       'signal',
       withVerboseWorkflowExecution
     ),
-    startWorkflow: req(
-      'StartWorkflowExecution',
-      'start'
-    ),
+    startWorkflow: req('StartWorkflowExecution', 'start'),
     terminateWorkflow: req(
       'TerminateWorkflowExecution',
       'terminate',


### PR DESCRIPTION
### Added
- Expose start workflow in cadence-web service. This is currently not used in the UI but may be in the future.

### Changed
- Introduced `lodash.get` to resolve request params optionally. If these params don't resolve it will use what is passed to the request function instead.