### PR TITLE
Add feature-flag config for defaultDateRange

### DIFF
--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -76,6 +76,10 @@ export default {
       value: false,
     },
     {
+      key: 'defaultDateRange',
+      value: 30,
+    },
+    {
       key: 'domainAuthorization',
       value: false,
     },

--- a/server/feature-flags.json
+++ b/server/feature-flags.json
@@ -16,6 +16,10 @@
     "value": []
   },
   {
+    "key": "defaultDateRange",
+    "value": 30
+  },
+  {
     "key": "domainAuthorization",
     "value": true
   },


### PR DESCRIPTION
Make default date range configurable. Instead of using 30 days. This should reduce load heavily loaded ES clusters.