### PR TITLE
Fix/domain region caching

### DIFF
--- a/client/store/index.js
+++ b/client/store/index.js
@@ -110,8 +110,9 @@ const getStoreConfig = ({ router, state }) => {
         return;
       }
 
-      // ensures cross region does not persist to local storage.
+      // ensures these states do not persist to local storage.
       const crossRegion = getCrossRegionDefaultState();
+      const domain = getDomainDefaultState();
 
       const domainAutocomplete = domainAutocompleteReducer(
         state.domainAutocomplete
@@ -119,10 +120,11 @@ const getStoreConfig = ({ router, state }) => {
 
       return {
         ...state,
+        crossRegion,
+        domain,
         ...(domainAutocomplete && {
           domainAutocomplete,
         }),
-        crossRegion,
       };
     },
     storage: window.localStorage,


### PR DESCRIPTION
If a user fails over a domain, in the current way the application will continue to show the active status in the other region. This can confuse users so have decided to not cache this information when a browser refreshes. That way if a user tries to refresh the page, they will see up-to-date information of the cluster active status.

### Changed
- stopping domain store from restoring its state from local storage