### PR TITLE
Feature/migrate recent domains

### DIFF
--- a/client/containers/domain-autocomplete/actions.js
+++ b/client/containers/domain-autocomplete/actions.js
@@ -71,10 +71,7 @@ const actions = {
       updatedVisitedDomainList
     );
 
-    const domainName =
-      typeof value === 'string' ? value : value.domainInfo.name;
-
-    dispatch(ROUTE_PUSH, `/domains/${domainName}`);
+    dispatch(ROUTE_PUSH, `/domains/${value.domainInfo.name}`);
   },
   [DOMAIN_AUTOCOMPLETE_ON_SEARCH]: async ({ commit, dispatch }, payload) => {
     commit(DOMAIN_AUTOCOMPLETE_SET_SEARCH, payload);

--- a/client/containers/domain-autocomplete/get-default-state.js
+++ b/client/containers/domain-autocomplete/get-default-state.js
@@ -19,12 +19,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import { migrateRecentDomains } from './helpers';
+
 const getDefaultState = (state = {}) => ({
   isLoading: false,
   domainList: [],
   search: '',
-  visitedDomainList:
-    JSON.tryParse(localStorage.getItem('recent-domains')) || [],
+  visitedDomainList: migrateRecentDomains(
+    JSON.tryParse(localStorage.getItem('recent-domains'))
+  ),
   ...state,
 });
 

--- a/client/containers/domain-autocomplete/helpers/combine-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/combine-domain-list.js
@@ -26,8 +26,8 @@ const combineDomainList = ({ domainList, visitedDomainList }) => {
   return [
     ...domainList,
     ...visitedDomainList.filter(domain =>
-      typeof domain === 'string'
-        ? domainNameList.indexOf(domain) === -1
+      domain.domainInfo.uuid === undefined
+        ? domainNameList.indexOf(domain.domainInfo.name) === -1
         : domainListUuidList.indexOf(domain.domainInfo.uuid) === -1
     ),
   ];

--- a/client/containers/domain-autocomplete/helpers/combine-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/combine-domain-list.spec.js
@@ -24,14 +24,22 @@ import combineDomainList from './combine-domain-list';
 describe('combineDomainList', () => {
   describe('when passed domainList & visitedDomainList', () => {
     const visitedDomainList = [
-      'domain1',
+      {
+        domainInfo: {
+          name: 'domain1',
+        },
+      },
       {
         domainInfo: {
           name: 'domain2',
           uuid: 2,
         },
       },
-      'domain3',
+      {
+        domainInfo: {
+          name: 'domain3',
+        },
+      },
       {
         domainInfo: {
           name: 'domain4',
@@ -83,7 +91,11 @@ describe('combineDomainList', () => {
             uuid: 2,
           },
         },
-        'domain3',
+        {
+          domainInfo: {
+            name: 'domain3',
+          },
+        },
         {
           domainInfo: {
             name: 'domain4',

--- a/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.js
@@ -22,11 +22,8 @@
 const filterVisitedDomainList = ({ search, visitedDomainList }) =>
   !search
     ? visitedDomainList
-    : visitedDomainList.filter(domain => {
-        const domainName =
-          typeof domain === 'string' ? domain : domain.domainInfo.name;
-
-        return domainName.indexOf(search) !== -1;
-      });
+    : visitedDomainList.filter(
+        domain => domain.domainInfo.name.indexOf(search) !== -1
+      );
 
 export default filterVisitedDomainList;

--- a/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.spec.js
@@ -26,14 +26,22 @@ describe('filterVisitedDomainList', () => {
 
   beforeEach(() => {
     visitedDomainList = [
-      'domain1',
+      {
+        domainInfo: {
+          name: 'domain1',
+        },
+      },
       {
         domainInfo: {
           name: 'domain2',
           uuid: 2,
         },
       },
-      'other',
+      {
+        domainInfo: {
+          name: 'other',
+        },
+      },
     ];
   });
 
@@ -54,7 +62,11 @@ describe('filterVisitedDomainList', () => {
       const output = filterVisitedDomainList({ search, visitedDomainList });
 
       expect(output).toEqual([
-        'domain1',
+        {
+          domainInfo: {
+            name: 'domain1',
+          },
+        },
         {
           domainInfo: {
             name: 'domain2',

--- a/client/containers/domain-autocomplete/helpers/format-domain-label.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-label.js
@@ -19,15 +19,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import get from 'lodash.get';
+
 const formatDomainLabel = domain =>
-  typeof domain === 'string'
-    ? domain
-    : [
-        domain.domainInfo.name,
-        domain.isGlobalDomain ? 'Global' : 'Local',
-        domain.replicationConfiguration.activeClusterName,
-      ]
-        .filter(domain => !!domain)
-        .join(' - ');
+  [
+    domain.domainInfo.name,
+    domain.isGlobalDomain !== undefined &&
+      (domain.isGlobalDomain ? 'Global' : 'Local'),
+    get(domain, 'replicationConfiguration.activeClusterName'),
+  ]
+    .filter(entry => !!entry)
+    .join(' - ');
 
 export default formatDomainLabel;

--- a/client/containers/domain-autocomplete/helpers/format-domain-label.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-label.js
@@ -28,7 +28,7 @@ const formatDomainLabel = domain =>
       (domain.isGlobalDomain ? 'Global' : 'Local'),
     get(domain, 'replicationConfiguration.activeClusterName'),
   ]
-    .filter(entry => !!entry)
+    .filter(substring => !!substring)
     .join(' - ');
 
 export default formatDomainLabel;

--- a/client/containers/domain-autocomplete/helpers/format-domain-label.spec.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-label.spec.js
@@ -22,8 +22,12 @@
 import formatDomainLabel from './format-domain-label';
 
 describe('formatDomainLabel', () => {
-  describe('when passed domain string', () => {
-    const domain = 'domainName';
+  describe('when passed domain object with only name defined', () => {
+    const domain = {
+      domainInfo: {
+        name: 'domainName',
+      },
+    };
 
     it('should render only the domainName.', () => {
       const output = formatDomainLabel(domain);

--- a/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
+++ b/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
@@ -19,13 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export { default as combineDomainList } from './combine-domain-list';
-export { default as filterTopDomainList } from './filter-top-domain-list';
-export { default as filterVisitedDomainList } from './filter-visited-domain-list';
-export { default as formatDomainLabel } from './format-domain-label';
-export { default as formatDomainList } from './format-domain-list';
-export { default as migrateRecentDomains } from './migrate-recent-domains';
-export { default as sortDomainList } from './sort-domain-list';
-export { default as statePrefix } from './state-prefix';
-export { default as typePrefix } from './type-prefix';
-export { default as updateVisitedDomainList } from './update-visited-domain-list';
+const migrateRecentDomains = (recentDomains = []) =>
+  recentDomains.map(domainName => ({
+    domainInfo: {
+      name: domainName,
+    },
+  }));
+
+export default migrateRecentDomains;

--- a/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
+++ b/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
@@ -19,11 +19,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const migrateRecentDomains = (recentDomains = []) =>
-  recentDomains.map(domainName => ({
-    domainInfo: {
-      name: domainName,
-    },
-  }));
+const migrateRecentDomains = recentDomains =>
+  (recentDomains &&
+    recentDomains.map(domainName => ({
+      domainInfo: {
+        name: domainName,
+      },
+    }))) ||
+  [];
 
 export default migrateRecentDomains;

--- a/client/containers/domain-autocomplete/helpers/migrate-recent-domains.spec.js
+++ b/client/containers/domain-autocomplete/helpers/migrate-recent-domains.spec.js
@@ -19,13 +19,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export { default as combineDomainList } from './combine-domain-list';
-export { default as filterTopDomainList } from './filter-top-domain-list';
-export { default as filterVisitedDomainList } from './filter-visited-domain-list';
-export { default as formatDomainLabel } from './format-domain-label';
-export { default as formatDomainList } from './format-domain-list';
-export { default as migrateRecentDomains } from './migrate-recent-domains';
-export { default as sortDomainList } from './sort-domain-list';
-export { default as statePrefix } from './state-prefix';
-export { default as typePrefix } from './type-prefix';
-export { default as updateVisitedDomainList } from './update-visited-domain-list';
+import migrateRecentDomains from './migrate-recent-domains';
+
+describe('migrateRecentDomains', () => {
+  describe('when passed recentDomains array strings', () => {
+    it('should format to array objects.', () => {
+      const recentDomains = ['domainA', 'domainB', 'domainC'];
+      const output = migrateRecentDomains(recentDomains);
+
+      expect(output).toEqual([
+        {
+          domainInfo: {
+            name: 'domainA',
+          },
+        },
+        {
+          domainInfo: {
+            name: 'domainB',
+          },
+        },
+        {
+          domainInfo: {
+            name: 'domainC',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/client/containers/domain-autocomplete/helpers/sort-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/sort-domain-list.js
@@ -21,10 +21,8 @@
 
 const sortDomainList = domainList =>
   domainList.sort((domainA, domainB) => {
-    const domainNameA =
-      typeof domainA === 'string' ? domainA : domainA.domainInfo.name;
-    const domainNameB =
-      typeof domainB === 'string' ? domainB : domainB.domainInfo.name;
+    const domainNameA = domainA.domainInfo.name;
+    const domainNameB = domainB.domainInfo.name;
 
     if (domainNameA < domainNameB) {
       return -1;

--- a/client/containers/domain-autocomplete/helpers/sort-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/sort-domain-list.spec.js
@@ -30,9 +30,9 @@ describe('sortDomainList', () => {
 
   describe('when passed an unsorted domainList', () => {
     it('should return an alphabetically sorted domainList', () => {
-      const domainA = 'domainA';
-      const domainB = 'domainB';
-      const domainC = 'domainC';
+      const domainA = createDomainObject('domainA');
+      const domainB = createDomainObject('domainB');
+      const domainC = createDomainObject('domainC');
       const domainD = createDomainObject('domainD');
       const domainE = createDomainObject('domainE');
       const domainF = createDomainObject('domainF');

--- a/client/containers/domain-autocomplete/helpers/update-visited-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/update-visited-domain-list.js
@@ -22,13 +22,11 @@
 import { VISITED_DOMAIN_LIST_LIMIT } from '../constants';
 
 const updateVisitedDomainList = ({ value, visitedDomainList }) => {
-  const name = typeof value === 'string' ? value : value.domainInfo.name;
-  const uuid = typeof value === 'string' ? null : value.domainInfo.uuid;
+  const name = value.domainInfo.name;
+  const uuid = value.domainInfo.uuid || null;
 
-  const matchedDomainIndex = visitedDomainList.findIndex(domain =>
-    typeof domain === 'string'
-      ? domain === name
-      : domain.domainInfo.uuid === uuid
+  const matchedDomainIndex = visitedDomainList.findIndex(
+    domain => domain.domainInfo.uuid === uuid || domain.domainInfo.name === name
   );
 
   if (matchedDomainIndex === -1) {

--- a/client/containers/domain-autocomplete/helpers/update-visited-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/update-visited-domain-list.spec.js
@@ -24,7 +24,11 @@ import updateVisitedDomainList from './update-visited-domain-list';
 
 describe('updateVisitedDomainList', () => {
   const getVisitedDomainList = () => [
-    'domainString',
+    {
+      domainInfo: {
+        name: 'domainString',
+      },
+    },
     {
       domainInfo: {
         uuid: 2,


### PR DESCRIPTION
### Added
- `migrateRecentDomains` which will help migrate `recent-domains` cookie to convert to a domain object w/ name.

### Changed
- changed all instances where domain was being type asserted to string and updating to object only.
- updated uuid checking if it is migrated from `recent-domains`
- updated tests to use new format for strings to objects with only name.