### PR TITLE
Table - Refactor and add support for fixed width columns

### DIFF
--- a/src/containers/domains-page/config/domains-table-columns.config.ts
+++ b/src/containers/domains-page/config/domains-table-columns.config.ts
@@ -8,11 +8,13 @@ export const domainTableColumns: Array<TableColumn<DomainData>> = [
     name: 'Domain Name',
     id: 'name',
     renderCell: DomainsTableDomainNameCell,
+    width: '80%',
     sortable: true,
   },
   {
     name: 'Cluster',
     id: 'cluster',
     renderCell: DomainsTableClusterCell,
+    width: '20%',
   },
 ];

--- a/src/layout/table/__tests__/table.test.tsx
+++ b/src/layout/table/__tests__/table.test.tsx
@@ -24,6 +24,7 @@ const SAMPLE_COLUMNS = Array.from(
     renderCell: ({ value }: TestDataT) => {
       return `data_${value}_${colIndex}`;
     },
+    width: `${100 / SAMPLE_DATA_NUM_COLUMNS}%`,
   })
 );
 

--- a/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.styles.ts
+++ b/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.styles.ts
@@ -1,0 +1,19 @@
+import { styled, withStyle } from 'baseui';
+import { StyledTableHeadCellSortable } from 'baseui/table-semantic';
+
+export const components = {
+  SortableHeaderContainer: styled('div', ({ $theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: $theme.sizing.scale300,
+  })),
+  TableSortableHeadCellRoot: withStyle<
+    typeof StyledTableHeadCellSortable,
+    { $width: string }
+  >(StyledTableHeadCellSortable, ({ $theme, $width }) => ({
+    ...$theme.typography.LabelXSmall,
+    width: $width,
+    color: '#5E5E5E',
+  })),
+};

--- a/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.tsx
+++ b/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ChevronUp from 'baseui/icon/chevron-up';
+import ChevronDown from 'baseui/icon/chevron-down';
+
+import type { Props } from './table-sortable-head-cell.types';
+import { components } from './table-sortable-head-cell.styles';
+
+export default function TableSortableHeadCell({
+  name,
+  columnID,
+  width,
+  onSort,
+  sortColumn,
+  sortOrder,
+}: Props) {
+  let SortIcon, sortLabel;
+
+  switch (columnID === sortColumn && sortOrder) {
+    case 'ASC':
+      SortIcon = ChevronUp;
+      sortLabel = 'ascending sorting';
+      break;
+    case 'DESC':
+      SortIcon = ChevronDown;
+      sortLabel = 'descending sorting';
+      break;
+    default:
+      SortIcon = null;
+      sortLabel = 'not sorted';
+      break;
+  }
+
+  return (
+    <components.TableSortableHeadCellRoot
+      $size="compact"
+      $divider="clean"
+      $width={width}
+      onClick={() => onSort(columnID)}
+      $isFocusVisible={false}
+    >
+      <components.SortableHeaderContainer
+        aria-label={`${columnID}, ${sortLabel}`}
+      >
+        {name}
+        {columnID === sortColumn && SortIcon && (
+          <SortIcon size="16px" aria-hidden="true" role="presentation" />
+        )}
+      </components.SortableHeaderContainer>
+    </components.TableSortableHeadCellRoot>
+  );
+}

--- a/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.types.ts
+++ b/src/layout/table/table-sortable-head-cell/table-sortable-head-cell.types.ts
@@ -1,0 +1,8 @@
+export type Props = {
+  name: string;
+  columnID: string;
+  width: string;
+  sortColumn?: string;
+  sortOrder?: string;
+  onSort: (column: string) => void;
+};

--- a/src/layout/table/table.styles.ts
+++ b/src/layout/table/table.styles.ts
@@ -1,0 +1,50 @@
+import { styled, withStyle } from 'baseui';
+import {
+  StyledRoot,
+  StyledTableHeadCell,
+  StyledTableHeadCellSortable,
+  StyledTableBodyCell,
+  StyledTableLoadingMessage,
+} from 'baseui/table-semantic';
+
+export const components = {
+  TableRoot: withStyle(StyledRoot, {
+    alignSelf: 'center',
+    flex: '1 1 0',
+    overflow: 'visible',
+    width: '100%',
+  }),
+  SortableHeaderContainer: styled('div', ({ $theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    columnGap: $theme.sizing.scale300,
+  })),
+  TableMessage: withStyle(StyledTableLoadingMessage, {
+    display: 'flex',
+    justifyContent: 'center',
+  }),
+  TableHeadCell: withStyle<typeof StyledTableHeadCell, { $width: string }>(
+    StyledTableHeadCell,
+    ({ $theme, $width }) => ({
+      ...$theme.typography.LabelXSmall,
+      width: $width,
+      color: '#5E5E5E',
+    })
+  ),
+  TableHeadCellSortable: withStyle<
+    typeof StyledTableHeadCellSortable,
+    { $width: string }
+  >(StyledTableHeadCellSortable, ({ $theme, $width }) => ({
+    ...$theme.typography.LabelXSmall,
+    width: $width,
+    color: '#5E5E5E',
+  })),
+  TableBodyCell: withStyle<typeof StyledTableBodyCell, { $width: string }>(
+    StyledTableBodyCell,
+    ({ $width }) => ({
+      width: $width,
+      wordBreak: 'break-word',
+    })
+  ),
+};

--- a/src/layout/table/table.tsx
+++ b/src/layout/table/table.tsx
@@ -1,21 +1,16 @@
 import React from 'react';
-import { styled, withStyle, type Theme } from 'baseui';
 import {
-  StyledRoot,
   StyledTable,
   StyledTableHead,
   StyledTableHeadRow,
-  StyledTableHeadCell,
-  StyledTableHeadCellSortable,
   StyledTableBody,
   StyledTableBodyRow,
   StyledTableBodyCell,
-  StyledTableLoadingMessage,
 } from 'baseui/table-semantic';
-import ChevronUp from 'baseui/icon/chevron-up';
-import ChevronDown from 'baseui/icon/chevron-down';
 
 import type { Props } from './table.types';
+import { components } from './table.styles';
+import TableSortableHeadCell from './table-sortable-head-cell/table-sortable-head-cell';
 
 export default function Table<T extends Object>({
   data,
@@ -25,22 +20,28 @@ export default function Table<T extends Object>({
   ...sortParams
 }: Props<T>) {
   return (
-    <TableRoot>
+    <components.TableRoot>
       <StyledTable>
         <StyledTableHead>
           <StyledTableHeadRow>
             {columns.map((column) =>
               column.sortable ? (
-                <SortableTableHeadCell
+                <TableSortableHeadCell
                   key={column.id}
                   name={column.name}
                   columnID={column.id}
+                  width={column.width}
                   {...sortParams}
                 />
               ) : (
-                <TableHeadCell $size="compact" $divider="clean" key={column.id}>
+                <components.TableHeadCell
+                  $size="compact"
+                  $divider="clean"
+                  $width={column.width}
+                  key={column.id}
+                >
                   {column.name}
-                </TableHeadCell>
+                </components.TableHeadCell>
               )
             )}
           </StyledTableHeadRow>
@@ -62,109 +63,13 @@ export default function Table<T extends Object>({
                 })}
               </StyledTableBodyRow>
             ))}
-          <TableMessageCell numColumns={columns.length}>
-            {endMessage}
-          </TableMessageCell>
+          <tr>
+            <td colSpan={columns.length}>
+              <components.TableMessage>{endMessage}</components.TableMessage>
+            </td>
+          </tr>
         </StyledTableBody>
       </StyledTable>
-    </TableRoot>
+    </components.TableRoot>
   );
 }
-
-function TableMessageCell({
-  numColumns,
-  children,
-}: {
-  numColumns: number;
-  children: React.ReactNode;
-}) {
-  return (
-    <tr>
-      <td colSpan={numColumns}>
-        <TableMessage>{children}</TableMessage>
-      </td>
-    </tr>
-  );
-}
-
-function SortableTableHeadCell({
-  name,
-  columnID,
-  sortColumn,
-  sortOrder,
-  onSort,
-}: {
-  name: string;
-  columnID: string;
-  sortColumn?: string;
-  sortOrder?: string;
-  onSort: (column: string) => void;
-}) {
-  let SortIcon, sortLabel;
-
-  switch (columnID === sortColumn && sortOrder) {
-    case 'ASC':
-      SortIcon = ChevronUp;
-      sortLabel = 'ascending sorting';
-      break;
-    case 'DESC':
-      SortIcon = ChevronDown;
-      sortLabel = 'descending sorting';
-      break;
-    default:
-      SortIcon = null;
-      sortLabel = 'not sorted';
-      break;
-  }
-
-  return (
-    <TableHeadCellSortable
-      $size="compact"
-      $divider="clean"
-      onClick={() => onSort(columnID)}
-      $isFocusVisible={false}
-    >
-      <SortableHeaderContainer aria-label={`${columnID}, ${sortLabel}`}>
-        {name}
-        {columnID === sortColumn && SortIcon && (
-          <SortIcon size="16px" aria-hidden="true" role="presentation" />
-        )}
-      </SortableHeaderContainer>
-    </TableHeadCellSortable>
-  );
-}
-
-const SortableHeaderContainer = styled('div', ({ $theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  columnGap: $theme.sizing.scale300,
-}));
-
-const TableRoot = withStyle(StyledRoot, ({ $theme }) => ({
-  alignSelf: 'center',
-  flex: '1 1 0',
-  overflow: 'visible',
-  width: '100%',
-}));
-
-const TableMessage = withStyle(StyledTableLoadingMessage, ({ $theme }) => ({
-  display: 'flex',
-  justifyContent: 'center',
-}));
-
-const tableHeadCellStyles = ($theme: Theme) => ({
-  ...$theme.typography.LabelXSmall,
-  color: '#5E5E5E',
-});
-
-const TableHeadCell = withStyle(StyledTableHeadCell, ({ $theme }) => ({
-  ...tableHeadCellStyles($theme),
-}));
-
-const TableHeadCellSortable = withStyle(
-  StyledTableHeadCellSortable,
-  ({ $theme }) => ({
-    ...tableHeadCellStyles($theme),
-  })
-);

--- a/src/layout/table/table.types.ts
+++ b/src/layout/table/table.types.ts
@@ -2,6 +2,7 @@ export type TableColumn<T> = {
   name: string;
   id: string;
   renderCell: React.ComponentType<T> | ((row: T) => React.ReactNode);
+  width: string;
   sortable?: boolean;
 };
 


### PR DESCRIPTION
## Summary
- Refactor table code by moving styled components to separate file
- Add "width" prop to column config to define fixed width for each column
- Configure width for domains table

## Test plan
Ran locally.

![Screenshot 2024-04-24 at 1 22 21 PM](https://github.com/uber/cadence-web/assets/26538200/defcedd0-c7d6-4148-aa07-b91d3fc6a521)
