### PR TITLE
add md icons as overrides to baseweb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "query-string": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.1.0",
         "react-intersection-observer": "^9.8.1",
         "styletron-engine-monolithic": "^1.0.0",
         "styletron-react": "^6.1.1",
@@ -8137,6 +8138,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.1.0.tgz",
+      "integrity": "sha512-D3zug1270S4hbSlIRJ0CUS97QE1yNNKDjzQe3HqY0aefp2CBn9VgzgES27sRR2gOvFK+0CNx/BW0ggOESp6fqQ==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-input-mask": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.1.0",
     "react-intersection-observer": "^9.8.1",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1",

--- a/src/config/theme/base-web-icons-ovverrides.config.ts
+++ b/src/config/theme/base-web-icons-ovverrides.config.ts
@@ -1,0 +1,11 @@
+import { IconProps } from "baseui/icon";
+import { Icon } from "baseui/styles";
+import { ComponentType } from "react";
+import { MdSearch } from "react-icons/md";
+
+const baseWebIconsOverrides = {
+  // IconProps needed by basweb is super type of IconBaseProps from react-icons so no issues should happen from casting
+  Search: MdSearch as ComponentType<IconProps>
+} satisfies Icon;
+
+export default baseWebIconsOverrides;

--- a/src/config/theme/theme-light.config.ts
+++ b/src/config/theme/theme-light.config.ts
@@ -1,5 +1,8 @@
+import baseWebIconsOverrides from "./base-web-icons-ovverrides.config";
+
 const themeLight = {
   grid: { maxWidth: 1580 },
+  icons: baseWebIconsOverrides
 };
 
 export default themeLight;


### PR DESCRIPTION
- Install react-icons 
- Add config file to override baseweb icons
- Override baseweb search icon to use MdSearch