### PR TITLE
Removing the feature where the UI moved up while clicking on an event

### DIFF
--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -52,8 +52,7 @@ export default {
         'elapsed',
       compactDetails:
         localStorage.getItem(`${this.domain}:history-compact-details`) ===
-        'true',
-      scrolledToEventOnInit: false,
+        'true',      
       splitEnabled: false,
       eventType: 'All',
       eventTypes: [
@@ -310,19 +309,6 @@ export default {
     },
   },
   watch: {
-    eventId(eventId) {
-      this.scrollEventIntoView(eventId);
-    },
-    filteredEvents() {
-      if (
-        !this.scrolledToEventOnInit &&
-        this.eventId !== undefined &&
-        this.filteredEventIdToIndex[this.eventId] !== undefined
-      ) {
-        this.scrolledToEventOnInit = true;
-        setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
-      }
-    },
     graphView() {
       this.setSplitSize();
     },

--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -52,7 +52,7 @@ export default {
         'elapsed',
       compactDetails:
         localStorage.getItem(`${this.domain}:history-compact-details`) ===
-        'true',      
+        'true',
       splitEnabled: false,
       eventType: 'All',
       eventTypes: [


### PR DESCRIPTION
Currently the Cadence UI scrolls up when a particular event is clicked on. Some of the users have conveyed that this is an annoying experience. So this pull request removes that feature.