### PR TITLE
preserve query params on cluster redirect

### DIFF
--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -72,6 +72,7 @@ const lifecycle = {
       // in some cases users have urls that are generic (with no cluster name specified) those are used when we want to auto redirect the user to one of the clusters by default without carring about which cluster.
       dispatch(ROUTE_REPLACE, {
         name: state.route.name,
+        query: state.route.query,
         params: {
           ...state.route.params,
           clusterName: this.activeCluster?.clusterName,

--- a/client/test/domain.test.js
+++ b/client/test/domain.test.js
@@ -92,13 +92,13 @@ describe('Domain ', () => {
       .withDomainDescription('ci-test', desc)
       .withWorkflows({ status: 'open' })
       .withWorkflows({ status: 'closed', startTimeOffset: 30 })
-      .startingAt('/domains/ci-test')
+      .startingAt('/domains/ci-test?t=test')
       .go();
 
     return [testEl, scenario];
   }
 
-  it('should redirect to cluster if it is missing in the url in a cross region domain environment', async function test() {
+  it('should redirect to cluster if it is missing in the url in a cross region domain environment while preserving queryParams', async function test() {
     // if clusterName is missing in the url and active cluser exists
     // make sure to redirect to add cluster to url
     // we make sure the activeCluster config exists by passing feature flags for crossRegion configs
@@ -108,6 +108,8 @@ describe('Domain ', () => {
 
     await testEl.waitUntilExists('.feature-flag .active-status');
     scenario.location.should.contain('/ci-test-cluster');
+    // query paramas should be preserveded
+    scenario.location.should.contain('t=test');
   });
 
   it('should not redirect to cluster if it is missing in the url in a non cross region domain environment', async function test() {


### PR DESCRIPTION
When a url that doesn't include cluster is opened, user is automatically redirected to the active cluster. The redirection logic has an issue as it ignores queryParams that existed in the url before the automatic redirection.

The fix is to add the existing query params to the redirection route.