### PR TITLE
Add .prettierrc file to fix ESLint - Prettier conflicts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,17 +4,8 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:prettier/recommended',
   ],
-  plugins: ['react'],
+  plugins: ['react', 'prettier'],
   rules: {
     'react/react-in-jsx-scope': 'off',
-    'prettier/prettier': [
-      'error',
-      {
-        bracketSpacing: true,
-        singleQuote: true,
-        trailingComma: 'es5',
-        jsxBracketSameLine: false,
-      },
-    ],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:prettier/recommended',
   ],
-  plugins: ['react', 'prettier'],
+  plugins: ['react'],
   rules: {
     'react/react-in-jsx-scope': 'off',
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "bracketSpacing": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "jsxBracketSameLine": false
+}


### PR DESCRIPTION
Add a separate .prettierrc config file instead of having the config inline within .eslintrc.js, so that the VSCode Prettier extension can read this configuration too.