### PR TITLE
Fix/Cross region global single cluster

### DIFF
--- a/client/containers/domain-autocomplete/actions.js
+++ b/client/containers/domain-autocomplete/actions.js
@@ -118,9 +118,10 @@ const actions = {
     );
 
     if (
-      value.isGlobalDomain ||
       !allowedCrossOrigin ||
-      !value.replicationConfiguration
+      !value.replicationConfiguration ||
+      (value.isGlobalDomain &&
+        value.replicationConfiguration.clusters.length > 1)
     ) {
       return dispatchToGlobalRoute();
     }


### PR DESCRIPTION
### Changed
- Added a check for cluster length when navigating user to domain from domain autocomplete. Global domains with a single cluster will be treated like a local domain.