### PR TITLE
Page section component

### DIFF
--- a/src/components/page-section/__test__/page-section.test.tsx
+++ b/src/components/page-section/__test__/page-section.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@/test-utils/rtl';
+import PageSection from '../page-section';
+
+describe('PageSection', () => {
+  it('should use section tag by default', () => {
+    const { getByRole } = render(<PageSection aria-label="test label">Test Content</PageSection>);
+    const sectionElement = getByRole('region', { name: 'test label' });
+    expect(sectionElement).toBeInTheDocument();
+    expect(sectionElement.tagName).toBe('SECTION');
+  });
+  it('renders with custom element', () => {
+    const { getByRole } = render(<PageSection as="nav">Test Content</PageSection>);
+    const sectionElement = getByRole('navigation', { name: '' });
+    expect(sectionElement).toBeInTheDocument();
+    expect(sectionElement.tagName).toBe('NAV');
+  });
+  it('renders provided children', () => {
+    const { getByText } = render(<PageSection as="menu">Test menu</PageSection>);
+    const sectionElement = getByText('Test menu');
+    expect(sectionElement).toBeInTheDocument();
+  });
+});

--- a/src/components/page-section/__test__/page-section.test.tsx
+++ b/src/components/page-section/__test__/page-section.test.tsx
@@ -4,19 +4,25 @@ import PageSection from '../page-section';
 
 describe('PageSection', () => {
   it('should use section tag by default', () => {
-    const { getByRole } = render(<PageSection aria-label="test label">Test Content</PageSection>);
+    const { getByRole } = render(
+      <PageSection aria-label="test label">Test Content</PageSection>
+    );
     const sectionElement = getByRole('region', { name: 'test label' });
     expect(sectionElement).toBeInTheDocument();
     expect(sectionElement.tagName).toBe('SECTION');
   });
   it('renders with custom element', () => {
-    const { getByRole } = render(<PageSection as="nav">Test Content</PageSection>);
+    const { getByRole } = render(
+      <PageSection as="nav">Test Content</PageSection>
+    );
     const sectionElement = getByRole('navigation', { name: '' });
     expect(sectionElement).toBeInTheDocument();
     expect(sectionElement.tagName).toBe('NAV');
   });
   it('renders provided children', () => {
-    const { getByText } = render(<PageSection as="menu">Test menu</PageSection>);
+    const { getByText } = render(
+      <PageSection as="menu">Test menu</PageSection>
+    );
     const sectionElement = getByText('Test menu');
     expect(sectionElement).toBeInTheDocument();
   });

--- a/src/components/page-section/page-section.tsx
+++ b/src/components/page-section/page-section.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { Cell, Grid } from 'baseui/layout-grid';
 import { Props } from './page-section.types';
 
-export default function PageSection<T extends React.ComponentType<any> | keyof JSX.IntrinsicElements = "section">({ children, as, ...rest }: Props<T>) {
+export default function PageSection<
+  T extends React.ComponentType<any> | keyof JSX.IntrinsicElements = 'section',
+>({ children, as, ...rest }: Props<T>) {
   const Component = as || 'section';
   return (
     <Component {...rest}>

--- a/src/components/page-section/page-section.tsx
+++ b/src/components/page-section/page-section.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Cell, Grid } from 'baseui/layout-grid';
+import { Props } from './page-section.types';
+
+export default function PageSection<T extends React.ComponentType<any> | keyof JSX.IntrinsicElements = "section">({ children, as, ...rest }: Props<T>) {
+  const Component = as || 'section';
+  return (
+    <Component {...rest}>
+      <Grid>
+        <Cell span={12}>{children}</Cell>
+      </Grid>
+    </Component>
+  );
+}

--- a/src/components/page-section/page-section.types.tsx
+++ b/src/components/page-section/page-section.types.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export type Props<T extends React.ComponentType<any> | keyof JSX.IntrinsicElements> = {
+export type Props<
+  T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
+> = {
   children: React.ReactNode;
   as?: T;
 } & Omit<React.ComponentPropsWithoutRef<T>, 'as'>;

--- a/src/components/page-section/page-section.types.tsx
+++ b/src/components/page-section/page-section.types.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export type Props<T extends React.ComponentType<any> | keyof JSX.IntrinsicElements> = {
+  children: React.ReactNode;
+  as?: T;
+} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>;


### PR DESCRIPTION
Creating a component to handle page sections and adding default spacing to it:
- The component accepts an `as` prop to allow changing the default `section` element that is used.
- The types are built to infer the props needed by the element/component provided in the `as` prop and type check that those props are passed to `PageSection`.