### PR TITLE
 Implement auth using admin JWT token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Set these environment variables if you need to change their defaults
 | CADENCE_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI  |                |
 | ENABLE_AUTH          | Enable auth feature                                | false             |
 | AUTH_TYPE          | concurrently supports ADMIN_JWT                      | ''                |
-| AUTH_ADMIN_JWT_PRIVATE_KEY          | JWT signing private key for ADMIN_JWT type  | 8088      |
+| AUTH_ADMIN_JWT_PRIVATE_KEY          | JWT signing private key for ADMIN_JWT type  | ''        |
 
 ### Running locally
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Set these environment variables if you need to change their defaults
 | CADENCE_TCHANNEL_PEERS    | Comma-delmited list of tchannel peers         | 127.0.0.1:7933    |
 | CADENCE_TCHANNEL_SERVICE  | Name of the cadence tchannel service to call  | cadence-frontend  |
 | CADENCE_WEB_PORT          | HTTP port to serve on                         | 8088              |
-| CADENCE_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI  |                   |
+| CADENCE_EXTERNAL_SCRIPTS     | Addtional JavaScript tags to serve in the UI  |                |
+| ENABLE_AUTH          | Enable auth feature                                | false             |
+| AUTH_TYPE          | concurrently supports ADMIN_JWT                      | ''                |
+| AUTH_ADMIN_JWT_PRIVATE_KEY          | JWT signing private key for ADMIN_JWT type  | 8088      |
 
 ### Running locally
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3027,6 +3027,11 @@
       "resolved": "https://unpm.uberinternal.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://unpm.uberinternal.com/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -4440,6 +4445,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -8121,6 +8134,23 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://unpm.uberinternal.com/jsprim/-/jsprim-1.4.1.tgz",
@@ -8141,6 +8171,25 @@
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keygrip": {
@@ -8524,15 +8573,50 @@
       "resolved": "https://unpm.uberinternal.com/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://unpm.uberinternal.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://unpm.uberinternal.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "html-webpack-plugin": "^2.30.1",
     "html-webpack-template": "^6.1.0",
     "is-ipv4-node": "^1.0.6",
+    "jsonwebtoken": "^8.5.1",
     "koa": "^2.3.0",
     "koa-better-error-handler": "^1.3.0",
     "koa-bodyparser": "^4.2.0",

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,9 @@ app.init = function({
   serviceName = process.env.CADENCE_TCHANNEL_SERVICE || SERVICE_NAME_DEFAULT,
   timeout = REQUEST_TIMEOUT_DEFAULT,
   useWebpack = process.env.NODE_ENV !== 'production',
+  enableAuth = process.env.ENABLE_AUTH === 'enabled',
+  authType = process.env.AUTH_TYPE,
+  authAdminJwtPrivateKey = process.env.AUTH_ADMIN_JWT_PRIVATE_KEY,
 } = {}) {
   const requestConfig = {
     retryFlags,
@@ -96,15 +99,11 @@ app.init = function({
       })
     )
     .use(async function(ctx, next) {
-      if (
-        process.env.ENABLE_AUTH &&
-        process.env.AUTH_TYPE === 'ADMIN_JWT' &&
-        process.env.AUTH_ADMIN_JWT_PRIVATE_KEY
-      ) {
+      if (enableAuth && authType === 'ADMIN_JWT' && authAdminJwtPrivateKey) {
         ctx.authTokenHeaders = ctx.authTokenHeaders || {};
         const token = jwt.sign(
           { admin: true, ttl: 10 },
-          process.env.AUTH_ADMIN_JWT_PRIVATE_KEY,
+          authAdminJwtPrivateKey,
           {
             algorithm: 'RS256',
           }

--- a/server/index.js
+++ b/server/index.js
@@ -55,7 +55,7 @@ app.init = function({
   serviceName = process.env.CADENCE_TCHANNEL_SERVICE || SERVICE_NAME_DEFAULT,
   timeout = REQUEST_TIMEOUT_DEFAULT,
   useWebpack = process.env.NODE_ENV !== 'production',
-  enableAuth = process.env.ENABLE_AUTH === 'enabled',
+  enableAuth = process.env.ENABLE_AUTH === 'true',
   authType = process.env.AUTH_TYPE,
   authAdminJwtPrivateKey = process.env.AUTH_ADMIN_JWT_PRIVATE_KEY,
 } = {}) {

--- a/server/index.js
+++ b/server/index.js
@@ -94,12 +94,20 @@ app.init = function({
         filter: contentType => !contentType.startsWith('text/event-stream'),
       })
     )
-    // this doesn't work
-    //.use(async function(ctx) {
-    //   ctx.authTokenHeaders = {
-    //     'token-name': ctx.headers['token-injected'],
-    //   };
-    // })
+    .use(async function(ctx, next) {
+      //ctx.authTokenHeaders = { 'token-name': ctx.headers['token-injected'] };
+      if (
+        process.env.ENABLE_AUTH &&
+        process.env.AUTH_TYPE === 'ADMIN_JWT' &&
+        process.env.AUTH_ADMIN_JWT_PRIVATE_KEY
+      ) {
+        ctx.authTokenHeaders['cadence-authorization'] = '1234';
+        // TODO use auth0 library to create an admin token like https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
+        console.log(ctx, 'hahahahah');
+      }
+
+      await next();
+    })
     .use(tchannelClient({ peers, requestConfig }))
     .use(
       useWebpack

--- a/server/index.js
+++ b/server/index.js
@@ -101,6 +101,7 @@ app.init = function({
         process.env.AUTH_TYPE === 'ADMIN_JWT' &&
         process.env.AUTH_ADMIN_JWT_PRIVATE_KEY
       ) {
+        ctx.authTokenHeaders = ctx.authTokenHeaders || {};
         ctx.authTokenHeaders['cadence-authorization'] = '1234';
         // TODO use auth0 library to create an admin token like https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
         console.log(ctx, 'hahahahah');

--- a/server/index.js
+++ b/server/index.js
@@ -94,6 +94,12 @@ app.init = function({
         filter: contentType => !contentType.startsWith('text/event-stream'),
       })
     )
+    // this doesn't work
+    //.use(async function(ctx) {
+    //   ctx.authTokenHeaders = {
+    //     'token-name': ctx.headers['token-injected'],
+    //   };
+    // })
     .use(tchannelClient({ peers, requestConfig }))
     .use(
       useWebpack

--- a/server/middleware/tchannel-client/index.js
+++ b/server/middleware/tchannel-client/index.js
@@ -39,15 +39,6 @@ const tchannelClient = ({ peers, requestConfig }) =>
   async function(ctx, next) {
     const { authTokenHeaders = {} } = ctx;
 
-    if (
-      process.env.ENABLE_AUTH &&
-      process.env.AUTH_TYPE === 'ADMIN_JWT' &&
-      process.env.AUTH_ADMIN_JWT_PRIVATE_KEY
-    ) {
-      authTokenHeaders['cadence-authorization'] = '1234';
-      // TODO use auth0 library to create an admin token like https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
-    }
-
     const client = TChannel();
     const channels = await makeChannels({ client, peers });
     const request = makeRequest({

--- a/server/middleware/tchannel-client/index.js
+++ b/server/middleware/tchannel-client/index.js
@@ -39,6 +39,15 @@ const tchannelClient = ({ peers, requestConfig }) =>
   async function(ctx, next) {
     const { authTokenHeaders = {} } = ctx;
 
+    if (
+      process.env.ENABLE_AUTH &&
+      process.env.AUTH_TYPE === 'ADMIN_JWT' &&
+      process.env.AUTH_ADMIN_JWT_PRIVATE_KEY
+    ) {
+      authTokenHeaders['cadence-authorization'] = '1234';
+      // TODO use auth0 library to create an admin token like https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
+    }
+
     const client = TChannel();
     const channels = await makeChannels({ client, peers });
     const request = makeRequest({


### PR DESCRIPTION
For https://docs.google.com/document/d/1a-Xo9FSCLubYlIQHB_eX5j4Yv2GDv_82J94At2dAL3o/edit#

This is to let users without OICD to use cadence server with OAuth enabled, similar to https://github.com/uber/cadence-java-client/blob/master/src/main/java/com/uber/cadence/serviceclient/auth/AdminJwtAuthorizationProvider.java
and 
https://github.com/uber-go/cadence-client/blob/master/internal/jwt_authorization.go

Tested locally with OAuth enabled:

```
(qlong-auth-token) $ENABLE_AUTH=true AUTH_TYPE=ADMIN_JWT AUTH_ADMIN_JWT_PRIVATE_KEY=`cat ~/cadence/config/credentials/keytest`  npm run dev
..
```
![Screen Shot 2021-09-09 at 12 02 33 PM](https://user-images.githubusercontent.com/4523955/132747288-62ed8742-d182-4750-a729-f1b69569f390.png)

