### PR TITLE
Parse status query param to int

### DIFF
--- a/server/router/routes/workflow-archived-list-handler.js
+++ b/server/router/routes/workflow-archived-list-handler.js
@@ -35,9 +35,16 @@ const workflowArchivedListHandler = async ctx => {
   } else {
     const startTime = moment(query.startTime || NaN);
     const endTime = moment(query.endTime || NaN);
+    const parsedStatus =
+      query.status && !isNaN(query.status)
+        ? parseInt(query.status)
+        : query.status;
 
     ctx.assert(startTime.isValid() && endTime.isValid(), 400);
-    queryString = buildQueryString(startTime, endTime, query);
+    queryString = buildQueryString(startTime, endTime, {
+      ...query,
+      status: parsedStatus,
+    });
   }
 
   const archivedWorkflowsResponse = await ctx.cadence.archivedWorkflows({


### PR DESCRIPTION
Archival query params are taken from the url so they are treated as strings.
In order to send a correct archival query status needs to be an int so that it is sent without quotes surrounding it.

The fix is to parse the status to integers if possible while reading them from url & pass the parsed value to the query builder