### PR TITLE
Set expiresIn when self-signing JWT token

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -122,6 +122,7 @@ app.init = function({
           authAdminJwtPrivateKey,
           {
             algorithm: 'RS256',
+            expiresIn: '10s',
           }
         );
 


### PR DESCRIPTION
Adding standard `exp` field, but keeping `ttl` for backwards compatibility. 