### PR TITLE
[cadence-tools] add meta data to grpc calls

### DIFF
--- a/server/middleware/grpc-client/grpc-service.js
+++ b/server/middleware/grpc-client/grpc-service.js
@@ -118,6 +118,10 @@ class GRPCService {
     meta.add('rpc-caller', 'cadence-ui');
     meta.add('rpc-encoding', 'proto');
 
+    Object.entries(this.ctx.authTokenHeaders || {}).forEach(([key, value]) => {
+      meta.add(key, value);
+    });
+
     return meta;
   }
 }


### PR DESCRIPTION
Grpc requests are missing for auth headers passed in the context.
We now can provide auth headers from the context and will be added to the meta data