### PR TITLE
export workflow history using correct url

### DIFF
--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -88,6 +88,7 @@ export default {
     'workflowHistoryEventHighlightList',
     'workflowHistoryEventHighlightListEnabled',
     'workflowId',
+    'origin',
   ],
   created() {
     this.onResizeWindow = debounce(() => {
@@ -399,7 +400,7 @@ export default {
         >
         <a
           class="export"
-          :href="baseAPIURL + '/export'"
+          :href="origin + baseAPIURL + '/export'"
           :download="exportFilename"
           >Export</a
         >

--- a/client/containers/workflow-history/connector.js
+++ b/client/containers/workflow-history/connector.js
@@ -21,9 +21,11 @@
 
 import { connect } from 'vuex-connect';
 import { WORKFLOW_EXECUTION_PENDING_TASK_COUNT } from '../workflow/getter-types';
+import { DOMAIN_CROSS_ORIGIN } from '../domain/getter-types';
 
 const gettersToProps = {
   pendingTaskCount: WORKFLOW_EXECUTION_PENDING_TASK_COUNT,
+  origin: DOMAIN_CROSS_ORIGIN,
 };
 
 const stateToProps = {

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -577,7 +577,7 @@ describe('Workflow', () => {
 
       exportEl.should.have.attr(
         'href',
-        '/api/domains/ci-test/workflows/email-daily-summaries/emailRun1/export'
+        'http://localhost:8090/api/domains/ci-test/workflows/email-daily-summaries/emailRun1/export'
       );
       exportEl.should.have.attr(
         'download',


### PR DESCRIPTION
Export button didn't work correctly with cross origin environments. 
So now origin is added to the the export url.