### PR TITLE
Release/3.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.27.0",
+  "version": "3.28.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.3",
+  "version": "3.28.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.2",
+  "version": "3.28.0-beta.3",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.27.0",
+  "version": "3.28.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.0",
+  "version": "3.28.0-beta.1",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.0-beta.1",
+  "version": "3.28.0-beta.2",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
### Added
- `DomainAutocomplete` to `DomainSearch` screen. This will allow users to search for a domain without knowing the full domain name.
(#363, #366, #367, #368, #369, #353, #374, #376, #377)

- `DomainAutocomplete` to Application header for changing domains while inside a domain or workflow screen. 
(#363, #366, #367, #368, #369, #353, #374, #376, #377)

- Allow `width` to be passed as a prop to `button-icon` component. 
(#356)

- `DomainService` which allows searching for a domain with a partial/complete querystring. 
(#361)

- replaced `$http` with `httpService` so that services can access http as well as components and is consistent between the two. 
(#364)

- `CacheManager` which handles caching on server. cache logic is now removed from `ClusterService` to use `CacheManager` instead. 
(#360)

- Integration test helpers (`getFixture`, `emptyNewsFeed`, `MockDate`).
(#358, #359, #364)

- Feature flag slots.
(#357)

### Changed
- Renamed `DomainList` to `DomainSearch`.
(#353)

- Refactoring existing screens to work with domain search changes (`WorkflowList`, `DomainSettings`).
(#371, #372, #364)

- Upgrade vue-select library.
(#362, #370)

### Removed
- `DomainNavigation` replaced with `DomainAutocomplete`.
(#353)

### Screenshots
#### DomainSearch (landing) screen w/o text (recently visited domains)
<img width="1347" alt="Screen Shot 2021-07-27 at 1 01 36 PM" src="https://user-images.githubusercontent.com/58960161/127219913-4b774b77-8604-4f78-b806-079ca174644a.png">

#### DomainSearch (landing) screen w/ text (matched domains)
<img width="1347" alt="Screen Shot 2021-07-27 at 1 03 50 PM" src="https://user-images.githubusercontent.com/58960161/127220090-169b1894-e9b0-4f9c-9f94-e59946a48a4f.png">

#### DomainAutocomplete in Application header not opened (spyglass to open)
<img width="1347" alt="Screen Shot 2021-07-27 at 1 05 36 PM" src="https://user-images.githubusercontent.com/58960161/127220343-07ea91fe-217f-41e0-9c06-aeb53788507d.png">

#### DomainAutocomplete in Application header opened w/o search text (recently visited domains)
<img width="1347" alt="Screen Shot 2021-07-27 at 1 05 13 PM" src="https://user-images.githubusercontent.com/58960161/127220382-630d5b9a-3462-4149-87ad-252a3617f86d.png">

#### DomainAutocomplete in Application header opened w/ search text (matched domains)
<img width="1347" alt="Screen Shot 2021-07-27 at 1 05 27 PM" src="https://user-images.githubusercontent.com/58960161/127220410-50068ed1-645e-4ab4-9007-2d6c046d67dd.png">