### PR TITLE
Refactor Domains page

### DIFF
--- a/src/app/(Home)/domains/page.tsx
+++ b/src/app/(Home)/domains/page.tsx
@@ -1,3 +1,3 @@
-import DomainPage from '@/views/domains-page/domains-page';
+import DomainsPage from '@/views/domains-page/domains-page';
 
-export default DomainPage;
+export default DomainsPage;

--- a/src/views/domains-page/config/domains-page-filters.config.ts
+++ b/src/views/domains-page/config/domains-page-filters.config.ts
@@ -1,7 +1,7 @@
-import { DomainPageFilters } from '../domains-page-filters/domains-page-filters.types';
+import { DomainsPageFiltersConfig } from '../domains-page-filters/domains-page-filters.types';
 import DomainsPageFiltersClusterName from '../domains-page-filters-cluster-name/domains-page-filters-cluster-name';
 
-const domainPageFilters = [
+const domainsPageFiltersConfig = [
   {
     id: 'clusterName',
     filterFunc: (domain, queryParams) =>
@@ -11,6 +11,6 @@ const domainPageFilters = [
       ),
     renderFilter: DomainsPageFiltersClusterName,
   },
-] as const satisfies DomainPageFilters;
+] as const satisfies DomainsPageFiltersConfig;
 
-export default domainPageFilters;
+export default domainsPageFiltersConfig;

--- a/src/views/domains-page/config/domains-page-query-params.config.ts
+++ b/src/views/domains-page/config/domains-page-query-params.config.ts
@@ -1,7 +1,7 @@
 import { PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
 import { SortingOrder } from '@/components/table/table.types';
 
-const domainPageQueryParamsConfig: [
+const domainsPageQueryParamsConfig: [
   PageQueryParam<'searchText', string>,
   PageQueryParam<'clusterName', string>,
   PageQueryParam<'sortColumn', string>,
@@ -27,4 +27,4 @@ const domainPageQueryParamsConfig: [
   },
 ] as const;
 
-export default domainPageQueryParamsConfig;
+export default domainsPageQueryParamsConfig;

--- a/src/views/domains-page/config/domains-table-columns.config.ts
+++ b/src/views/domains-page/config/domains-table-columns.config.ts
@@ -3,7 +3,7 @@ import { DomainData } from '../domains-page.types';
 import DomainsTableClusterCell from '../domains-table-cluster-cell/domains-table-cluster-cell';
 import DomainsTableDomainNameCell from '../domains-table-domain-name-cell/domains-table-domain-name-cell';
 
-export const domainTableColumns: Array<TableColumn<DomainData>> = [
+const domainsTableColumnsConfig: Array<TableColumn<DomainData>> = [
   {
     name: 'Domain Name',
     id: 'name',
@@ -18,3 +18,5 @@ export const domainTableColumns: Array<TableColumn<DomainData>> = [
     width: '20%',
   },
 ];
+
+export default domainsTableColumnsConfig;

--- a/src/views/domains-page/domains-page-filters-cluster-name/domains-page-filters-cluster-name.tsx
+++ b/src/views/domains-page/domains-page-filters-cluster-name/domains-page-filters-cluster-name.tsx
@@ -8,7 +8,7 @@ import {
 import { FormControl } from 'baseui/form-control';
 import { Select } from 'baseui/select';
 import CLUSTERS_CONFIGS from '@/config/clusters/clusters.config';
-import { DomainPageFilterProps } from '../domains-page-filters/domains-page-filters.types';
+import { DomainsPageFilterProps } from '../domains-page-filters/domains-page-filters.types';
 
 const clustersOptions = CLUSTERS_CONFIGS.map(({ clusterName }) => ({
   label: clusterName,
@@ -18,7 +18,7 @@ const clustersOptions = CLUSTERS_CONFIGS.map(({ clusterName }) => ({
 function DomainsPageFiltersClusterName({
   onChange,
   value,
-}: DomainPageFilterProps) {
+}: DomainsPageFilterProps) {
   const { cls } = useStyletronClasses(cssStyles);
 
   const clusterValue = clustersOptions.filter(({ id }) => id === value);

--- a/src/views/domains-page/domains-page-filters/domains-page-filters.tsx
+++ b/src/views/domains-page/domains-page-filters/domains-page-filters.tsx
@@ -6,11 +6,12 @@ import { Delete, Filter, Search } from 'baseui/icon';
 import { Cell, Grid } from 'baseui/layout-grid';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
-import domainsPageQueryParamsConfig from '../config/domains-page-query-params.config';
-import getDomainsPageChangedFiltersCount from '../helpers/get-domain-page-changed-filters-count';
-import domainsPageFiltersConfig from '../config/domains-page-filters.config';
+
 import { cssStyles, overrides } from './domains-page-filters.styles';
-import clearDomainsPageFilters from '../helpers/clear-domain-page-filters';
+import domainsPageQueryParamsConfig from '../config/domains-page-query-params.config';
+import domainsPageFiltersConfig from '../config/domains-page-filters.config';
+import getDomainsPageChangedFiltersCount from '../helpers/get-domain-page-changed-filters-count';
+import clearDomainsPageFilters from '../helpers/clear-domains-page-filters';
 
 export default function DomainsPageFilters() {
   const [queryParams, setQueryParams] = usePageQueryParams(

--- a/src/views/domains-page/domains-page-filters/domains-page-filters.tsx
+++ b/src/views/domains-page/domains-page-filters/domains-page-filters.tsx
@@ -6,15 +6,15 @@ import { Delete, Filter, Search } from 'baseui/icon';
 import { Cell, Grid } from 'baseui/layout-grid';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
-import domainPageQueryParamsConfig from '../config/domains-page-query-params.config';
+import domainsPageQueryParamsConfig from '../config/domains-page-query-params.config';
 import getDomainsPageChangedFiltersCount from '../helpers/get-domain-page-changed-filters-count';
-import domainPageFilters from '../config/domains-page-filters.config';
+import domainsPageFiltersConfig from '../config/domains-page-filters.config';
 import { cssStyles, overrides } from './domains-page-filters.styles';
-import clearDomainPageFilters from '../helpers/clear-domain-page-filters';
+import clearDomainsPageFilters from '../helpers/clear-domain-page-filters';
 
-export default function DomainPageFilters() {
+export default function DomainsPageFilters() {
   const [queryParams, setQueryParams] = usePageQueryParams(
-    domainPageQueryParamsConfig,
+    domainsPageQueryParamsConfig,
     { pageRerender: false }
   );
   const { cls, theme } = useStyletronClasses(cssStyles);
@@ -58,7 +58,7 @@ export default function DomainPageFilters() {
           </div>
           {showFilters && (
             <div className={cls.filtersContainer}>
-              {domainPageFilters.map((f) => {
+              {domainsPageFiltersConfig.map((f) => {
                 return (
                   <f.renderFilter
                     key={f.id}
@@ -73,7 +73,7 @@ export default function DomainPageFilters() {
                   kind="tertiary"
                   size="compact"
                   onClick={() => {
-                    clearDomainPageFilters(setQueryParams);
+                    clearDomainsPageFilters(setQueryParams);
                   }}
                 >
                   Clear filters

--- a/src/views/domains-page/domains-page-filters/domains-page-filters.types.ts
+++ b/src/views/domains-page/domains-page-filters/domains-page-filters.types.ts
@@ -2,23 +2,23 @@ import type {
   PageQueryParamKeys,
   PageQueryParamValues,
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
-import domainPageQueryParamsConfig from '@/views/domains-page/config/domains-page-query-params.config';
+import domainsPageQueryParamsConfig from '@/views/domains-page/config/domains-page-query-params.config';
 import { DomainData } from '../domains-page.types';
 
-export type DomainPageFilterProps<InputType = any, OutputType = any> = {
+export type DomainsPageFilterProps<InputType = any, OutputType = any> = {
   value: InputType;
   onChange: (v: OutputType) => void;
 };
 
-export type DomainPageFilter = {
-  id: PageQueryParamKeys<typeof domainPageQueryParamsConfig>;
+export type DomainsPageFilterConfig = {
+  id: PageQueryParamKeys<typeof domainsPageQueryParamsConfig>;
   filterFunc: (
     d: DomainData,
-    queryParams: PageQueryParamValues<typeof domainPageQueryParamsConfig>
+    queryParams: PageQueryParamValues<typeof domainsPageQueryParamsConfig>
   ) => boolean;
   renderFilter:
-    | React.ComponentType<DomainPageFilterProps>
-    | ((props: DomainPageFilterProps) => React.ReactNode);
+    | React.ComponentType<DomainsPageFilterProps>
+    | ((props: DomainsPageFilterProps) => React.ReactNode);
 };
 
-export type DomainPageFilters = Array<DomainPageFilter>;
+export type DomainsPageFiltersConfig = Array<DomainsPageFilterConfig>;

--- a/src/views/domains-page/domains-page-title/__tests__/domain-page-title.test.tsx
+++ b/src/views/domains-page/domains-page-title/__tests__/domain-page-title.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { render, screen } from '@/test-utils/rtl';
-import DomainPageTitle from '../domains-page-title';
+import DomainsPageTitle from '../domains-page-title';
 
-describe('DomainPageTitle', () => {
+describe('DomainsPageTitle', () => {
   it('should render title', async () => {
-    render(<DomainPageTitle countBadge={null} />);
+    render(<DomainsPageTitle countBadge={null} />);
     await screen.findByText('All domains');
   });
 
   it('should render passed count badge', async () => {
-    render(<DomainPageTitle countBadge={<div data-testid="count-badge" />} />);
+    render(<DomainsPageTitle countBadge={<div data-testid="count-badge" />} />);
     await screen.findAllByTestId('count-badge');
   });
 });

--- a/src/views/domains-page/domains-page-title/domains-page-title.tsx
+++ b/src/views/domains-page/domains-page-title/domains-page-title.tsx
@@ -5,7 +5,7 @@ import useStyletronClasses from '@/hooks/use-styletron-classes';
 import { cssStyles } from './domains-page-title.styles';
 import { Props } from './domains-page-title.types';
 
-export default function DomainPageTitle({ countBadge }: Props) {
+export default function DomainsPageTitle({ countBadge }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
 
   return (

--- a/src/views/domains-page/domains-page.tsx
+++ b/src/views/domains-page/domains-page.tsx
@@ -1,7 +1,7 @@
-import React, { JSXElementConstructor, Suspense } from 'react';
-import DomainPageHeader from '@/views/domains-page/domains-page-filters/domains-page-filters';
+import React, { Suspense } from 'react';
+import DomainsPageFilters from '@/views/domains-page/domains-page-filters/domains-page-filters';
 import DomainsTable from '@/views/domains-page/domains-table/domains-table';
-import DomainPageTitle from '@/views/domains-page/domains-page-title/domains-page-title';
+import DomainsPageTitle from '@/views/domains-page/domains-page-title/domains-page-title';
 import DomainsPageTitleBadge from '@/views/domains-page/domains-page-title-badge/domains-page-title-badge';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import { getCachedAllDomains } from '@/views/domains-page/helpers/get-all-domains';
@@ -10,7 +10,7 @@ import AsyncPropsLoader from '@/components/async-props-loader/async-props-loader
 export default async function DomainsPage() {
   return (
     <>
-      <DomainPageTitle
+      <DomainsPageTitle
         countBadge={
           <Suspense>
             <AsyncPropsLoader
@@ -23,9 +23,7 @@ export default async function DomainsPage() {
           </Suspense>
         }
       />
-      <Suspense>
-        <DomainPageHeader />
-      </Suspense>
+      <DomainsPageFilters />
       <Suspense fallback={<SectionLoadingIndicator />}>
         <AsyncPropsLoader
           component={DomainsTable}

--- a/src/views/domains-page/domains-table-end-message/domains-table-end-message.tsx
+++ b/src/views/domains-page/domains-table-end-message/domains-table-end-message.tsx
@@ -7,7 +7,7 @@ const EndMessageContainer = styled('div', ({ $theme }) => ({
   color: $theme.colors.contentTertiary,
 }));
 
-export default function DomainTableEndMessage({
+export default function DomainsTableEndMessage({
   canLoadMoreResults,
   hasSearchResults,
   infiniteScrollTargetRef,

--- a/src/views/domains-page/domains-table/domains-table.tsx
+++ b/src/views/domains-page/domains-table/domains-table.tsx
@@ -6,28 +6,31 @@ import Table from '@/components/table/table';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import sortBy, { SortByReturnValue, toggleSortOrder } from '@/utils/sort-by';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
-import DomainTableEndMessage from '@/views/domains-page/domains-table-end-message/domains-table-end-message';
-import domainPageQueryParamsConfig from '../config/domains-page-query-params.config';
+import DomainsTableEndMessage from '@/views/domains-page/domains-table-end-message/domains-table-end-message';
+import domainsPageQueryParamsConfig from '../config/domains-page-query-params.config';
 
-import { domainTableColumns } from '../config/domains-table-columns.config';
+import domainsTableColumnsConfig from '../config/domains-table-columns.config';
 
 import type { DomainData } from '../domains-page.types';
 import { SortingOrder } from '@/components/table/table.types';
 import { Props } from './domains-table.types';
 import { cssStyles } from './domains-table.styles';
 import { useInView } from 'react-intersection-observer';
-import domainPageFilters from '../config/domains-page-filters.config';
+import domainsPageFiltersConfig from '../config/domains-page-filters.config';
 
 const DOMAINS_LIST_PAGE_SIZE = 20;
 
-function DomainsTable({ domains, tableColumns = domainTableColumns }: Props) {
+function DomainsTable({
+  domains,
+  tableColumns = domainsTableColumnsConfig,
+}: Props) {
   const { cls } = useStyletronClasses(cssStyles);
   const [visibleListItems, setVisibleListItems] = useState(
     Math.min(DOMAINS_LIST_PAGE_SIZE, domains.length)
   );
 
   const [queryParams, setQueryParams] = usePageQueryParams(
-    domainPageQueryParamsConfig,
+    domainsPageQueryParamsConfig,
     { pageRerender: false }
   );
 
@@ -42,7 +45,7 @@ function DomainsTable({ domains, tableColumns = domainTableColumns }: Props) {
         (!lowerCaseSearch ||
           d.id.toLowerCase().includes(lowerCaseSearch) ||
           d.name.toLowerCase().includes(lowerCaseSearch)) &&
-        domainPageFilters.every((f) => f.filterFunc(d, queryParams))
+        domainsPageFiltersConfig.every((f) => f.filterFunc(d, queryParams))
     );
   }, [domains, queryParams]);
   const sortedDomains = useMemo(
@@ -91,7 +94,7 @@ function DomainsTable({ domains, tableColumns = domainTableColumns }: Props) {
             sortColumn={queryParams.sortColumn}
             sortOrder={queryParams.sortOrder as SortingOrder}
             endMessage={
-              <DomainTableEndMessage
+              <DomainsTableEndMessage
                 key={visibleListItems}
                 canLoadMoreResults={
                   paginatedDomains.length < sortedDomains.length

--- a/src/views/domains-page/domains-table/domains-table.types.ts
+++ b/src/views/domains-page/domains-table/domains-table.types.ts
@@ -1,9 +1,9 @@
 import type { TableColumn } from '@/components/table/table.types';
 import type { DomainData } from '../domains-page.types';
 
-export type DomainTableColumns = Array<TableColumn<DomainData>>;
+export type DomainsTableColumns = Array<TableColumn<DomainData>>;
 
 export type Props = {
   domains: Array<DomainData>;
-  tableColumns?: DomainTableColumns;
+  tableColumns?: DomainsTableColumns;
 };

--- a/src/views/domains-page/helpers/clear-domains-page-filters.ts
+++ b/src/views/domains-page/helpers/clear-domains-page-filters.ts
@@ -2,15 +2,15 @@ import {
   PageQueryParamSetter,
   PageQueryParams,
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
-import domainPageFilters from '../config/domains-page-filters.config';
-import { DomainPageFilters } from '../domains-page-filters/domains-page-filters.types';
+import domainsPageFiltersConfig from '../config/domains-page-filters.config';
+import { DomainsPageFiltersConfig } from '../domains-page-filters/domains-page-filters.types';
 
-function clearDomainPageFilters<P extends PageQueryParams>(
+function clearDomainsPageFilters<P extends PageQueryParams>(
   setQueryParams: PageQueryParamSetter<P>,
-  filters: DomainPageFilters = domainPageFilters
+  filters: DomainsPageFiltersConfig = domainsPageFiltersConfig
 ) {
   const emptyFiltersKeyValueEntries = filters.map((f) => [f.id, undefined]);
   const emptyValuesObj = Object.fromEntries(emptyFiltersKeyValueEntries);
   setQueryParams(emptyValuesObj);
 }
-export default clearDomainPageFilters;
+export default clearDomainsPageFilters;

--- a/src/views/domains-page/helpers/get-domain-page-changed-filters-count.ts
+++ b/src/views/domains-page/helpers/get-domain-page-changed-filters-count.ts
@@ -2,14 +2,14 @@ import {
   PageQueryParamValues,
   PageQueryParams,
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
-import domainPageFilters from '../config/domains-page-filters.config';
-import domainPageQueryParamsConfig from '../config/domains-page-query-params.config';
-import { DomainPageFilters } from '../domains-page-filters/domains-page-filters.types';
+import domainsPageFiltersConfig from '../config/domains-page-filters.config';
+import domainsPageQueryParamsConfig from '../config/domains-page-query-params.config';
+import { DomainsPageFiltersConfig } from '../domains-page-filters/domains-page-filters.types';
 
 function getDomainsPageChangedFiltersCount(
   queryParams: PageQueryParamValues<PageQueryParams>,
-  queryParamsConfig: PageQueryParams = domainPageQueryParamsConfig,
-  filters: DomainPageFilters = domainPageFilters
+  queryParamsConfig: PageQueryParams = domainsPageQueryParamsConfig,
+  filters: DomainsPageFiltersConfig = domainsPageFiltersConfig
 ) {
   const configsByKey = Object.fromEntries(
     queryParamsConfig.map((c) => [c.key, c])


### PR DESCRIPTION
- Rename all occurrences of "domain" to "domains"
- Rename DomainPageHeader import to DomainsPageFilters, in line with the actual component name
- Remove Suspense boundary around DomainsPageFilters
- Add "config" suffix to all config exports
- Make all config exports default