### PR TITLE
Better scrolling for workflows list

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -453,15 +453,15 @@ header.top-bar
       font-weight: bold;
     }
   }
-
-body, main
+html, body
   height 100%
-main
-  position absolute
-  width 100%
+body, main
   display flex
   flex-direction column
-
+body
+  overscroll-behavior: none;
+main
+  flex:1
 main
   > section
     display flex

--- a/client/App.vue
+++ b/client/App.vue
@@ -453,15 +453,19 @@ header.top-bar
       font-weight: bold;
     }
   }
-html, body
-  height 100%
-body, main
-  display flex
-  flex-direction column
-body
+html, body {
+  height: 100%;
+}
+body, main {
+  display: flex;
+  flex-direction: column;
+}
+body {
   overscroll-behavior: none;
-main
+}
+main {
   flex:1
+}
 main
   > section
     display flex

--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -53,7 +53,7 @@ export default {
 </script>
 
 <template>
-  <section class="workflow-grid" :class="{ loading }">
+  <section class="workflow-grid-wrapper" :class="{ loading }">
     <div class="row-header">
       <div class="col col-id">Workflow ID</div>
       <div class="col col-link">Run ID</div>
@@ -107,9 +107,11 @@ export default {
 
 paged-grid();
 
-.workflow-grid {
-  height: calc(100vh - 203px);
-
+.workflow-grid-wrapper{
+  display: flex;
+  flex:1;
+  flex-direction: column;
+  min-width: 1000px;
   &.loading.has-results::after {
     content: none;
   }
@@ -192,5 +194,8 @@ paged-grid();
       width: 170px;
     }
   }
+}
+.workflow-grid {
+  flex:1 1 400px;
 }
 </style>

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -609,8 +609,8 @@ export default {
 
 section.workflow-list
   display: flex;
-  flex: auto;
   flex-direction: column;
+  flex: 1;
 
   &.loading section.results table
     opacity 0.7

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -65,7 +65,7 @@ describe('Workflow list', () => {
       .querySelector('[data-cy="status-filter"] .vs__selected')
       .should.contain.text('All');
 
-    await resultsEl.waitUntilExists('.workflow-grid-wrapper.ready');
+    await resultsEl.waitUntilExists('.workflow-grid.ready');
 
     resultsEl
       .textNodes('.row-header > div')

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -57,13 +57,15 @@ describe('Workflow list', () => {
 
   it('should query for all workflows and show the results in a grid', async function test() {
     const [workflowsEl] = await workflowsTest(this.test);
-    const resultsEl = workflowsEl.querySelector('section.workflow-grid');
+    const resultsEl = workflowsEl.querySelector(
+      'section.workflow-grid-wrapper'
+    );
 
     workflowsEl
       .querySelector('[data-cy="status-filter"] .vs__selected')
       .should.contain.text('All');
 
-    await resultsEl.waitUntilExists('.workflow-grid.ready');
+    await resultsEl.waitUntilExists('.workflow-grid-wrapper.ready');
 
     resultsEl
       .textNodes('.row-header > div')
@@ -208,7 +210,9 @@ describe('Workflow list', () => {
 
     await retry(() =>
       testEl
-        .querySelectorAll('section.workflow-list section.workflow-grid .row')
+        .querySelectorAll(
+          'section.workflow-list section.workflow-grid-wrapper .row'
+        )
         .should.have.length(1)
     );
     await Promise.delay(50);
@@ -243,7 +247,9 @@ describe('Workflow list', () => {
 
     await retry(() =>
       workflowsEl
-        .textNodes('section.workflow-list section.workflow-grid .row .col-id')
+        .textNodes(
+          'section.workflow-list section.workflow-grid-wrapper .row .col-id'
+        )
         .should.deep.equal(['demoWfId'])
     );
   });
@@ -267,7 +273,9 @@ describe('Workflow list', () => {
 
     await retry(() =>
       workflowsEl
-        .textNodes('section.workflow-list section.workflow-grid .row .col-id')
+        .textNodes(
+          'section.workflow-list section.workflow-grid-wrapper .row .col-id'
+        )
         .should.deep.equal(['demoWfId'])
     );
   });
@@ -311,7 +319,9 @@ describe('Workflow list', () => {
 
     await retry(() =>
       workflowsEl
-        .textNodes('section.workflow-list section.workflow-grid .row .col-name')
+        .textNodes(
+          'section.workflow-list section.workflow-grid-wrapper .row .col-name'
+        )
         .should.deep.equal(['demo'])
     );
   });
@@ -337,7 +347,7 @@ describe('Workflow list', () => {
     await retry(() => {
       workflowsEl.querySelector('div.no-results').should.be.displayed;
       workflowsEl
-        .querySelector('section.workflow-grid')
+        .querySelector('section.workflow-grid-wrapper')
         .should.not.contain('.results');
     });
   });


### PR DESCRIPTION
The goal from this Changes was to add a horizontal scrollbar to be able to read the workflows table on narrow screens.
While working on that there was multiple issues with the existing scrollbars that made placing a new scroll bar harder.
So here are the fixes that is made to the scrollbars:
- Scrollbars always showing 
![Screenshot 2023-07-19 at 16 02 37](https://github.com/uber/cadence-web/assets/137278762/e8682202-8f60-4ece-be61-4d588bdd3754)
- Double scrollbars always showing
![Screenshot 2023-07-19 at 16 07 25](https://github.com/uber/cadence-web/assets/137278762/52780ef0-2d64-4fef-9aea-d4bd60e5cb51)
- Scrolling the workflows pulls down the complete page (some bounce effect)
- extra space at the bottom
![Screenshot 2023-07-20 at 11 09 43](https://github.com/uber/cadence-web/assets/137278762/e235eaea-c179-4ca8-80ba-0867c9b2f6ec)


This PR fixes all the above + add a horizontal scrollbar for workflows page if page is smaller than 1000px
This is how it looks now:
![Screenshot 2023-07-20 at 11 08 34](https://github.com/uber/cadence-web/assets/137278762/f586d87d-fd9d-472d-93ee-b23fe5148d56)
