### PR TITLE
Revert "export workflow history using correct url"

### DIFF
--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -88,7 +88,6 @@ export default {
     'workflowHistoryEventHighlightList',
     'workflowHistoryEventHighlightListEnabled',
     'workflowId',
-    'origin',
   ],
   created() {
     this.onResizeWindow = debounce(() => {
@@ -400,7 +399,7 @@ export default {
         >
         <a
           class="export"
-          :href="origin + baseAPIURL + '/export'"
+          :href="baseAPIURL + '/export'"
           :download="exportFilename"
           >Export</a
         >

--- a/client/containers/workflow-history/connector.js
+++ b/client/containers/workflow-history/connector.js
@@ -21,11 +21,9 @@
 
 import { connect } from 'vuex-connect';
 import { WORKFLOW_EXECUTION_PENDING_TASK_COUNT } from '../workflow/getter-types';
-import { DOMAIN_CROSS_ORIGIN } from '../domain/getter-types';
 
 const gettersToProps = {
   pendingTaskCount: WORKFLOW_EXECUTION_PENDING_TASK_COUNT,
-  origin: DOMAIN_CROSS_ORIGIN,
 };
 
 const stateToProps = {

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -577,7 +577,7 @@ describe('Workflow', () => {
 
       exportEl.should.have.attr(
         'href',
-        'http://localhost:8090/api/domains/ci-test/workflows/email-daily-summaries/emailRun1/export'
+        '/api/domains/ci-test/workflows/email-daily-summaries/emailRun1/export'
       );
       exportEl.should.have.attr(
         'download',


### PR DESCRIPTION
Browser doesn't allow downloading cross origin files with links instead it opens the file in another tab.
 
So Reverting uber/cadence-web#543 as it still doesn't fix the problem