### PR TITLE
Feature/workflow list domain name

### DIFF
--- a/server/router/helpers/index.js
+++ b/server/router/helpers/index.js
@@ -21,6 +21,7 @@
 
 const buildQueryString = require('./build-query-string');
 const delay = require('./delay');
+const injectDomainIntoWorkflowList = require('./inject-domain-into-workflow-list');
 const isAdvancedVisibilityEnabled = require('./is-advanced-visibility-enabled');
 const listWorkflows = require('./list-workflows');
 const mapHistoryResponse = require('./map-history-response');
@@ -30,6 +31,7 @@ const replacer = require('./replacer');
 module.exports = {
   buildQueryString,
   delay,
+  injectDomainIntoWorkflowList,
   isAdvancedVisibilityEnabled,
   listWorkflows,
   mapHistoryResponse,

--- a/server/router/helpers/inject-domain-into-workflow-list.js
+++ b/server/router/helpers/inject-domain-into-workflow-list.js
@@ -19,25 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const { injectDomainIntoWorkflowList } = require('../helpers');
+const injectDomainIntoWorkflowList = (domainName, workflowListResponse) =>
+  workflowListResponse.executions.map(execution => ({
+    ...execution,
+    domainName,
+  }));
 
-const workflowListHandler = async ctx => {
-  const q = ctx.query || {};
-  const { params = {} } = ctx;
-
-  const listWorkflowsResponse = await ctx.cadence.listWorkflows({
-    query: q.queryString || undefined,
-    nextPageToken: q.nextPageToken
-      ? Buffer.from(q.nextPageToken, 'base64')
-      : undefined,
-  });
-
-  listWorkflowsResponse.executions = injectDomainIntoWorkflowList(
-    params.domain,
-    listWorkflowsResponse
-  );
-
-  ctx.body = listWorkflowsResponse;
-};
-
-module.exports = workflowListHandler;
+module.exports = injectDomainIntoWorkflowList;

--- a/server/router/helpers/list-workflows.js
+++ b/server/router/helpers/list-workflows.js
@@ -25,7 +25,7 @@ const isAdvancedVisibilityEnabled = require('./is-advanced-visibility-enabled');
 const momentToLong = require('./moment-to-long');
 
 async function listWorkflows({ clusterService, state }, ctx) {
-  const { query = {} } = ctx;
+  const { params = {}, query = {} } = ctx;
   const startTime = moment(query.startTime || NaN);
   const endTime = moment(query.endTime || NaN);
 
@@ -69,7 +69,16 @@ async function listWorkflows({ clusterService, state }, ctx) {
 
   const requestApi = advancedVisibility ? 'listWorkflows' : state + 'Workflows';
 
-  ctx.body = await ctx.cadence[requestApi](requestArgs);
+  const workflowListResponse = await ctx.cadence[requestApi](requestArgs);
+
+  workflowListResponse.executions = workflowListResponse.executions.map(
+    execution => ({
+      ...execution,
+      domainName: params.domain,
+    })
+  );
+
+  ctx.body = workflowListResponse;
 }
 
 module.exports = listWorkflows;

--- a/server/router/helpers/list-workflows.js
+++ b/server/router/helpers/list-workflows.js
@@ -21,6 +21,7 @@
 
 const moment = require('moment');
 const buildQueryString = require('./build-query-string');
+const injectDomainIntoWorkflowList = require('./inject-domain-into-workflow-list');
 const isAdvancedVisibilityEnabled = require('./is-advanced-visibility-enabled');
 const momentToLong = require('./moment-to-long');
 
@@ -71,11 +72,9 @@ async function listWorkflows({ clusterService, state }, ctx) {
 
   const workflowListResponse = await ctx.cadence[requestApi](requestArgs);
 
-  workflowListResponse.executions = workflowListResponse.executions.map(
-    execution => ({
-      ...execution,
-      domainName: params.domain,
-    })
+  workflowListResponse.executions = injectDomainIntoWorkflowList(
+    params.domain,
+    workflowListResponse
   );
 
   ctx.body = workflowListResponse;

--- a/server/router/routes/workflow-archived-list-handler.js
+++ b/server/router/routes/workflow-archived-list-handler.js
@@ -40,19 +40,19 @@ const workflowArchivedListHandler = async ctx => {
     queryString = buildQueryString(startTime, endTime, query);
   }
 
-  const archivedWorkflowResponse = await ctx.cadence.archivedWorkflows({
+  const archivedWorkflowsResponse = await ctx.cadence.archivedWorkflows({
     query: queryString,
     nextPageToken: nextPageToken
       ? Buffer.from(nextPageToken, 'base64')
       : undefined,
   });
 
-  archivedWorkflowResponse.executions = injectDomainIntoWorkflowList(
+  archivedWorkflowsResponse.executions = injectDomainIntoWorkflowList(
     params.domain,
-    archivedWorkflowResponse
+    archivedWorkflowsResponse
   );
 
-  ctx.body = archivedWorkflowResponse;
+  ctx.body = archivedWorkflowsResponse;
 };
 
 module.exports = workflowArchivedListHandler;

--- a/server/router/routes/workflow-archived-list-handler.js
+++ b/server/router/routes/workflow-archived-list-handler.js
@@ -24,6 +24,7 @@ const { buildQueryString } = require('../helpers');
 
 const workflowArchivedListHandler = async ctx => {
   const { nextPageToken, ...query } = ctx.query || {};
+  const { params = {} } = ctx;
   let queryString;
 
   if (query.queryString) {
@@ -36,12 +37,21 @@ const workflowArchivedListHandler = async ctx => {
     queryString = buildQueryString(startTime, endTime, query);
   }
 
-  ctx.body = await ctx.cadence.archivedWorkflows({
+  const archivedWorkflowResponse = await ctx.cadence.archivedWorkflows({
     query: queryString,
     nextPageToken: nextPageToken
       ? Buffer.from(nextPageToken, 'base64')
       : undefined,
   });
+
+  archivedWorkflowResponse.executions = archivedWorkflowResponse.executions.map(
+    execution => ({
+      ...execution,
+      domainName: params.domain,
+    })
+  );
+
+  ctx.body = archivedWorkflowResponse;
 };
 
 module.exports = workflowArchivedListHandler;

--- a/server/router/routes/workflow-archived-list-handler.js
+++ b/server/router/routes/workflow-archived-list-handler.js
@@ -20,7 +20,10 @@
 // THE SOFTWARE.
 
 const moment = require('moment');
-const { buildQueryString } = require('../helpers');
+const {
+  buildQueryString,
+  injectDomainIntoWorkflowList,
+} = require('../helpers');
 
 const workflowArchivedListHandler = async ctx => {
   const { nextPageToken, ...query } = ctx.query || {};
@@ -44,11 +47,9 @@ const workflowArchivedListHandler = async ctx => {
       : undefined,
   });
 
-  archivedWorkflowResponse.executions = archivedWorkflowResponse.executions.map(
-    execution => ({
-      ...execution,
-      domainName: params.domain,
-    })
+  archivedWorkflowResponse.executions = injectDomainIntoWorkflowList(
+    params.domain,
+    archivedWorkflowResponse
   );
 
   ctx.body = archivedWorkflowResponse;

--- a/server/router/routes/workflow-list-handler.js
+++ b/server/router/routes/workflow-list-handler.js
@@ -21,13 +21,23 @@
 
 const workflowListHandler = async ctx => {
   const q = ctx.query || {};
+  const { params = {} } = ctx;
 
-  ctx.body = await ctx.cadence.listWorkflows({
+  const listWorkflowsResponse = await ctx.cadence.listWorkflows({
     query: q.queryString || undefined,
     nextPageToken: q.nextPageToken
       ? Buffer.from(q.nextPageToken, 'base64')
       : undefined,
   });
+
+  listWorkflowsResponse.executions = listWorkflowsResponse.executions.map(
+    execution => ({
+      ...execution,
+      domainName: params.domain,
+    })
+  );
+
+  ctx.body = listWorkflowsResponse;
 };
 
 module.exports = workflowListHandler;

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -31,6 +31,7 @@ describe('Listing Workflows', function() {
       startTime: dateToLong('2017-11-10T21:30:00.000Z'),
       closeTime: null,
       closeStatus: null,
+      domainName: 'canary',
       historyLength: null,
       isCron: null,
       autoResetPoints: null,


### PR DESCRIPTION
### Added
- injecting `domainName` from request into workflow list (Open, Closed, List, Archival APIs) response. This will be needed in order to list multiple domains' workflows within the workflow list (basic, advanced, archival) screen in order to navigate to that workflow.

### Screenshots
<img width="1251" alt="Screen Shot 2021-07-29 at 3 22 09 PM" src="https://user-images.githubusercontent.com/58960161/127573244-a192b0e0-aad3-45f9-ba2f-8f62e87ceeb4.png">
