### PR TITLE
Update cadence-idl to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "webpack-hot-client": "^1.3.0"
   },
   "napa": {
-    "cadence-idl": "uber/cadence-idl#57c717b37a361f441be070ad6bd436328677c5ef"
+    "cadence-idl": "uber/cadence-idl#e3a59cdd3c3676b0edee2f3262a22379f25b9fa5"
   },
   "napa-config": {
     "cache": false

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -21,8 +21,8 @@
 
 const grpc = require('@grpc/grpc-js');
 
-describe('Describe Domain', function() {
-  it('should list domains', async function() {
+describe('Describe Domain', function () {
+  it('should list domains', async function () {
     const domains = {
       tchannel: [
         {
@@ -38,10 +38,12 @@ describe('Describe Domain', function() {
           failoverInfo: null,
           failoverVersion: 0,
           configuration: {
+            AsyncWorkflowConfiguration: null,
             badBinaries: null,
             emitMetric: true,
             historyArchivalStatus: null,
             historyArchivalURI: null,
+            isolationgroups: null,
             visibilityArchivalStatus: null,
             visibilityArchivalURI: null,
             workflowExecutionRetentionPeriodInDays: 14,
@@ -88,7 +90,7 @@ describe('Describe Domain', function() {
       .expect(domains.tchannel);
   });
 
-  it('should describe the domain', async function() {
+  it('should describe the domain', async function () {
     const domainDesc = {
       tchannel: {
         domainInfo: {
@@ -103,11 +105,13 @@ describe('Describe Domain', function() {
         failoverVersion: 0,
         isGlobalDomain: true,
         configuration: {
+          AsyncWorkflowConfiguration: null,
           badBinaries: null,
           workflowExecutionRetentionPeriodInDays: 14,
           emitMetric: true,
           historyArchivalStatus: null,
           historyArchivalURI: null,
+          isolationgroups: null,
           visibilityArchivalStatus: null,
           visibilityArchivalURI: null,
         },
@@ -152,7 +156,7 @@ describe('Describe Domain', function() {
       .expect(domainDesc.tchannel);
   });
 
-  it('should return 404 if the domain is not found', async function() {
+  it('should return 404 if the domain is not found', async function () {
     const errorHandler = ({ describeRequest }) => {
       const message = `domain "${describeRequest.name}" does not exist`;
       const error = {

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -21,8 +21,8 @@
 
 const grpc = require('@grpc/grpc-js');
 
-describe('Describe Domain', function () {
-  it('should list domains', async function () {
+describe('Describe Domain', function() {
+  it('should list domains', async function() {
     const domains = {
       tchannel: [
         {
@@ -90,7 +90,7 @@ describe('Describe Domain', function () {
       .expect(domains.tchannel);
   });
 
-  it('should describe the domain', async function () {
+  it('should describe the domain', async function() {
     const domainDesc = {
       tchannel: {
         domainInfo: {
@@ -156,7 +156,7 @@ describe('Describe Domain', function () {
       .expect(domainDesc.tchannel);
   });
 
-  it('should return 404 if the domain is not found', async function () {
+  it('should return 404 if the domain is not found', async function() {
     const errorHandler = ({ describeRequest }) => {
       const message = `domain "${describeRequest.name}" does not exist`;
       const error = {

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -50,6 +50,7 @@ const wfHistoryThrift = [
       cronSchedule: null,
       firstDecisionTaskBackoffSeconds: null,
       firstExecutionRunId: null,
+      firstScheduledTimeNano: null,
       header: null,
       initiator: null,
       lastCompletionResult: null,
@@ -58,7 +59,9 @@ const wfHistoryThrift = [
       parentInitiatedEventId: null,
       parentWorkflowDomain: null,
       parentWorkflowExecution: null,
+      partitionConfig: null,
       prevAutoResetPoints: null,
+      requestId: null,
       retryPolicy: null,
       searchAttributes: null,
       taskStartToCloseTimeoutSeconds: 30,
@@ -121,6 +124,7 @@ const wfHistoryGrpc = [
       cronSchedule: null,
       firstDecisionTaskBackoff: null,
       firstExecutionRunId: null,
+      firstScheduledTimeNano: null,
       header: null,
       initiator: null,
       lastCompletionResult: null,
@@ -129,7 +133,9 @@ const wfHistoryGrpc = [
       parentInitiatedEventId: null,
       parentWorkflowDomain: null,
       parentWorkflowExecution: null,
+      partitionConfig: null,
       prevAutoResetPoints: null,
+      requestId: null,
       retryPolicy: null,
       searchAttributes: null,
       taskStartToCloseTimeout: { seconds: 30 },
@@ -194,8 +200,8 @@ const wfHistoryJson = [
   },
 ];
 
-describe('Workflow History', function() {
-  it('should forward the request to the cadence frontend with workflowId and runId', function() {
+describe('Workflow History', function () {
+  it('should forward the request to the cadence frontend with workflowId and runId', function () {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       const request = {
         tchannel: {
@@ -237,7 +243,7 @@ describe('Workflow History', function() {
       .expect(200)
       .expect('Content-Type', /json/);
   });
-  it('should forward the nextPageToken', function() {
+  it('should forward the nextPageToken', function () {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       const requestNextPageToken = {
         tchannel: 'page2',
@@ -267,7 +273,7 @@ describe('Workflow History', function() {
         rawHistory: null,
       });
   });
-  it('should support long polling by forwarding the waitForNewEvent flag', function() {
+  it('should support long polling by forwarding the waitForNewEvent flag', function () {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       getRequest.waitForNewEvent.should.be.true;
 
@@ -288,7 +294,7 @@ describe('Workflow History', function() {
           .expect(200)
       );
   });
-  it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function() {
+  it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function () {
     const events = {
       tchannel: wfHistoryThrift,
       grpc: wfHistoryGrpc,
@@ -309,10 +315,10 @@ describe('Workflow History', function() {
         rawHistory: null,
       });
   });
-  describe('Export', function() {
+  describe('Export', function () {
     const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`;
 
-    it('should be able to export history in a format compatible with the CLI', function() {
+    it('should be able to export history in a format compatible with the CLI', function () {
       const events = {
         tchannel: wfHistoryThrift,
         grpc: wfHistoryGrpc,
@@ -327,7 +333,7 @@ describe('Workflow History', function() {
         .expect(200)
         .expect(wfHistoryCliJson);
     });
-    it('should page through all responses', async function() {
+    it('should page through all responses', async function () {
       let calls = 0;
       const events = {
         tchannel: wfHistoryThrift,

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -200,8 +200,8 @@ const wfHistoryJson = [
   },
 ];
 
-describe('Workflow History', function () {
-  it('should forward the request to the cadence frontend with workflowId and runId', function () {
+describe('Workflow History', function() {
+  it('should forward the request to the cadence frontend with workflowId and runId', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       const request = {
         tchannel: {
@@ -243,7 +243,7 @@ describe('Workflow History', function () {
       .expect(200)
       .expect('Content-Type', /json/);
   });
-  it('should forward the nextPageToken', function () {
+  it('should forward the nextPageToken', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       const requestNextPageToken = {
         tchannel: 'page2',
@@ -273,7 +273,7 @@ describe('Workflow History', function () {
         rawHistory: null,
       });
   });
-  it('should support long polling by forwarding the waitForNewEvent flag', function () {
+  it('should support long polling by forwarding the waitForNewEvent flag', function() {
     this.test.GetWorkflowExecutionHistory = ({ getRequest }) => {
       getRequest.waitForNewEvent.should.be.true;
 
@@ -294,7 +294,7 @@ describe('Workflow History', function () {
           .expect(200)
       );
   });
-  it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function () {
+  it('should transform Long numbers to JavaScript numbers, Long dates to ISO date strings, and line-delimited JSON buffers to JSON', function() {
     const events = {
       tchannel: wfHistoryThrift,
       grpc: wfHistoryGrpc,
@@ -315,10 +315,10 @@ describe('Workflow History', function () {
         rawHistory: null,
       });
   });
-  describe('Export', function () {
+  describe('Export', function() {
     const wfHistoryCliJson = `[{"eventId":1,"timestamp":1510701850351393089,"eventType":"WorkflowExecutionStarted","workflowExecutionStartedEventAttributes":{"workflowType":{"name":"github.com/uber/cadence/demo"},"taskList":{"name":"ci-task-queue"},"input":"eyJlbWFpbHMiOlsiamFuZUBleGFtcGxlLmNvbSIsImJvYkBleGFtcGxlLmNvbSJdLCJpbmNsdWRlRm9vdGVyIjp0cnVlfQ==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":30}},{"eventId":2,"timestamp":1510701850351393089,"eventType":"DecisionTaskScheduled","decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":1}},{"eventId":3,"timestamp":1510701867531262273,"eventType":"DecisionTaskStarted","decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"box1@ci-task-queue","requestId":"fafa095d-b4ca-423a-a812-223e62b5ccf8"}}]`;
 
-    it('should be able to export history in a format compatible with the CLI', function () {
+    it('should be able to export history in a format compatible with the CLI', function() {
       const events = {
         tchannel: wfHistoryThrift,
         grpc: wfHistoryGrpc,
@@ -333,7 +333,7 @@ describe('Workflow History', function () {
         .expect(200)
         .expect(wfHistoryCliJson);
     });
-    it('should page through all responses', async function () {
+    it('should page through all responses', async function() {
       let calls = 0;
       const events = {
         tchannel: wfHistoryThrift,

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-describe('Listing Workflows', function() {
+describe('Listing Workflows', function () {
   const demoExecThrift = {
     execution: {
       workflowId: 'demo',
@@ -38,8 +38,12 @@ describe('Listing Workflows', function() {
     executionTime: null,
     memo: null,
     parentDomainId: null,
+    parentDomainName: null,
     parentExecution: null,
+    parentInitatedId: null,
+    partitionConfig: null,
     searchAttributes: null,
+    updateTime: null,
   };
   const demoExecGrpc = {
     workflowExecution: {
@@ -59,8 +63,12 @@ describe('Listing Workflows', function() {
     executionTime: null,
     memo: null,
     parentDomainId: null,
+    parentDomainName: null,
     parentExecution: null,
+    parentInitatedId: null,
+    partitionConfig: null,
     searchAttributes: null,
+    updateTime: null,
   };
   const demoExecJson = Object.assign({}, demoExecThrift, {
     startTime: '2017-11-10T21:30:00.000Z',
@@ -102,7 +110,7 @@ describe('Listing Workflows', function() {
     return request().delete('/api/cluster/cache');
   });
 
-  it('should fail to list all workflows with ES disabled', function() {
+  it('should fail to list all workflows with ES disabled', function () {
     this.test.DescribeCluster = () => {
       return clusterElasticSearchDisabled;
     };
@@ -119,7 +127,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should list all workflows with ES enabled', function() {
+  it('should list all workflows with ES enabled', function () {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.query
         .match('2017-11-12T12:00:00.000Z')[0]
@@ -152,7 +160,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should list open workflows with ES disabled', function() {
+  it('should list open workflows with ES disabled', function () {
     this.test.ListOpenWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
       should.not.exist(listRequest.executionFilter);
@@ -208,7 +216,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should list open workflows with ES enabled', function() {
+  it('should list open workflows with ES enabled', function () {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.query
         .match('2017-11-12T12:00:00.000Z')[0]
@@ -241,7 +249,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should list closed workflows with ES disabled', function() {
+  it('should list closed workflows with ES disabled', function () {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
       should.not.exist(listRequest.executionFilter);
@@ -296,7 +304,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should list closed workflows with ES enabled', function() {
+  it('should list closed workflows with ES enabled', function () {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
 
@@ -330,7 +338,7 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should forward the next page token along', function() {
+  it('should forward the next page token along', function () {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
       switch (process.env.TRANSPORT_CLIENT_TYPE) {
         case 'tchannel': {
@@ -369,13 +377,13 @@ describe('Listing Workflows', function() {
       });
   });
 
-  it('should return 404 if another state of workflows is queried', function() {
+  it('should return 404 if another state of workflows is queried', function () {
     return request()
       .get('/api/domains/canary/workflows/failed')
       .expect(404);
   });
 
-  it('should return 400 if startTime or endTime are missing', async function() {
+  it('should return 400 if startTime or endTime are missing', async function () {
     await request()
       .get('/api/domains/canary/workflows/open?startTime=2017-11-01')
       .expect(400);

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-describe('Listing Workflows', function () {
+describe('Listing Workflows', function() {
   const demoExecThrift = {
     execution: {
       workflowId: 'demo',
@@ -110,7 +110,7 @@ describe('Listing Workflows', function () {
     return request().delete('/api/cluster/cache');
   });
 
-  it('should fail to list all workflows with ES disabled', function () {
+  it('should fail to list all workflows with ES disabled', function() {
     this.test.DescribeCluster = () => {
       return clusterElasticSearchDisabled;
     };
@@ -127,7 +127,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should list all workflows with ES enabled', function () {
+  it('should list all workflows with ES enabled', function() {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.query
         .match('2017-11-12T12:00:00.000Z')[0]
@@ -160,7 +160,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should list open workflows with ES disabled', function () {
+  it('should list open workflows with ES disabled', function() {
     this.test.ListOpenWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
       should.not.exist(listRequest.executionFilter);
@@ -216,7 +216,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should list open workflows with ES enabled', function () {
+  it('should list open workflows with ES enabled', function() {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.query
         .match('2017-11-12T12:00:00.000Z')[0]
@@ -249,7 +249,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should list closed workflows with ES disabled', function () {
+  it('should list closed workflows with ES disabled', function() {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
       should.not.exist(listRequest.executionFilter);
@@ -304,7 +304,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should list closed workflows with ES enabled', function () {
+  it('should list closed workflows with ES enabled', function() {
     this.test.ListWorkflowExecutions = ({ listRequest }) => {
       listRequest.domain.should.equal('canary');
 
@@ -338,7 +338,7 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should forward the next page token along', function () {
+  it('should forward the next page token along', function() {
     this.test.ListClosedWorkflowExecutions = ({ listRequest }) => {
       switch (process.env.TRANSPORT_CLIENT_TYPE) {
         case 'tchannel': {
@@ -377,13 +377,13 @@ describe('Listing Workflows', function () {
       });
   });
 
-  it('should return 404 if another state of workflows is queried', function () {
+  it('should return 404 if another state of workflows is queried', function() {
     return request()
       .get('/api/domains/canary/workflows/failed')
       .expect(404);
   });
 
-  it('should return 400 if startTime or endTime are missing', async function () {
+  it('should return 400 if startTime or endTime are missing', async function() {
     await request()
       .get('/api/domains/canary/workflows/open?startTime=2017-11-01')
       .expect(400);


### PR DESCRIPTION
### Summary
- Use latest IDL files in cadence-web by updating package.json with the latest commit hash from [uber/cadence-idl](https://github.com/uber/cadence-idl)

### Test plan
- Ran locally, and loaded a sample domain & workflow as a sanity check.
- Updated unit test fixtures with the new types