### PR TITLE
Fix bug in Cadence Web where falsy values do not render correctly

### DIFF
--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -22,7 +22,8 @@
 import getStringElipsis from './get-string-elipsis';
 
 const getJsonStringObject = value => {
-  const jsonStringFull = value !== null && value !== undefined ? JSON.stringify(value, null, 2) : '';
+  const jsonStringFull =
+    value !== null && value !== undefined ? JSON.stringify(value, null, 2) : '';
   const jsonStringDisplay = getStringElipsis(jsonStringFull);
 
   return {

--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -22,8 +22,7 @@
 import getStringElipsis from './get-string-elipsis';
 
 const getJsonStringObject = value => {
-  const jsonStringFull =
-    value !== null && value !== undefined ? JSON.stringify(value, null, 2) : '';
+  const jsonStringFull = value !== undefined ? JSON.stringify(value, null, 2) : '';
   const jsonStringDisplay = getStringElipsis(jsonStringFull);
 
   return {

--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -22,8 +22,8 @@
 import getStringElipsis from './get-string-elipsis';
 
 const getJsonStringObject = value => {
-  const jsonStringFull = value ? JSON.stringify(value, null, 2) : '';
-  const jsonStringDisplay = value ? getStringElipsis(jsonStringFull) : '';
+  const jsonStringFull = value !== null && value !== undefined ? JSON.stringify(value, null, 2) : '';
+  const jsonStringDisplay = getStringElipsis(jsonStringFull);
 
   return {
     jsonStringDisplay,

--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -22,7 +22,8 @@
 import getStringElipsis from './get-string-elipsis';
 
 const getJsonStringObject = value => {
-  const jsonStringFull = value !== undefined ? JSON.stringify(value, null, 2) : '';
+  const jsonStringFull =
+    value !== undefined ? JSON.stringify(value, null, 2) : '';
   const jsonStringDisplay = getStringElipsis(jsonStringFull);
 
   return {

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -31,6 +31,14 @@ describe('getStringElipsis', () => {
       expect(output).toEqual('a-short-string');
     });
   });
+  describe('when passed the empty string', () => {
+    it('should return the empty string', () => {
+      const input = '';
+      const output = getStringElipsis(input);
+
+      expect(output).toEqual('');
+    });
+  });
   describe('when passed a string that has a length equal to MAXIMUM_JSON_CHARACTER_LIMIT', () => {
     it('should return a substring of the original string up until the limit and display a message.', () => {
       const input = ''.padEnd(MAXIMUM_JSON_CHARACTER_LIMIT, '_');


### PR DESCRIPTION
### Summary
This change fixes an issue with cadence-web where false/0 values in the activity result do not render correctly. This is due to a check in the `getJsonStringObject` helper function returning an empty string if the result is falsy. While this is the intended behaviour for null/undefined, we want to render other values (such as false and 0) correctly.

This change makes the check for null/undefined in the `getJsonStringObject` function more explicit.
As an aside, an unnecessary null check in the line below it is removed.

### Test plan
Ran cadence-web locally and loaded a test workflow to ensure the output is as expected.
 
#### Before
![Screenshot 2023-11-15 at 4 12 50 PM](https://github.com/uber/cadence-web/assets/26538200/8ada5bab-6f21-42d9-9bc2-5f2cd8bfc618)
![Screenshot 2023-11-15 at 4 12 57 PM](https://github.com/uber/cadence-web/assets/26538200/b6a540ee-a69f-437b-a6cd-146fa66c2043)

#### After
![Screenshot 2023-11-15 at 4 13 16 PM](https://github.com/uber/cadence-web/assets/26538200/e0c46b6c-543e-434c-bf13-dac7c673572f)
![Screenshot 2023-11-15 at 4 13 23 PM](https://github.com/uber/cadence-web/assets/26538200/32bebc71-f1f7-47eb-b892-23564fd869e8)

To test null and undefined, I hardcoded the result:
![Screenshot 2023-11-15 at 4 32 42 PM](https://github.com/uber/cadence-web/assets/26538200/4621b530-3e72-4a29-957c-f859fc34c0c8)
![Screenshot 2023-11-15 at 4 41 21 PM](https://github.com/uber/cadence-web/assets/26538200/adb4f402-084e-468f-8574-a9530aa8c33e)

To test the removal of the unnecessary null check, a unit test was added to ensure that the `getStringElipsis` util function returns the expected output.