### PR TITLE
v3.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.29.6",
+  "version": "3.30.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.30.0-beta.0",
+  "version": "3.30.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.29.6",
+  "version": "3.30.0-beta.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.30.0-beta.0",
+  "version": "3.30.0",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
## What's Changed
* fixing copyright headers for 2022 by @just-at-uber in https://github.com/uber/cadence-web/pull/454
* Update package lock by @just-at-uber in https://github.com/uber/cadence-web/pull/453
* Fixing eslint-plugin-header version in package-lock by @just-at-uber in https://github.com/uber/cadence-web/pull/457
* Upgrade to Node 16 Gallium with Debian Bullseye by @WToma in https://github.com/uber/cadence-web/pull/452
* Update timezone library for cadence-web by @just-at-uber in https://github.com/uber/cadence-web/pull/458

## New Contributors
* @WToma made their first contribution in https://github.com/uber/cadence-web/pull/452

**Full Changelog**: https://github.com/uber/cadence-web/compare/v3.29.6...v3.30.0