### PR TITLE
Fix/domain autocomplete missing state

### DIFF
--- a/client/containers/domain-autocomplete/reducer.js
+++ b/client/containers/domain-autocomplete/reducer.js
@@ -21,9 +21,10 @@
 
 import { migrateRecentDomains } from './helpers';
 
-const reducer = state => ({
-  ...state,
-  visitedDomainList: migrateRecentDomains(state.visitedDomainList),
-});
+const reducer = state =>
+  state && {
+    ...state,
+    visitedDomainList: migrateRecentDomains(state.visitedDomainList),
+  };
 
 export default reducer;

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -92,9 +92,15 @@ const getStoreConfig = ({ router, state }) => {
         return;
       }
 
+      const domainAutocomplete = domainAutocompleteReducer(
+        state.domainAutocomplete
+      );
+
       return {
         ...state,
-        domainAutocomplete: domainAutocompleteReducer(state.domainAutocomplete),
+        ...(domainAutocomplete && {
+          domainAutocomplete,
+        }),
       };
     },
     storage: window.localStorage,


### PR DESCRIPTION
### Added
- check for partial state loading in `DomainAutocomplete` reducer. This can occur when upgrading Cadence UI versions and Vuex tries to load state from local storage and the reducer fails to load.

### Screenshots
#### After
<img width="1528" alt="Screen Shot 2021-07-29 at 9 30 54 AM" src="https://user-images.githubusercontent.com/58960161/127530218-3f3d22db-6316-4ab5-8910-3a9a83056595.png">

#### Before
<img width="1530" alt="Screen Shot 2021-07-29 at 9 32 12 AM" src="https://user-images.githubusercontent.com/58960161/127530304-26c835a7-e6c3-41e4-97b9-70e49609367b.png">
