### PR TITLE
Fix/dropdown accessibility

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -437,6 +437,8 @@ header.top-bar
   }
 
   .environment-select {
+    color: #000;
+
     .vs__dropdown-toggle {
       border-color: transparent;
     }

--- a/client/containers/active-status/component.vue
+++ b/client/containers/active-status/component.vue
@@ -81,8 +81,12 @@ export default {
 <style lang="stylus">
 @require "../../styles/definitions"
 
+span.active-status {
+  color: white;
+}
+
 .active-status {
-  color: white !important;
+  color: #000;
   padding: 5px 10px;
   text-transform: uppercase;
 

--- a/client/containers/domain-autocomplete/component.vue
+++ b/client/containers/domain-autocomplete/component.vue
@@ -105,6 +105,7 @@ export default {
 @require "../../styles/base.styl"
 
 .domain-autocomplete {
+  color: #000;
   width: 100%;
 
   .navigate-to-domain {


### PR DESCRIPTION
When upgrading vue-select library in a previous patch release it broke styling for a few dropdowns in the app.
These changes should help fix accessibility issues with the dropdowns.

### Screenshots

#### Environment select
##### After
<img width="1044" alt="Screen Shot 2022-05-19 at 3 08 33 PM" src="https://user-images.githubusercontent.com/58960161/169413124-b073312d-2bd4-4e99-a2e1-d49141586d6d.png">

##### Before
<img width="1027" alt="Screen Shot 2022-05-19 at 3 09 36 PM" src="https://user-images.githubusercontent.com/58960161/169413158-a7e92724-12bd-4587-bb5e-eb53aacb1ad1.png">

#### Domain autocomplete
##### After
<img width="872" alt="Screen Shot 2022-05-19 at 3 14 38 PM" src="https://user-images.githubusercontent.com/58960161/169413332-9fbf809b-149e-4d74-9278-100a4d728d1b.png">

##### Before
<img width="1041" alt="Screen Shot 2022-05-19 at 3 09 41 PM" src="https://user-images.githubusercontent.com/58960161/169413352-4c664c5f-7fdf-497a-8fcb-dd6483d9644b.png">

#### Active status
##### After
<img width="1022" alt="Screen Shot 2022-05-19 at 3 08 58 PM" src="https://user-images.githubusercontent.com/58960161/169413380-638eccea-2b6a-4938-b977-7ee2ea9720ec.png">

##### Before
<img width="1049" alt="Screen Shot 2022-05-19 at 3 09 46 PM" src="https://user-images.githubusercontent.com/58960161/169413408-b530feb7-3a8a-437f-be67-577ff4991efb.png">
