### PR TITLE
Domains page links

### DIFF
--- a/src/views/domains-page/domains-table-cluster-cell/__tests__/domains-table-cluster-cell.test.tsx
+++ b/src/views/domains-page/domains-table-cluster-cell/__tests__/domains-table-cluster-cell.test.tsx
@@ -9,11 +9,11 @@ describe('DomainTableClusterCell', () => {
     const clusterLinks = await screen.findAllByRole('link');
     clusterLinks.forEach((clusterLink, i) => {
       expect(clusterLink.innerHTML).toBe(globalDomain.clusters[i].clusterName);
-      expect(clusterLink).toHaveAttribute('href', '/');
+      expect(clusterLink).toHaveAttribute('href', `/domains/${globalDomain.name}/${globalDomain.clusters[i].clusterName}`);
     });
   });
 
-  it('should render cluster name as text if domain is in single cluser', async () => {
+  it('should render cluster name as text if domain is in single cluster', async () => {
     render(<DomainsTableClusterCell {...localDomain} />);
     const clusterLinks = screen.queryAllByRole('link');
     expect(clusterLinks).toHaveLength(0);

--- a/src/views/domains-page/domains-table-cluster-cell/domains-table-cluster-cell.tsx
+++ b/src/views/domains-page/domains-table-cluster-cell/domains-table-cluster-cell.tsx
@@ -14,7 +14,7 @@ function DomainsTableClusterCell(props: DomainData) {
     <div className={cls.clustersLinks}>
       {props.clusters.length > 1 &&
         props.clusters.map(({ clusterName }) => (
-          <TableLink key={clusterName} href={'/'}>
+          <TableLink key={clusterName} href={`/domains/${props.name}/${clusterName}`}>
             {clusterName}
           </TableLink>
         ))}

--- a/src/views/domains-page/domains-table-domain-name-cell/__tests__/domains-table-domain-name-cell.test.tsx
+++ b/src/views/domains-page/domains-table-domain-name-cell/__tests__/domains-table-domain-name-cell.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@/test-utils/rtl';
+import DomainsTableDomainNameCell from '../domains-table-domain-name-cell';
+import { globalDomain } from '../../__fixtures__/domains';
+
+describe('DomainTableClusterCell', () => {
+  it('should render link for domain if domain using the active cluster', async () => {
+    render(<DomainsTableDomainNameCell {...globalDomain} />);
+    const clusterLinks = await screen.findAllByRole('link');
+    clusterLinks.forEach((clusterLink, i) => {
+      expect(clusterLink.innerHTML).toBe(globalDomain.name);
+      expect(clusterLink).toHaveAttribute('href', `/domains/${globalDomain.name}/${globalDomain.activeClusterName}`);
+    });
+  });
+});

--- a/src/views/domains-page/domains-table-domain-name-cell/domains-table-domain-name-cell.tsx
+++ b/src/views/domains-page/domains-table-domain-name-cell/domains-table-domain-name-cell.tsx
@@ -15,7 +15,7 @@ function DomainsTableDomainNameCell(props: DomainData) {
   return (
     <div className={cls.domainNameCell}>
       <Image width={16} height={16} alt="Cadence Icon" src={cadenceIcon} />
-      <TableLink href={'a'}>{props.name}</TableLink>
+      <TableLink href={`/domains/${props.name}/${props.activeClusterName}`}>{props.name}</TableLink>
     </div>
   );
 }

--- a/src/views/domains-page/domains-table-link/domains-table-link.tsx
+++ b/src/views/domains-page/domains-table-link/domains-table-link.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { withStyle } from 'baseui';
 import { StyledLink } from 'baseui/link';
+import Link from 'next/link';
+import { Props } from './domains-table-link.types';
 
 const TableLinkBase = withStyle<typeof StyledLink, { disabled: boolean }>(
   StyledLink,
@@ -18,18 +20,13 @@ const TableLinkBase = withStyle<typeof StyledLink, { disabled: boolean }>(
 export default function DomainsTableLink({
   href,
   children,
-  className,
-}: {
-  href?: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
+  ...restProps
+}: Props) {
   return (
     <TableLinkBase
-      className={className}
+      {...restProps}
+      $as={Link}
       href={href}
-      target="_blank"
-      rel="noreferrer"
       disabled={!href}
     >
       {children}

--- a/src/views/domains-page/domains-table-link/domains-table-link.types.ts
+++ b/src/views/domains-page/domains-table-link/domains-table-link.types.ts
@@ -1,0 +1,4 @@
+import Link from "next/link";
+import React from "react";
+
+export type Props = React.ComponentProps<typeof Link>;


### PR DESCRIPTION
Pointing domain name and cluster to the actual domain page link.

![Screenshot 2024-05-27 at 14 40 06](https://github.com/uber/cadence-web/assets/15056337/5bbbc3cb-ba67-4817-8ef4-665af81a8253)

- The domain name links to the domain on the active cluster 
-Each cluster name points its the domain on that cluster