### PR TITLE
Fix/news height

### DIFF
--- a/client/routes/index.vue
+++ b/client/routes/index.vue
@@ -39,7 +39,7 @@ export default {
 </script>
 
 <template>
-  <section>
+  <section class="window">
     <navigation-bar>
       <navigation-link
         :exact="true"
@@ -64,4 +64,10 @@ export default {
   </section>
 </template>
 
-<style lang="stylus"></style>
+<style lang="stylus">
+.window {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+</style>

--- a/client/routes/news/index.vue
+++ b/client/routes/news/index.vue
@@ -161,7 +161,7 @@ export default {
 
 <style lang="stylus">
 section.news {
-  height: 100%;
+  flex: 1;
 
   iframe {
     height: 100%


### PR DESCRIPTION
### Fixed
- Added window class to ensure flexbox is working for news page

### Screenshots
#### After
<img width="1680" alt="Screen Shot 2021-11-30 at 4 55 42 PM" src="https://user-images.githubusercontent.com/58960161/144152658-0cca0120-d6b8-4ae9-97ea-3577badfa7d1.png">

#### Before
<img width="1680" alt="Screen Shot 2021-11-30 at 4 54 59 PM" src="https://user-images.githubusercontent.com/58960161/144152680-d543b0fd-fef9-40fa-8be8-179dc187ac16.png">
