### PR TITLE
v3.35.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.35.2",
+  "version": "3.35.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence-web",
-  "version": "3.35.2",
+  "version": "3.35.4",
   "description": "Cadence Web UI",
   "main": "server/index.js",
   "licence": "MIT",


### PR DESCRIPTION
## What's Changed
* update license years to 2024 by @Assem-Uber in https://github.com/uber/cadence-web/pull/536
* Use default tchannel port in .docker_env by @mantas-sidlauskas in https://github.com/uber/cadence-web/pull/535
* preserve query params on cluster redirect by @Assem-Uber in https://github.com/uber/cadence-web/pull/539
* Set expiresIn when self-signing JWT token by @mantas-sidlauskas in https://github.com/uber/cadence-web/pull/538

* fix CloseStatus value in query string by @Assem-Hafez in https://github.com/uber/cadence-web/pull/541
* fix status in query string to accept strings and numbers by @Assem-Hafez in https://github.com/uber/cadence-web/pull/542
* Parse status query param to int by @Assem-Uber in https://github.com/uber/cadence-web/pull/544

* export workflow history using correct url by @Assem-Hafez in https://github.com/uber/cadence-web/pull/543
* Programatic download/export for workflow history by @Assem-Hafez in https://github.com/uber/cadence-web/pull/546


**Full Changelog**: https://github.com/uber/cadence-web/compare/v3.35.1...v3.35.4