### PR TITLE
Update workflow status badge to use grpc enum

### DIFF
--- a/src/views/shared/workflow-status-tag/__tests__/workflow-status-tag.test.tsx
+++ b/src/views/shared/workflow-status-tag/__tests__/workflow-status-tag.test.tsx
@@ -23,48 +23,48 @@ describe('WorkflowStatusTag', () => {
     text: string;
     link?: string;
   }> = [
-    {
-      name: 'should render Running correctly',
-      workflowStatus: 'running',
-      text: 'Running',
-    },
-    {
-      name: 'should render Completed correctly',
-      workflowStatus: 'completed',
-      text: 'Completed',
-    },
-    {
-      name: 'should render Failed correctly',
-      workflowStatus: 'failed',
-      text: 'Failed',
-    },
-    {
-      name: 'should render Timed Out correctly',
-      workflowStatus: 'timedOut',
-      text: 'Timed Out',
-    },
-    {
-      name: 'should render Canceled correctly',
-      workflowStatus: 'canceled',
-      text: 'Canceled',
-    },
-    {
-      name: 'should render Terminated correctly',
-      workflowStatus: 'terminated',
-      text: 'Terminated',
-    },
-    {
-      name: 'should render Continued As New correctly',
-      workflowStatus: 'continuedAsNew',
-      text: 'Continued As New',
-    },
-    {
-      name: 'should work with links correctly',
-      workflowStatus: 'continuedAsNew',
-      text: 'Continued As New',
-      link: 'mock_continued_workflow_link',
-    },
-  ];
+      {
+        name: 'should render Running correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_STATUS_RUNNING',
+        text: 'Running',
+      },
+      {
+        name: 'should render Completed correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+        text: 'Completed',
+      },
+      {
+        name: 'should render Failed correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_FAILED',
+        text: 'Failed',
+      },
+      {
+        name: 'should render Timed Out correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_TIMED_OUT',
+        text: 'Timed Out',
+      },
+      {
+        name: 'should render Canceled correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_CANCELED',
+        text: 'Canceled',
+      },
+      {
+        name: 'should render Terminated correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED',
+        text: 'Terminated',
+      },
+      {
+        name: 'should render Continued As New correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_CONTINUED_AS_NEW',
+        text: 'Continued As New',
+      },
+      {
+        name: 'should work with links correctly',
+        workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_CONTINUED_AS_NEW',
+        text: 'Continued As New',
+        link: 'mock_continued_workflow_link',
+      },
+    ];
 
   tests.forEach((test) => {
     it(test.name, () => {

--- a/src/views/shared/workflow-status-tag/workflow-status-tag-icon/__tests__/workflow-status-tag-icon.test.tsx
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag-icon/__tests__/workflow-status-tag-icon.test.tsx
@@ -21,18 +21,18 @@ describe('WorkflowStatusTagIcon', () => {
     link?: string;
     expectedIcon?: string;
   }> = [
-    {
-      name: 'should render Running start icon correctly',
-      kind: 'start',
-      status: 'running',
-      expectedIcon: 'running-spinner',
-    },
-    {
-      name: 'should return null if there is no icon configured',
-      kind: 'end',
-      status: 'running',
-    },
-  ];
+      {
+        name: 'should render Running start icon correctly',
+        kind: 'start',
+        status: 'WORKFLOW_EXECUTION_STATUS_RUNNING',
+        expectedIcon: 'running-spinner',
+      },
+      {
+        name: 'should return null if there is no icon configured',
+        kind: 'end',
+        status: 'WORKFLOW_EXECUTION_STATUS_RUNNING',
+      },
+    ];
 
   tests.forEach((test) => {
     it(test.name, () => {

--- a/src/views/shared/workflow-status-tag/workflow-status-tag-icon/workflow-status-tag-icon.tsx
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag-icon/workflow-status-tag-icon.tsx
@@ -6,7 +6,7 @@ import { Props } from './workflow-status-tag-icon.types';
 export default function WorkflowStatusTagIcon(props: Props) {
   switch (props.kind) {
     case 'start':
-      if (props.status === 'running') {
+      if (props.status === 'WORKFLOW_EXECUTION_STATUS_RUNNING') {
         return <styled.Spinner aria-label="running-spinner" />;
       }
     case 'end':

--- a/src/views/shared/workflow-status-tag/workflow-status-tag.constants.ts
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag.constants.ts
@@ -1,12 +1,12 @@
 import type { WorkflowStatus, Props } from './workflow-status-tag.types';
 
 export const WORKFLOW_STATUS_NAMES: Record<WorkflowStatus, string> = {
-  running: 'Running',
-  completed: 'Completed',
-  failed: 'Failed',
-  canceled: 'Canceled',
-  terminated: 'Terminated',
-  continuedAsNew: 'Continued As New',
-  timedOut: 'Timed Out',
-  unknown: 'Unknown',
+  WORKFLOW_EXECUTION_STATUS_RUNNING: 'Running',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED: 'Completed',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_FAILED: 'Failed',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_CANCELED: 'Canceled',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED: 'Terminated',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_CONTINUED_AS_NEW: 'Continued As New',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_TIMED_OUT: 'Timed Out',
+  WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID: 'Unknown',
 };

--- a/src/views/shared/workflow-status-tag/workflow-status-tag.styles.ts
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag.styles.ts
@@ -11,21 +11,21 @@ export function overrides(args: OverridesArgs) {
         style: ({ $theme }: { $theme: Theme }): StyleObject => {
           let tagColor: string;
           switch (args.status) {
-            case 'running':
+            case 'WORKFLOW_EXECUTION_STATUS_RUNNING':
               tagColor = $theme.colors.accent100;
               break;
-            case 'completed':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED':
               tagColor = $theme.colors.positive100;
               break;
-            case 'failed':
-            case 'timedOut':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_FAILED':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_TIMED_OUT':
               tagColor = $theme.colors.negative100;
               break;
-            case 'canceled':
-            case 'terminated':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_CANCELED':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED':
               tagColor = $theme.colors.warning100;
               break;
-            case 'continuedAsNew':
+            case 'WORKFLOW_EXECUTION_CLOSE_STATUS_CONTINUED_AS_NEW':
               tagColor = $theme.colors.primary100;
               break;
             default:

--- a/src/views/shared/workflow-status-tag/workflow-status-tag.tsx
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { Tag, VARIANT } from 'baseui/tag';
 

--- a/src/views/shared/workflow-status-tag/workflow-status-tag.types.ts
+++ b/src/views/shared/workflow-status-tag/workflow-status-tag.types.ts
@@ -1,12 +1,12 @@
 export type WorkflowStatus =
-  | 'running'
-  | 'completed'
-  | 'failed'
-  | 'canceled'
-  | 'terminated'
-  | 'continuedAsNew'
-  | 'timedOut'
-  | 'unknown';
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_FAILED'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_CANCELED'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_CONTINUED_AS_NEW'
+  | 'WORKFLOW_EXECUTION_CLOSE_STATUS_TIMED_OUT'
+  | 'WORKFLOW_EXECUTION_STATUS_RUNNING';
 
 export type Props = {
   status: WorkflowStatus;


### PR DESCRIPTION
- changing enum for workflow status tag to use the values from GRPC response (this is a temp state until we work on data transformation layer)
- added "use client" to the status tag to be able to use it in server components.