### PR TITLE
Update timezone library for cadence-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9376,9 +9376,9 @@
       "integrity": "sha1-sr52n6MZQL6e7qZGnAdeNQBvo9M="
     },
     "moment-timezone": {
-      "version": "0.5.32",
-      "resolved": "https://unpm.uberinternal.com/moment-timezone/-/moment-timezone-0.5.32.tgz",
-      "integrity": "sha1-23Z3zDzGgP0wMD69kLDaHKDf7MI=",
+      "version": "0.5.34",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
+      "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "mocha": "^4.0.1",
     "mocha-chrome": "^1.1.0",
     "mockdate": "^3.0.5",
-    "moment-timezone": "^0.5.32",
+    "moment-timezone": "^0.5.34",
     "nathanboktae-browser-test-utils": "^0.1.0",
     "node-abort-controller": "^1.0.4",
     "prettier": "^1.19.1",


### PR DESCRIPTION
this update contains 2021e - https://www.iana.org/time-zones

https://github.com/moment/moment-timezone/commit/877c86344f3f230e1bf5881253c29f89e39fe3d2