### PR TITLE
v3.35.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
## What's Changed
* Add documentation for running cadence-web on VSCode Dev Containers by @adhityamamallan in https://github.com/uber/cadence-web/pull/528
* Fix bug in Cadence Web where falsy values do not render correctly by @adhityamamallan in https://github.com/uber/cadence-web/pull/529
* Redirect user to active cluster when there is no cluster selected by @Assem-Uber in https://github.com/uber/cadence-web/pull/530
* Fix domain search page crash for crossRegion environments by @Assem-Uber in https://github.com/uber/cadence-web/pull/532
* update license years to 2024 by @Assem-Uber in https://github.com/uber/cadence-web/pull/536
* Use default tchannel port in .docker_env by @mantas-sidlauskas in https://github.com/uber/cadence-web/pull/535

## New Contributors
* @adhityamamallan made their first contribution in https://github.com/uber/cadence-web/pull/528
* @mantas-sidlauskas made their first contribution in https://github.com/uber/cadence-web/pull/535

**Full Changelog**: https://github.com/uber/cadence-web/compare/v3.34.0...v3.35.2