### PR TITLE
Removing security vulnerability

### DIFF
--- a/client/routes/help/index.vue
+++ b/client/routes/help/index.vue
@@ -188,15 +188,6 @@ export default {
           Ask a question on Stack Overflow
         </a>
       </div>
-      <div>
-        <a
-          href="https://groups.google.com/d/forum/cadence-discussion"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Join our discussion group
-        </a>
-      </div>
       <div v-if="!hideSlack">
         <a
           href="https://join.slack.com/t/uber-cadence/shared_invite/enQtNDczNTgxMjYxNDEzLTQyYjcxZDM2YTIxMTZkMzQ0NjgxYmI3OWY5ODhiOTliM2I5MzA4NTM4MjU4YzgzZDkwNGEzOTUzNTBlNDk3Yjc"


### PR DESCRIPTION
Removed link which is pointing to a google group which is not owned by Cadence team.

**After:**
<img width="819" alt="Screen Shot 2022-05-16 at 1 12 49 PM" src="https://user-images.githubusercontent.com/58960161/168675380-050ce75c-8501-4727-b8f3-ad4b2716c769.png">

**Before:**
<img width="1451" alt="Screen Shot 2022-05-16 at 1 15 35 PM" src="https://user-images.githubusercontent.com/58960161/168675408-803c436a-66fd-47cf-83fe-2ff9971edc22.png">

<img width="1284" alt="Screen Shot 2022-05-16 at 12 58 34 PM" src="https://user-images.githubusercontent.com/58960161/168675423-5382e65b-375b-45ff-81f8-0a57bd63969d.png">

