### PR TITLE
Enhance empty workflows message

### DIFF
--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -25,7 +25,7 @@ import NoResults from './no-results';
 
 export default {
   name: 'workflow-grid',
-  props: ['workflows', 'loading'],
+  props: ['workflows', 'loading','noResultsText'],
   data() {
     return {
       nextPageToken: undefined,
@@ -63,7 +63,7 @@ export default {
       <div class="col col-end">End Time</div>
     </div>
     <div class="spacer" />
-    <no-results :results="workflows" v-if="!loading" />
+    <no-results :results="workflows" v-if="!loading" :message="noResultsText" />
     <RecycleScroller
       key-field="uniqueId"
       :items="workflows"

--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -25,7 +25,7 @@ import NoResults from './no-results';
 
 export default {
   name: 'workflow-grid',
-  props: ['workflows', 'loading','noResultsText'],
+  props: ['workflows', 'loading', 'noResultsText'],
   data() {
     return {
       nextPageToken: undefined,

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -214,8 +214,8 @@ export default {
     noResultsMessageText() {
       const { status, workflowId, workflowName, startTime, endTime } =
         this.$route.query || {};
-
-      if (status !== STATUS_ALL || workflowId || workflowName) {
+      console.log(this.$route.query)
+      if ((status && status !== STATUS_ALL) || workflowId || workflowName) {
         return `No workflows for the selected filters`;
       }
 

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -196,10 +196,10 @@ export default {
       }
 
       return query.startTime && query.endTime
-        ? {
-          startTime: moment(query.startTime),
-          endTime: moment(query.endTime),
-        }
+      ? {
+            startTime: moment(query.startTime),
+            endTime: moment(query.endTime),
+          }
         : query.range;
     },
     startTime() {

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -22,6 +22,7 @@
 
 import moment from 'moment';
 import debounce from 'lodash-es/debounce';
+import lowerCase from 'lodash-es/lowerCase';
 import {
   IS_CRON_LIST,
   FILTER_MODE_ADVANCED,
@@ -196,9 +197,9 @@ export default {
 
       return query.startTime && query.endTime
         ? {
-            startTime: moment(query.startTime),
-            endTime: moment(query.endTime),
-          }
+          startTime: moment(query.startTime),
+          endTime: moment(query.endTime),
+        }
         : query.range;
     },
     startTime() {
@@ -209,6 +210,14 @@ export default {
       }
 
       return getStartTimeIsoString(range, startTime);
+    },
+    noResultsMessageText() {
+      const { status, workflowId, workflowName, startTime,endTime} = this.$route.query || {};
+
+      if (status !== STATUS_ALL || workflowId || workflowName) return `No workflows for the selected filters`;
+      if (typeof this.range === "string") return `No workflows within ${lowerCase(this.range)}`;
+      if (startTime && endTime) return `No workflows within selected period`;
+      return "No Results"
     },
     crossRegionProps() {
       const { clusterName, domain } = this;
@@ -597,6 +606,7 @@ export default {
     <error-message :error="error" />
     <workflow-grid
       :workflows="formattedResults"
+      :noResultsText="noResultsMessageText" 
       :loading="loading"
       @onScroll="onWorkflowGridScroll"
       v-if="!error"

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -212,12 +212,22 @@ export default {
       return getStartTimeIsoString(range, startTime);
     },
     noResultsMessageText() {
-      const { status, workflowId, workflowName, startTime,endTime} = this.$route.query || {};
+      const { status, workflowId, workflowName, startTime, endTime } =
+        this.$route.query || {};
 
-      if (status !== STATUS_ALL || workflowId || workflowName) return `No workflows for the selected filters`;
-      if (typeof this.range === "string") return `No workflows within ${lowerCase(this.range)}`;
-      if (startTime && endTime) return `No workflows within selected period`;
-      return "No Results"
+      if (status !== STATUS_ALL || workflowId || workflowName) {
+        return `No workflows for the selected filters`;
+      }
+
+      if (typeof this.range === 'string') {
+        return `No workflows within ${lowerCase(this.range)}`;
+      }
+
+      if (startTime && endTime) {
+        return `No workflows within selected period`;
+      }
+
+      return 'No Results';
     },
     crossRegionProps() {
       const { clusterName, domain } = this;
@@ -606,7 +616,7 @@ export default {
     <error-message :error="error" />
     <workflow-grid
       :workflows="formattedResults"
-      :noResultsText="noResultsMessageText" 
+      :noResultsText="noResultsMessageText"
       :loading="loading"
       @onScroll="onWorkflowGridScroll"
       v-if="!error"

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -196,7 +196,7 @@ export default {
       }
 
       return query.startTime && query.endTime
-      ? {
+        ? {
             startTime: moment(query.startTime),
             endTime: moment(query.endTime),
           }

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -214,7 +214,7 @@ export default {
     noResultsMessageText() {
       const { status, workflowId, workflowName, startTime, endTime } =
         this.$route.query || {};
-      console.log(this.$route.query)
+
       if ((status && status !== STATUS_ALL) || workflowId || workflowName) {
         return `No workflows for the selected filters`;
       }


### PR DESCRIPTION
Changing empty workflow message to take in account selected filters.
This would avoid users confusion that can happen when there are no workflows because of their selected filters.

Screenshots from the updated messages:
![Screenshot 2023-07-20 at 11 30 50](https://github.com/uber/cadence-web/assets/137278762/b26257bc-be79-46e9-af89-7e724f2d2c9f)
![Screenshot 2023-07-20 at 11 30 28](https://github.com/uber/cadence-web/assets/137278762/0094e224-0253-4a49-92e2-8d787d760868)

