### PR TITLE
Fix domain search page crash for crossRegion environments

### DIFF
--- a/client/containers/active-status/getters.js
+++ b/client/containers/active-status/getters.js
@@ -72,7 +72,7 @@ const getters = {
 
     const domainNamespace = domainHash[domainName];
 
-    if (!crossRegion || !isReady) {
+    if (!domainName || !crossRegion || !isReady) {
       return [];
     }
 

--- a/client/containers/active-status/getters.spec.js
+++ b/client/containers/active-status/getters.spec.js
@@ -1,0 +1,55 @@
+// Copyright (c) 2021-2023 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { ROUTE_PARAMS_DOMAIN } from '../route/getter-types';
+import {
+  CROSS_REGION,
+  CROSS_REGION_CLUSTER_ORIGIN_LIST,
+} from '../cross-region/getter-types';
+import { DOMAIN_HASH, DOMAIN_IS_READY } from '../domain/getter-types';
+import activeStatusGetterFns from './getters';
+import { ACTIVE_STATUS_CLUSTER_LIST } from './getter-types';
+import { initGetters } from '~test';
+
+describe('Active status getters', () => {
+  describe('when calling getters[ACTIVE_STATUS_CLUSTER_LIST]', () => {
+    it('should return the value empty list if dynamic dependent getters are Nil', () => {
+      const dependentGetterNames = [
+        CROSS_REGION_CLUSTER_ORIGIN_LIST,
+        CROSS_REGION,
+        ROUTE_PARAMS_DOMAIN,
+      ];
+
+      dependentGetterNames.forEach(getterName => {
+        const getterFns = {
+          ...activeStatusGetterFns,
+          [getterName]: () => null,
+          [DOMAIN_IS_READY]: () => true,
+          [DOMAIN_HASH]: () => ({}),
+        };
+        const getters = initGetters({ getterFns });
+        const output = getters[ACTIVE_STATUS_CLUSTER_LIST];
+
+        expect(output).toEqual([]);
+      });
+    });
+  });
+});

--- a/client/containers/active-status/getters.spec.js
+++ b/client/containers/active-status/getters.spec.js
@@ -31,7 +31,7 @@ import { initGetters } from '~test';
 
 describe('Active status getters', () => {
   describe('when calling getters[ACTIVE_STATUS_CLUSTER_LIST]', () => {
-    it('should return the value empty list if dynamic dependent getters are Nil', () => {
+    it('should return empty array if its dynamic dependent getters returned Nil', () => {
       const dependentGetterNames = [
         CROSS_REGION_CLUSTER_ORIGIN_LIST,
         CROSS_REGION,

--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -61,7 +61,7 @@ const lifecycle = {
     const routeSupportsClusterNameParam = urlParams?.hasOwnProperty(
       'clusterName'
     );
-    console.log(urlParams)
+
     const hasClusterNameParam = Boolean(urlParams.clusterName);
 
     if (

--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -58,9 +58,10 @@ const lifecycle = {
   mounted: ({ dispatch }) => dispatch(DOMAIN_ON_MOUNT),
   updated({ dispatch, state }) {
     const urlParams = state.route.params;
-    const routeSupportsClusterNameParam = urlParams.params?.hasOwnProperty(
+    const routeSupportsClusterNameParam = urlParams?.hasOwnProperty(
       'clusterName'
     );
+    console.log(urlParams)
     const hasClusterNameParam = Boolean(urlParams.clusterName);
 
     if (

--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -57,9 +57,17 @@ const gettersToProps = {
 const lifecycle = {
   mounted: ({ dispatch }) => dispatch(DOMAIN_ON_MOUNT),
   updated({ dispatch, state }) {
-    const urlParamClusterName = this.clusterName;
+    const urlParams = state.route.params;
+    const routeSupportsClusterNameParam = urlParams.params?.hasOwnProperty(
+      'clusterName'
+    );
+    const hasClusterNameParam = Boolean(urlParams.clusterName);
 
-    if (!urlParamClusterName && this.activeCluster?.clusterName) {
+    if (
+      routeSupportsClusterNameParam &&
+      !hasClusterNameParam &&
+      this.activeCluster?.clusterName
+    ) {
       // in some cases users have urls that are generic (with no cluster name specified) those are used when we want to auto redirect the user to one of the clusters by default without carring about which cluster.
       dispatch(ROUTE_REPLACE, {
         name: state.route.name,

--- a/client/test/domain.test.js
+++ b/client/test/domain.test.js
@@ -95,7 +95,6 @@ describe('Domain ', () => {
       .startingAt('/domains/ci-test')
       .go();
 
-
     return [testEl, scenario];
   }
 

--- a/client/test/domain.test.js
+++ b/client/test/domain.test.js
@@ -95,7 +95,6 @@ describe('Domain ', () => {
       .startingAt('/domains/ci-test')
       .go();
 
-    const configEl = await testEl.waitUntilExists('section.domain');
 
     return [testEl, scenario];
   }


### PR DESCRIPTION
Description:
While working on the feature for [redirection to the default cluster](https://github.com/uber/cadence-web/pull/530), the code started depending on clusters list getter. This getter was crashing on the domain search page because domain at that point is empty.

The fix:
Return empty clusters list array if domain is missing.

Other changes:
- Unit test was added to make sure the clusters list getter would always return empty array its dependent getter returns null.
- after reading more through the code  i tweaked the code for redirection to only set the cluster name in the route if the route actually has clusterName param in its definition. (this is not related to the error but can prevent some if the new routes are added that doesn't have clusterName param)