### PR TITLE
Cache domains request within rendering session

### DIFF
--- a/src/views/domains-page/helpers/get-all-domains.ts
+++ b/src/views/domains-page/helpers/get-all-domains.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { unstable_cache } from 'next/cache';
 import { DomainData } from '../domains-page.types';
@@ -18,8 +19,8 @@ export const getAllDomains = async () => {
   return { domains: Object.values(allUniqueDomains) };
 };
 
-export const getCachedAllDomains = unstable_cache(
+export const getCachedAllDomains = cache(unstable_cache(
   getAllDomains,
   ['cluster-domains'],
   { revalidate: 60 }
-);
+));


### PR DESCRIPTION
`unstable_cache` seems to get invoked if it the its cached value is invalidated.
This causes the requests that are added to it to be called multiple times as it is used multiple times in the same component.
To avoid that `unstable_cache` is rendered wrapped with `React.cache` so that it is only invoked once within the same render session.

This issue was found by logging from within the `getAllDomains` and whenever i use the function after the revalidate time period values were logged twice.