### PR TITLE
Feature/migrate domain list 4

### DIFF
--- a/client/containers/domain-autocomplete/reducer.js
+++ b/client/containers/domain-autocomplete/reducer.js
@@ -22,10 +22,8 @@
 import { migrateRecentDomains } from './helpers';
 
 const reducer = state => ({
-  ...state.domainAutocomplete,
-  visitedDomainList: migrateRecentDomains(
-    state.domainAutocomplete.visitedDomainList
-  ),
+  ...state,
+  visitedDomainList: migrateRecentDomains(state.visitedDomainList),
 });
 
 export default reducer;

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -85,10 +85,18 @@ const getStoreConfig = ({ router, state }) => {
   const initialState = getDefaultState(state);
 
   const vuexLocal = new VuexPersistence({
-    reducer: state => ({
-      ...state,
-      domainAutocomplete: domainAutocompleteReducer(state),
-    }),
+    restoreState: key => {
+      const state = JSON.tryParse(localStorage.getItem(key));
+
+      if (!state) {
+        return;
+      }
+
+      return {
+        ...state,
+        domainAutocomplete: domainAutocompleteReducer(state.domainAutocomplete),
+      };
+    },
     storage: window.localStorage,
   });
 


### PR DESCRIPTION
### Changed
- use `restoreState` instead of `reducer` as this will reduce on the data that is onLoad instead of onSave. Issue with reducer is if there is an issue, a user will need to refresh browser before seeing it fixed. Now it will fix data on load of browser.
- updated reducer to be passed only the state tree it needs