### PR TITLE
add ctx auth headers to GRPC meta data

### DIFF
--- a/server/middleware/grpc-client/grpc-service.js
+++ b/server/middleware/grpc-client/grpc-service.js
@@ -118,6 +118,10 @@ class GRPCService {
     meta.add('rpc-caller', 'cadence-ui');
     meta.add('rpc-encoding', 'proto');
 
+    Object.entries(this.ctx.authTokenHeaders || {}).forEach(([key, value]) => {
+      meta.add(key, value);
+    });
+
     return meta;
   }
 }


### PR DESCRIPTION
The context headers were missing in GRPC requests.
Changes are made to add the context auth headers to meta data along with all grpc calls