### PR TITLE
Fix/idl proto issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:gallium-bullseye AS BUILD_IMAGE
+FROM node:fermium-bullseye AS BUILD_IMAGE
 
 ### Build step ###
 WORKDIR /usr/build
@@ -13,7 +13,7 @@ RUN npm install --production --unsafe-perm
 RUN npm run build-production
 
 # switch to lite version of node
-FROM node:gallium-bullseye-slim
+FROM node:fermium-bullseye-slim
 
 ### Run step ###
 WORKDIR /usr/app

--- a/server/middleware/grpc-client/grpc-service.js
+++ b/server/middleware/grpc-client/grpc-service.js
@@ -27,7 +27,7 @@ const { formatRequestDefault } = require('./format-request');
 const { formatResponseDefault } = require('./format-response');
 const { transformDefault } = require('./transform');
 
-const BASE_PATH = path.resolve('./server/idl/proto');
+const BASE_PATH = path.join(__dirname, '../../idl/proto');
 const MAX_MESSAGE_SIZE = 64 * 1024 * 1024;
 const GRPC_OPTIONS = {
   'grpc.max_send_message_length': MAX_MESSAGE_SIZE,


### PR DESCRIPTION
### Fixed
- Downgrading docker node version to v14 to avoid E401 unauthorized error. (Fixes #464)
- `.proto` files not resolving in production build due to absolute pathing. Resolved by changing to relative pathing.