### PR TITLE
Redirect user to active cluster when there is no cluster selected

### DIFF
--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -20,10 +20,12 @@
 // THE SOFTWARE.
 
 import { connect } from 'vuex-connect';
+import { ROUTE_REPLACE } from '../route/action-types';
 import {
   ROUTE_PARAMS_CLUSTER_NAME,
   ROUTE_PARAMS_DOMAIN,
 } from '../route/getter-types';
+import { ACTIVE_STATUS_CLUSTER } from '../active-status/getter-types';
 import {
   DOMAIN_FETCH,
   DOMAIN_ON_MOUNT,
@@ -44,6 +46,7 @@ const actionsToEvents = {
 
 const gettersToProps = {
   clusterName: ROUTE_PARAMS_CLUSTER_NAME,
+  activeCluster: ACTIVE_STATUS_CLUSTER,
   domainName: ROUTE_PARAMS_DOMAIN,
   error: DOMAIN_ERROR,
   isLoading: DOMAIN_IS_LOADING,
@@ -53,6 +56,20 @@ const gettersToProps = {
 
 const lifecycle = {
   mounted: ({ dispatch }) => dispatch(DOMAIN_ON_MOUNT),
+  updated({ dispatch, state }) {
+    const urlParamClusterName = this.clusterName;
+
+    if (!urlParamClusterName && this.activeCluster?.clusterName) {
+      // in some cases users have urls that are generic (with no cluster name specified) those are used when we want to auto redirect the user to one of the clusters by default without carring about which cluster.
+      dispatch(ROUTE_REPLACE, {
+        name: state.route.name,
+        params: {
+          ...state.route.params,
+          clusterName: this.activeCluster?.clusterName,
+        },
+      });
+    }
+  },
 };
 
 export default connect({

--- a/client/test/domain.test.js
+++ b/client/test/domain.test.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2017-2023 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { getFixture } from './helpers';
+
+const crossRegionSpecificFlags = [
+  'crossRegion',
+  'crossRegion.activeStatusTag',
+  'crossRegion.allowedCrossOrigin',
+  'crossRegion.clusterOriginList',
+];
+
+const featureFlagsForMultipleClustersEnv = [
+  ...getFixture('featureFlags').filter(
+    ({ key }) => !crossRegionSpecificFlags.includes(key)
+  ),
+  {
+    key: 'crossRegion',
+    value: true,
+  },
+  {
+    key: 'crossRegion.activeStatusTag',
+    value: true,
+  },
+  {
+    key: 'crossRegion.allowedCrossOrigin',
+    value: true,
+  },
+  {
+    key: 'crossRegion.clusterOriginList',
+    value: [
+      {
+        clusterName: 'primary',
+        origin: 'http://localhost:8090',
+      },
+      {
+        clusterName: 'ci-test-cluster',
+        origin: 'http://localhost:8090',
+      },
+    ],
+  },
+];
+
+const featureFlagsForSingleClusterEnv = [
+  ...getFixture('featureFlags').filter(
+    ({ key }) => !crossRegionSpecificFlags.includes(key)
+  ),
+  {
+    key: 'crossRegion',
+    value: false,
+  },
+  {
+    key: 'crossRegion.activeStatusTag',
+    value: false,
+  },
+  {
+    key: 'crossRegion.allowedCrossOrigin',
+    value: false,
+  },
+  {
+    key: 'crossRegion.clusterOriginList',
+    value: [],
+  },
+];
+
+describe('Domain ', () => {
+  async function domainTest(mochaTest, { desc, featureFlags } = {}) {
+    const [testEl, scenario] = new Scenario(mochaTest)
+      .withCluster()
+      .withDomain('ci-test')
+      .withDomainAuthorization('ci-test', true)
+      .withFeatureFlags(featureFlags)
+      .withEmptyNewsFeed()
+      .withDomainDescription('ci-test', desc)
+      .withWorkflows({ status: 'open' })
+      .withWorkflows({ status: 'closed', startTimeOffset: 30 })
+      .startingAt('/domains/ci-test')
+      .go();
+
+    const configEl = await testEl.waitUntilExists('section.domain');
+
+    return [testEl, scenario];
+  }
+
+  it('should redirect to cluster if it is missing in the url in a cross region domain environment', async function test() {
+    // if clusterName is missing in the url and active cluser exists
+    // make sure to redirect to add cluster to url
+    // we make sure the activeCluster config exists by passing feature flags for crossRegion configs
+    const [testEl, scenario] = await domainTest(this.test, {
+      featureFlags: featureFlagsForMultipleClustersEnv,
+    });
+
+    await testEl.waitUntilExists('.feature-flag .active-status');
+    scenario.location.should.contain('/ci-test-cluster');
+  });
+
+  it('should not redirect to cluster if it is missing in the url in a non cross region domain environment', async function test() {
+    const [testEl, scenario] = await domainTest(this.test, {
+      featureFlags: featureFlagsForSingleClusterEnv,
+    });
+
+    // make sure that cross region is not in the dom before asserting on the location
+    const statusEl = await testEl
+      .waitUntilExists('.feature-flag .active-status')
+      .catch(() => {
+        scenario.location.should.not.contain('/ci-test-cluster');
+
+        return null;
+      });
+
+    (statusEl === null).should.equal(true);
+  });
+});

--- a/client/test/index.js
+++ b/client/test/index.js
@@ -155,6 +155,7 @@ require('./scenario');
 
 mocha.checkLeaks();
 
+require('./domain.test');
 require('./domain-search.test');
 require('./help.test');
 require('./workflow-list.test');

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -163,7 +163,7 @@ Scenario.prototype.withDomainDescription = function withDomainDescription(
 ) {
   const { origin } = this;
 
-  this.api.getOnce(
+  this.api.get(
     `${origin}/api/domains/${domain}`,
     deepmerge(
       {
@@ -218,7 +218,8 @@ Scenario.prototype.withFeatureFlags = function withFeatureFlags(
     this.api.getOnce(`${origin}/api/feature-flags/${key}`, {
       key,
       value,
-    });
+    }, { query: {} }); // for some reason when value contains an array of objects that has `origin` field it adds it to query params
+    // so we need to reset query tp empty obj
   });
 
   return this;
@@ -274,7 +275,7 @@ Scenario.prototype.withWorkflows = function withWorkflows({
     ? { executions: workflows, nextPageToken: '' }
     : workflows;
 
-  this.api.getOnce(url, response);
+  this.api.get(url, response);
 
   return this;
 };

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -215,10 +215,14 @@ Scenario.prototype.withFeatureFlags = function withFeatureFlags(
   const { origin } = this;
 
   featureFlags.forEach(({ key, value }) => {
-    this.api.getOnce(`${origin}/api/feature-flags/${key}`, {
-      key,
-      value,
-    }, { query: {} }); // for some reason when value contains an array of objects that has `origin` field it adds it to query params
+    this.api.getOnce(
+      `${origin}/api/feature-flags/${key}`,
+      {
+        key,
+        value,
+      },
+      { query: {} }
+    ); // for some reason when value contains an array of objects that has `origin` field it adds it to query params
     // so we need to reset query tp empty obj
   });
 

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -48,7 +48,7 @@ describe('Describe Domain', function() {
           },
           replicationConfiguration: {
             activeClusterName: 'ci-cluster',
-            clusters: [],
+            clusters: [{ clusterName: 'ci-cluster' }],
           },
         },
       ],
@@ -67,7 +67,7 @@ describe('Describe Domain', function() {
           visibilityArchivalStatus: 'ARCHIVAL_STATUS_INVALID',
           visibilityArchivalUri: '',
           activeClusterName: 'ci-cluster',
-          clusters: [],
+          clusters: [{ clusterName: 'ci-cluster' }],
           failoverVersion: '0',
           isGlobalDomain: false,
           failoverInfo: null,


### PR DESCRIPTION
In case of cross region domains, sometimes the urls are formed without specifying the cluster. This is beneficial  if users wants to be redirected to the domain without caring which is the active cluster. 
This caused some issues in fetching the information as most of the pages only takes in account the cluster if it was added to the url, regardless of the cluster selected in the dropdown.

The solution to this issue is to redirect the user to the url including the active cluster if it was missing in the URL only if the domain is cross region.


