### PR TITLE
Release/3.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.29.0-beta.0",
+  "version": "3.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.7",
+  "version": "3.29.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.29.0-beta.0",
+  "version": "3.29.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.28.7",
+  "version": "3.29.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
Cross region support allows the user to navigate to one URL and access both data centers. Simply search for a domain and the application will take the user to the active region. Clicking on the Active tag will allow the user to switch to the passive region if the domain is global.

### Added
- cross region support 
  - #404 
  - #405
  - #406
  - #407
  - #408
  - #411
  - #414
  - #415
  - #417
  - #418
  - #419
  - #420
  - #421

### Fixed
- babel lint 
  - #403

### Screenshots
<img width="625" alt="140197269-0a3373af-c30b-41a0-b029-ae99179b7c9e" src="https://user-images.githubusercontent.com/58960161/140835032-7557e131-5b55-4f37-bf78-2a66dc8d5d55.png">

<img width="625" alt="140197285-58dfce94-42b4-4b40-9187-ee365c2cc6ea" src="https://user-images.githubusercontent.com/58960161/140835037-550abb1f-95a6-40f8-83d3-33f11a3cfcb0.png">


