### PR TITLE
fix linting issues with workflow tab content

### DIFF
--- a/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
@@ -2,5 +2,5 @@ import type { WorkflowPageTabsContentsMap } from '../workflow-page-tab-content/w
 
 export const worflowPageTabsContentsMapConfig = {
   // TODO: @assem.hafez add summary tab
-  summary: () => null,
+  summary: (props: any) => null,
 } as const satisfies WorkflowPageTabsContentsMap;

--- a/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
@@ -1,8 +1,8 @@
 import type { WorkflowPageTabsContentsMap } from '../workflow-page-tab-content/workflow-page-tab-content.types';
 
-const worflowPageTabsContentsMapConfig = {
+const workflowPageTabsContentsMapConfig = {
   // TODO: @assem.hafez add summary tab
   summary: (props: any) => null,
 } as const satisfies WorkflowPageTabsContentsMap;
 
-export default worflowPageTabsContentsMapConfig;
+export default workflowPageTabsContentsMapConfig;

--- a/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
@@ -1,6 +1,8 @@
 import type { WorkflowPageTabsContentsMap } from '../workflow-page-tab-content/workflow-page-tab-content.types';
 
-export const worflowPageTabsContentsMapConfig = {
+const worflowPageTabsContentsMapConfig = {
   // TODO: @assem.hafez add summary tab
   summary: (props: any) => null,
 } as const satisfies WorkflowPageTabsContentsMap;
+
+export default worflowPageTabsContentsMapConfig;

--- a/src/views/workflow-page/workflow-page-tab-content/__tests__/workflow-page-tab-content.test.tsx
+++ b/src/views/workflow-page/workflow-page-tab-content/__tests__/workflow-page-tab-content.test.tsx
@@ -14,6 +14,11 @@ const mockedTabContentsMap: WorkflowPageTabsContentsMap = {
   summary: MockedTabContent,
 };
 
+jest.mock(
+  '../config/workflow-page-tabs-contents-map.config',
+  () => mockedTabContentsMap
+);
+
 const params: WorkflowPageTabContentProps['params'] = {
   cluster: 'example-cluster',
   domain: 'example-domain',
@@ -24,19 +29,14 @@ const params: WorkflowPageTabContentProps['params'] = {
 
 describe('WorkflowPageTabContent', () => {
   it('renders tab content with correct params when workflowTab exists in contentsMap', () => {
-    const { getByText } = render(
-      <WorkflowPageTabContent
-        params={params}
-        tabsContentMap={mockedTabContentsMap}
-      />
-    );
+    const { getByText } = render(<WorkflowPageTabContent params={params} />);
     expect(getByText(JSON.stringify(params))).toBeInTheDocument();
   });
 
   it('does not return any tab cotent if workflowTab is not present in the contentsMap', () => {
     const paramsWithoutTabContent = { ...params, workflowTab: 'unkown-tab' };
-    //@ts-ignore allow passing unknown workflowtab to test recieving wrong value as a param
     const { container } = render(
+      //@ts-ignore allow passing unknown workflowtab to test recieving wrong value as a param
       <WorkflowPageTabContent params={paramsWithoutTabContent} />
     );
     expect(container.firstChild?.textContent).toBe('');

--- a/src/views/workflow-page/workflow-page-tab-content/__tests__/workflow-page-tab-content.test.tsx
+++ b/src/views/workflow-page/workflow-page-tab-content/__tests__/workflow-page-tab-content.test.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
 import { render } from '@/test-utils/rtl';
 import WorkflowPageTabContent from '../workflow-page-tab-content';
-import type {
-  WorkflowPageTabContentProps,
-  WorkflowPageTabsContentsMap,
-} from '../workflow-page-tab-content.types';
+import type { WorkflowPageTabContentProps } from '../workflow-page-tab-content.types';
 
-const MockedTabContent = ({ params }: WorkflowPageTabContentProps) => (
-  <div>{JSON.stringify(params)}</div>
-);
-
-const mockedTabContentsMap: WorkflowPageTabsContentsMap = {
-  summary: MockedTabContent,
-};
-
-jest.mock(
-  '../config/workflow-page-tabs-contents-map.config',
-  () => mockedTabContentsMap
-);
+jest.mock('../../config/workflow-page-tabs-contents-map.config', () => ({
+  summary: ({ params }: WorkflowPageTabContentProps) => (
+    <div>{JSON.stringify(params)}</div>
+  ),
+}));
 
 const params: WorkflowPageTabContentProps['params'] = {
   cluster: 'example-cluster',

--- a/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
+++ b/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
@@ -1,14 +1,14 @@
 'use client';
 import React from 'react';
 import type { Props } from './workflow-page-tab-content.types';
-import worflowPageTabsContentsMapConfig from '../config/workflow-page-tabs-contents-map.config';
+import workflowPageTabsContentsMapConfig from '../config/workflow-page-tabs-contents-map.config';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 import { cssStyles } from './workflow-page-tab-content.styles';
 
 export default function WorkflowPageTabContent({ params }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
   const selectedWorkflowTabName = params.workflowTab;
-  const TabContent = worflowPageTabsContentsMapConfig[selectedWorkflowTabName];
+  const TabContent = workflowPageTabsContentsMapConfig[selectedWorkflowTabName];
   if (TabContent)
     return (
       <div className={cls.tabContentContainer}>

--- a/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
+++ b/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
@@ -5,13 +5,10 @@ import { worflowPageTabsContentsMapConfig } from '../config/workflow-page-tabs-c
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 import { cssStyles } from './workflow-page-tab-content.styles';
 
-export default function WorkflowPageTabContent({
-  params,
-  tabsContentMap = worflowPageTabsContentsMapConfig,
-}: Props) {
+export default function WorkflowPageTabContent({ params }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
   const selectedWorkflowTabName = params.workflowTab;
-  const TabContent = tabsContentMap[selectedWorkflowTabName];
+  const TabContent = worflowPageTabsContentsMapConfig[selectedWorkflowTabName];
   if (TabContent)
     return (
       <div className={cls.tabContentContainer}>

--- a/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
+++ b/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import type { Props } from './workflow-page-tab-content.types';
-import { worflowPageTabsContentsMapConfig } from '../config/workflow-page-tabs-contents-map.config';
+import worflowPageTabsContentsMapConfig from '../config/workflow-page-tabs-contents-map.config';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 import { cssStyles } from './workflow-page-tab-content.styles';
 

--- a/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types.ts
+++ b/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types.ts
@@ -21,5 +21,4 @@ export type WorkflowPageTabContentProps = {
 
 export type Props = {
   params: WorkflowPageTabsParams;
-  tabsContentMap?: WorkflowPageTabsContentsMap;
 };


### PR DESCRIPTION
seems like nextjs checks the types of the component used in pages.
So had to remove the optional config prop from `WorkflowPageTabContent`
and revisit the unit tests