### PR TITLE
Add cron schedule to workflow summary page

### DIFF
--- a/client/containers/workflow/component.vue
+++ b/client/containers/workflow/component.vue
@@ -49,6 +49,7 @@ export default {
         input: undefined,
         isWorkflowRunning: undefined,
         parentWorkflowRoute: undefined,
+        cronSchedule: undefined,
         result: undefined,
         wfStatus: undefined,
         workflow: undefined,
@@ -147,6 +148,7 @@ export default {
       this.history.loading = undefined;
 
       this.summary.input = undefined;
+      this.summary.cronSchedule = undefined;
       this.summary.isWorkflowRunning = undefined;
       this.summary.parentWorkflowRoute = undefined;
       this.summary.result = undefined;
@@ -395,6 +397,7 @@ export default {
       :display-workflow-id="displayWorkflowId"
       :domain="domain"
       :input="summary.input"
+      :cronSchedule="summary.cronSchedule"
       :isWorkflowRunning="summary.isWorkflowRunning"
       :parentWorkflowRoute="summary.parentWorkflowRoute"
       :result="summary.result"

--- a/client/containers/workflow/helpers/get-summary.js
+++ b/client/containers/workflow/helpers/get-summary.js
@@ -38,6 +38,7 @@ const getSummary = ({ clusterName, events, isWorkflowRunning, workflow }) => {
     return {
       input: undefined,
       isWorkflowRunning,
+      cronSchedule: undefined,
       parentWorkflowRoute: undefined,
       result: undefined,
       wfStatus: undefined,
@@ -77,6 +78,7 @@ const getSummary = ({ clusterName, events, isWorkflowRunning, workflow }) => {
 
   return {
     input,
+    cronSchedule: firstEvent.details.cronSchedule,
     isWorkflowRunning,
     parentWorkflowRoute,
     result,

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -43,6 +43,7 @@ export default {
     'input',
     'isWorkflowRunning',
     'parentWorkflowRoute',
+    'cronSchedule',
     'result',
     'runId',
     'timeFormat',
@@ -250,6 +251,10 @@ export default {
           </router-link>
         </dd>
       </div>
+      <div class="cron-schedule" v-if="cronSchedule">
+        <dt>Cron Schedule</dt>
+        <dd>{{ cronSchedule }}</dd>
+      </div>
       <div class="task-list">
         <dt>Task List</dt>
         <dd>
@@ -318,7 +323,7 @@ section.workflow-summary
     margin-bottom 1em
     dt
       padding 0 4px
-  .run-id, .task-list, .workflow-id, .workflow-name
+  .run-id, .task-list, .workflow-id, .workflow-name, .cron-schedule
     dd
       font-weight 300
       font-family monospace-font-family

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -123,6 +123,7 @@ export default {
         eventType: 'WorkflowExecutionStarted',
         eventId: 1,
         details: {
+          cronSchedule: '30 * * * *',
           workflowType: {
             name: 'email-daily-summaries',
           },

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -50,10 +50,8 @@ describe('Workflow', () => {
         )
         .withTaskList('ci_task_list')
         .startingAt(
-          `/domains/ci-test/workflows/${extendedOptions.workflowId}/${
-            extendedOptions.runId
-          }/${extendedOptions.view}${
-            extendedOptions.query ? `?${extendedOptions.query}` : ''
+          `/domains/ci-test/workflows/${extendedOptions.workflowId}/${extendedOptions.runId
+          }/${extendedOptions.view}${extendedOptions.query ? `?${extendedOptions.query}` : ''
           }`
         ),
       extendedOptions,
@@ -123,6 +121,10 @@ describe('Workflow', () => {
       summaryEl.should.not.have.descendant('.pending-activities');
 
       summaryEl.should.not.have.descendant('.parent-workflow');
+
+      summaryEl
+        .querySelector('.cron-schedule dd')
+        .should.have.text('30 * * * *');
 
       summaryEl
         .querySelector('.workflow-status dd')
@@ -869,6 +871,7 @@ describe('Workflow', () => {
         startDetails
           .textNodes('dl.details dt')
           .should.deep.equal([
+            'cronSchedule',
             'workflowType.name',
             'taskList.name',
             'input',
@@ -878,6 +881,7 @@ describe('Workflow', () => {
         startDetails
           .textNodes('dl.details dd')
           .should.deep.equal([
+            '30 * * * *',
             'email-daily-summaries',
             'ci-task-queue',
             inputPreText,

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -50,8 +50,10 @@ describe('Workflow', () => {
         )
         .withTaskList('ci_task_list')
         .startingAt(
-          `/domains/ci-test/workflows/${extendedOptions.workflowId}/${extendedOptions.runId
-          }/${extendedOptions.view}${extendedOptions.query ? `?${extendedOptions.query}` : ''
+          `/domains/ci-test/workflows/${extendedOptions.workflowId}/${
+            extendedOptions.runId
+          }/${extendedOptions.view}${
+            extendedOptions.query ? `?${extendedOptions.query}` : ''
           }`
         ),
       extendedOptions,


### PR DESCRIPTION
Cron schedule is important enough to be shown on the main summary page.
Previously in order to access it we needed to check the first event details.

<img width="1728" alt="Screenshot 2023-09-08 at 12 30 05" src="https://github.com/uber/cadence-web/assets/137278762/5ec84471-3890-4840-aa2d-3610c463bded">
