### PR TITLE
v3.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.25.0",
+  "version": "3.26.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.26.0-beta.0",
+  "version": "3.26.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.26.0-beta.0",
+  "version": "3.26.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.25.0",
+  "version": "3.26.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
### Added
- workflow list screen will disable advanced search button for clusters that don't support advanced visibility (ElasticSearch) (#322)
- cadence-web node server endpoint to get cluster information (#291)
- cluster vuex store (#328, #327, #326, #325, #324, #291)
- button to support `enabled` prop (#323)

### Changed
- refactored cadence-web node server to accept init params & improved readabillity (#330, #329, #290, #289)
- workflow list screen now uses container pattern (#321, #320, #319, #318, #317, #315, #314, #313, #312, #311, #305, #304, #303, #299, #298, #297, #293)
- route vuex store changes (#300)
- settings modal now uses container pattern (#294)

### Fixed
- bug where a console error would warn a user when navigating to the workflow list screen (#316)
- flakey integration tests (#333, #302, #296)
- global components referencing (#295)

### Screenshots
#### Advanced search button disabled when ES is not available
<img width="1792" alt="Screen Shot 2021-05-27 at 11 39 11 AM" src="https://user-images.githubusercontent.com/58960161/119879677-5270ad80-bee0-11eb-8456-b4ad02db7981.png">
