### PR TITLE
Feature/get query result refactor

### DIFF
--- a/client/routes/workflow/helpers/get-query-result.js
+++ b/client/routes/workflow/helpers/get-query-result.js
@@ -23,4 +23,4 @@ const getQueryResult = queryResponse => {
   return { payloads: queryResponse };
 };
 
-export { getQueryResult };
+export default getQueryResult;

--- a/client/routes/workflow/helpers/index.js
+++ b/client/routes/workflow/helpers/index.js
@@ -25,6 +25,7 @@ export { default as getEventFullDetails } from './get-event-full-details';
 export { default as getEventSummary } from './get-event-summary';
 export { default as getHistoryEvents } from './get-history-events';
 export { default as getHistoryTimelineEvents } from './get-history-timeline-events';
+export { default as getQueryResult } from './get-query-result';
 export { default as getSummary } from './get-summary';
 export { default as getSummaryWorkflowStatus } from './get-summary-workflow-status';
 export { default as getTimeElapsedDisplay } from './get-time-elapsed-display';

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { getQueryResult } from './helpers/get-query-result';
+import { getQueryResult } from './helpers';
 
 export default {
   data() {

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { getQueryResult } from './helpers/get-query-result';
+import { getQueryResult } from './helpers';
 import { getDatetimeFormattedString } from '~helpers';
 
 export default {


### PR DESCRIPTION
Refactor getQueryResult to match import pattern for other helpers

### Changed
- `import { getQueryResult } from './helpers/get-query-result';` => `import { getQueryResult } from './helpers';`
