### PR TITLE
Feature/graph container refactor

### DIFF
--- a/client/containers/graph/get-default-state.js
+++ b/client/containers/graph/get-default-state.js
@@ -19,18 +19,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {
-  getDefaultState as getGraphDefaultState,
-  getters as graphGetters,
-  mutations as graphMutations,
-} from './graph';
-export {
-  container as SettingsWorkflowHistory,
-  getDefaultState as getSettingsWorkflowHistoryDefaultState,
-  getters as settingsWorkflowHistoryGetters,
-  mutations as settingsWorkflowHistoryMutations,
-} from './settings-workflow-history';
-export {
-  container as WorkflowHistory,
-  getDefaultState as getWorkflowHistoryDefaultState,
-} from './workflow-history';
+const getDefaultState = (state = {}) => ({
+  childRoute: null,
+  newExecutionId: null,
+  parentRoute: null,
+  hasChildBtn: false,
+  childBtnText: null,
+  parentBtnText: 'to parent',
+  ...state,
+});
+
+export default getDefaultState;

--- a/client/containers/graph/getters.js
+++ b/client/containers/graph/getters.js
@@ -19,13 +19,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import { get } from 'lodash-es';
+
 const getters = {
-  childRoute: state => state.graph.childRoute,
-  newExecutionId: state => state.graph.newExecutionId,
-  hasChildBtn: state => state.graph.hasChildBtn,
-  childBtnText: state => state.graph.childBtnText,
-  parentBtnText: state => state.graph.parentBtnText,
-  parentRoute: state => state.graph.parentRoute,
+  childRoute: state => get(state, 'graph.childRoute'),
+  newExecutionId: state => get(state, 'graph.newExecutionId'),
+  hasChildBtn: state => get(state, 'graph.hasChildBtn'),
+  childBtnText: state => get(state, 'graph.childBtnText'),
+  parentBtnText: state => get(state, 'graph.parentBtnText'),
+  parentRoute: state => get(state, 'graph.parentRoute'),
 };
 
 export default getters;

--- a/client/containers/graph/getters.js
+++ b/client/containers/graph/getters.js
@@ -19,18 +19,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {
-  getDefaultState as getGraphDefaultState,
-  getters as graphGetters,
-  mutations as graphMutations,
-} from './graph';
-export {
-  container as SettingsWorkflowHistory,
-  getDefaultState as getSettingsWorkflowHistoryDefaultState,
-  getters as settingsWorkflowHistoryGetters,
-  mutations as settingsWorkflowHistoryMutations,
-} from './settings-workflow-history';
-export {
-  container as WorkflowHistory,
-  getDefaultState as getWorkflowHistoryDefaultState,
-} from './workflow-history';
+const getters = {
+  childRoute: state => state.graph.childRoute,
+  newExecutionId: state => state.graph.newExecutionId,
+  hasChildBtn: state => state.graph.hasChildBtn,
+  childBtnText: state => state.graph.childBtnText,
+  parentBtnText: state => state.graph.parentBtnText,
+  parentRoute: state => state.graph.parentRoute,
+};
+
+export default getters;

--- a/client/containers/graph/index.js
+++ b/client/containers/graph/index.js
@@ -19,18 +19,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {
-  getDefaultState as getGraphDefaultState,
-  getters as graphGetters,
-  mutations as graphMutations,
-} from './graph';
-export {
-  container as SettingsWorkflowHistory,
-  getDefaultState as getSettingsWorkflowHistoryDefaultState,
-  getters as settingsWorkflowHistoryGetters,
-  mutations as settingsWorkflowHistoryMutations,
-} from './settings-workflow-history';
-export {
-  container as WorkflowHistory,
-  getDefaultState as getWorkflowHistoryDefaultState,
-} from './workflow-history';
+import getDefaultState from './get-default-state';
+import getters from './getters';
+import mutations from './mutations';
+
+export { getDefaultState, getters, mutations };

--- a/client/containers/graph/mutations.js
+++ b/client/containers/graph/mutations.js
@@ -19,18 +19,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export {
-  getDefaultState as getGraphDefaultState,
-  getters as graphGetters,
-  mutations as graphMutations,
-} from './graph';
-export {
-  container as SettingsWorkflowHistory,
-  getDefaultState as getSettingsWorkflowHistoryDefaultState,
-  getters as settingsWorkflowHistoryGetters,
-  mutations as settingsWorkflowHistoryMutations,
-} from './settings-workflow-history';
-export {
-  container as WorkflowHistory,
-  getDefaultState as getWorkflowHistoryDefaultState,
-} from './workflow-history';
+import getDefaultState from './get-default-state';
+
+const mutations = {
+  childRoute(state, param) {
+    state.graph.childRoute = param.route;
+    state.graph.hasChildBtn = true;
+    state.graph.childBtnText = param.btnText;
+  },
+  newExecutionRoute(state, route) {
+    (state.graph.newExecutionId = route),
+      (state.graph.hasChildBtn = !state.graph.hasChildBtn);
+  },
+  previousExecutionRoute(state, route) {
+    (state.graph.parentRoute = route),
+      (state.graph.parentBtnText = 'previous execution');
+  },
+  toggleChildBtn(state) {
+    state.graph.hasChildBtn = false;
+  },
+  parentRoute(state, route) {
+    state.graph.parentRoute = route;
+  },
+  resetGraphState(state) {
+    Object.assign(state.graph, getDefaultState());
+  },
+};
+
+export default mutations;

--- a/client/main.js
+++ b/client/main.js
@@ -53,7 +53,7 @@ import WorkflowArchivalBasic from './routes/domain/workflow-archival/basic';
 import WorkflowList from './routes/domain/workflow-list';
 import WorkflowSummary from './routes/workflow/summary';
 import WorkflowTabs from './routes/workflow';
-import store from './store/index.js';
+import initStore from './store';
 import { WorkflowHistory } from '~containers';
 
 import { http, injectMomentDurationFormat, jsonTryParse } from '~helpers';
@@ -343,6 +343,8 @@ if (typeof mocha === 'undefined') {
   if (!document.querySelector('main')) {
     document.body.appendChild(document.createElement('main'));
   }
+
+  const store = initStore();
 
   // eslint-disable-next-line no-new
   new Vue({

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -21,86 +21,54 @@
 
 import Vue from 'vue';
 import Vuex from 'vuex';
-import VuexPersistence from 'vuex-persist';
 import {
+  // graph
+  getGraphDefaultState,
+  graphGetters,
+  graphMutations,
+
+  // settings
   getSettingsWorkflowHistoryDefaultState,
-  getWorkflowHistoryDefaultState,
   settingsWorkflowHistoryGetters,
   settingsWorkflowHistoryMutations,
+
+  // workflow history
+  getWorkflowHistoryDefaultState,
 } from '~containers';
 
-// Graph store
-
-const getGraphDefaultState = () => ({
-  childRoute: null,
-  newExecutionId: null,
-  parentRoute: null,
-  hasChildBtn: false,
-  childBtnText: null,
-  parentBtnText: 'to parent',
+const getDefaultState = (state = {}) => ({
+  graph: getGraphDefaultState(state.graph),
+  settingsWorkflowHistory: getSettingsWorkflowHistoryDefaultState(
+    state.settingsWorkflowHistory
+  ),
+  workflowHistory: getWorkflowHistoryDefaultState(state.workflowHistory),
 });
 
-const graphMutations = {
-  childRoute(state, param) {
-    state.graph.childRoute = param.route;
-    state.graph.hasChildBtn = true;
-    state.graph.childBtnText = param.btnText;
-  },
-  newExecutionRoute(state, route) {
-    (state.graph.newExecutionId = route),
-      (state.graph.hasChildBtn = !state.graph.hasChildBtn);
-  },
-  previousExecutionRoute(state, route) {
-    (state.graph.parentRoute = route),
-      (state.graph.parentBtnText = 'previous execution');
-  },
-  toggleChildBtn(state) {
-    state.graph.hasChildBtn = false;
-  },
-  parentRoute(state, route) {
-    state.graph.parentRoute = route;
-  },
-  resetGraphState(state) {
-    Object.assign(state.graph, getGraphDefaultState());
-  },
+const getStoreConfig = ({ state }) => {
+  const initialState = getDefaultState(state);
+
+  const storeConfig = {
+    state: initialState,
+    mutations: {
+      ...graphMutations,
+      ...settingsWorkflowHistoryMutations,
+    },
+    getters: {
+      ...graphGetters,
+      ...settingsWorkflowHistoryGetters,
+    },
+  };
+
+  return storeConfig;
 };
 
-const graphGetters = {
-  childRoute: state => state.graph.childRoute,
-  newExecutionId: state => state.graph.newExecutionId,
-  hasChildBtn: state => state.graph.hasChildBtn,
-  childBtnText: state => state.graph.childBtnText,
-  parentBtnText: state => state.graph.parentBtnText,
-  parentRoute: state => state.graph.parentRoute,
+const initStore = ({ state } = {}) => {
+  Vue.use(Vuex);
+
+  const storeConfig = getStoreConfig({ state });
+  const store = new Vuex.Store(storeConfig);
+
+  return store;
 };
 
-// Application store
-
-const getDefaultState = () => ({
-  graph: getGraphDefaultState(),
-  settingsWorkflowHistory: getSettingsWorkflowHistoryDefaultState(),
-  workflowHistory: getWorkflowHistoryDefaultState(),
-});
-
-const state = getDefaultState();
-
-Vue.use(Vuex);
-
-const vuexLocal = new VuexPersistence({
-  storage: window.localStorage,
-});
-
-const store = new Vuex.Store({
-  state: state,
-  mutations: {
-    ...graphMutations,
-    ...settingsWorkflowHistoryMutations,
-  },
-  getters: {
-    ...graphGetters,
-    ...settingsWorkflowHistoryGetters,
-  },
-  plugins: [vuexLocal.plugin],
-});
-
-export default store;
+export default initStore;

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -21,6 +21,7 @@
 
 import Vue from 'vue';
 import Vuex from 'vuex';
+import VuexPersistence from 'vuex-persist';
 import {
   // graph
   getGraphDefaultState,
@@ -47,6 +48,10 @@ const getDefaultState = (state = {}) => ({
 const getStoreConfig = ({ state }) => {
   const initialState = getDefaultState(state);
 
+  const vuexLocal = new VuexPersistence({
+    storage: window.localStorage,
+  });
+
   const storeConfig = {
     state: initialState,
     mutations: {
@@ -57,6 +62,7 @@ const getStoreConfig = ({ state }) => {
       ...graphGetters,
       ...settingsWorkflowHistoryGetters,
     },
+    plugins: [vuexLocal.plugin],
   };
 
   return storeConfig;

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -21,7 +21,6 @@
 
 import Router from 'vue-router';
 import Vue from 'vue';
-import Vuex from 'vuex';
 import moment from 'moment';
 import fetchMock from 'fetch-mock';
 import qs from 'friendly-querystring';
@@ -30,12 +29,13 @@ import deepmerge from 'deepmerge';
 
 import main from '../main';
 import { http } from '../helpers';
+import initStore from '../store';
 import fixtures from './fixtures';
 
 export default function Scenario(test) {
   // eslint-disable-next-line no-param-reassign
   test.scenario = this;
-  this.storeConfig = {};
+  this.storeState = {};
   this.mochaTest = test;
   this.api = fetchMock.sandbox().catch((url, req, opts) => {
     let msg = `Unexpected request: ${url}${
@@ -66,7 +66,9 @@ Scenario.prototype.render = function render(attachToBody) {
 
   const el = document.createElement('div');
 
-  const store = new Vuex.Store(this.storeConfig);
+  const store = initStore({
+    state: this.storeState,
+  });
 
   if (attachToBody || this.isDebuggingJustThisTest()) {
     document.body.appendChild(el);
@@ -232,8 +234,8 @@ Scenario.prototype.withNewsFeed = function withNewsFeed() {
   return this;
 };
 
-Scenario.prototype.withStoreConfig = function withStoreConfig(config = {}) {
-  this.storeConfig = config;
+Scenario.prototype.withStoreState = function withStoreState(state = {}) {
+  this.storeState = state;
 
   return this;
 };
@@ -289,7 +291,7 @@ Scenario.prototype.withWorkflow = function withWorkflow(
   this.workflowId = workflowId;
   this.runId = runId;
 
-  this.api.getOnce(this.execApiBase(), {
+  this.api.get(this.execApiBase(), {
     executionConfiguration: {
       taskList: { name: 'ci_task_list' },
       executionStartToCloseTimeoutSeconds: 3600,

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -46,11 +46,9 @@ describe('Workflow', () => {
           },
         ])
         .withNewsFeed()
-        .withStoreConfig({
-          state: {
-            workflowHistory: {
-              graphEnabled: true,
-            },
+        .withStoreState({
+          workflowHistory: {
+            graphEnabled: true,
           },
         })
         .withWorkflow(


### PR DESCRIPTION
### Changed
- Move graph from `store` into `containers/graph` folder. 
- Small refactor on getDefaultState to accept initial state.
- Small refactor on graph getter to use `get` lodash helper.
- Small refactor of store to be more organised and optionally accept initial state (used in integration tests).
- Fix how integration tests initializes the store using initialState and actually using the real store used by the App.