### PR TITLE
Fix/workflow history loading spinner

### DIFF
--- a/client/containers/workflow/component.vue
+++ b/client/containers/workflow/component.vue
@@ -325,8 +325,12 @@ export default {
   <section
     class="execution"
     :class="{
-      loading: wfLoading || history.loading,
-      ready: !wfLoading && !history.loading,
+      loading:
+        wfLoading ||
+        (history.loading && (!historyEvents || !historyEvents.length)),
+      ready:
+        !wfLoading &&
+        (!history.loading || (historyEvents && historyEvents.length)),
     }"
   >
     <navigation-bar>

--- a/client/containers/workflow/component.vue
+++ b/client/containers/workflow/component.vue
@@ -328,9 +328,7 @@ export default {
       loading:
         wfLoading ||
         (history.loading && (!historyEvents || !historyEvents.length)),
-      ready:
-        !wfLoading &&
-        (!history.loading || (historyEvents && historyEvents.length)),
+      ready: !wfLoading && !history.loading,
     }"
   >
     <navigation-bar>


### PR DESCRIPTION
### Fixed
- bug introduced in latest release where loading spinner would continue to show on open workflows until it completed