### PR TITLE
Fix page query params types and adapt existing configs to it

### DIFF
--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -13,8 +13,8 @@ export type Props<T> = {
   endMessage: React.ReactNode;
   // Sort params
   onSort: (column: string) => void;
-  sortColumn: string;
-  sortOrder: SortingOrder;
+  sortColumn?: string;
+  sortOrder?: SortingOrder;
 };
 
 export type SortingOrder = 'ASC' | 'DESC';

--- a/src/hooks/use-page-query-params/__fixtures__/page-query-params.fixtures.ts
+++ b/src/hooks/use-page-query-params/__fixtures__/page-query-params.fixtures.ts
@@ -4,11 +4,11 @@ import {
 } from '../use-page-query-params.types';
 
 export const queryParamsConfig: [
-  PageQueryParam<'sortBy', string>,
-  PageQueryParam<'aliased', string>,
+  PageQueryParam<'sortBy', string | undefined>,
+  PageQueryParam<'aliased', string | undefined>,
   PageQueryParam<'defaulted', string>,
-  PageQueryParam<'parsed', number>,
-  PageQueryParamMultiValue<'parsedMultiVal', number[]>,
+  PageQueryParam<'parsed', number | undefined>,
+  PageQueryParamMultiValue<'parsedMultiVal', number[] | undefined>,
   PageQueryParamMultiValue<'multiValDefaulted', string[]>,
 ] = [
   {
@@ -28,7 +28,7 @@ export const queryParamsConfig: [
   },
   {
     key: 'parsedMultiVal',
-    parseValue: (v) => (v ? parseInt(v) : 0),
+    parseValue: (vals) => vals.map((v) => parseInt(v)),
     isMultiValue: true,
   },
   {

--- a/src/hooks/use-page-query-params/helpers/get-page-query-params-values.ts
+++ b/src/hooks/use-page-query-params/helpers/get-page-query-params-values.ts
@@ -22,8 +22,8 @@ const getPageQueryParamsValues = <P extends PageQueryParams>(
   return config.reduce((result, configObject) => {
     const queryParamKey = configObject.queryParamKey || configObject.key;
     const valInUrl = urlQueryParamsObject[queryParamKey];
-    const isMultiValue = configObject.isMultiValue || false;
-    const val = getArrayValForMultiValParams(valInUrl, isMultiValue);
+    const isMultiValue = configObject.isMultiValue;
+    const val = getArrayValForMultiValParams(valInUrl, Boolean(isMultiValue));
     const configKey: PageQueryParamKeys<P> = configObject.key;
 
     if (
@@ -32,10 +32,10 @@ const getPageQueryParamsValues = <P extends PageQueryParams>(
       (isMultiValue && val.length === 0)
     ) {
       result[configKey] = configObject?.defaultValue;
-    } else if (typeof configObject.parseValue === 'function') {
-      result[configKey] = Array.isArray(val)
-        ? val.map(configObject.parseValue)
-        : configObject.parseValue(val);
+    } else if (!isMultiValue && typeof configObject.parseValue === 'function') {
+      result[configKey] = configObject.parseValue(val as string);
+    } else if (isMultiValue && typeof configObject.parseValue === 'function') {
+      result[configKey] = configObject.parseValue(val as string[]);
     } else {
       result[configKey] = val as ExtractedPageParamsValuesType<
         typeof configKey,

--- a/src/hooks/use-page-query-params/helpers/get-updated-url-search.ts
+++ b/src/hooks/use-page-query-params/helpers/get-updated-url-search.ts
@@ -29,13 +29,13 @@ const getUpdatedUrlSearch = <P extends PageQueryParams>(
       const queryParamValue =
         queryParamValuesToUpdateMap[c.key as PageQueryParamKeys<P>];
       const queryParamKey = c.queryParamKey || c.key;
-      if (queryParamValue === undefined) searchParamsURL.delete(queryParamKey);
-      else if (Array.isArray(queryParamValue)) {
-        searchParamsURL.delete(queryParamKey);
-        queryParamValue.forEach((v) => {
+      searchParamsURL.delete(queryParamKey);
+      if (c.isMultiValue && Array.isArray(queryParamValue)) {
+        (queryParamValue as any[]).forEach((v) => {
           searchParamsURL.append(queryParamKey, String(v));
         });
-      } else searchParamsURL.set(queryParamKey, String(queryParamValue));
+      } else if (queryParamValue !== undefined)
+        searchParamsURL.set(queryParamKey, String(queryParamValue));
     }
   });
 

--- a/src/utils/sort-by.ts
+++ b/src/utils/sort-by.ts
@@ -31,8 +31,8 @@ function toggleSortOrder({
   currentSortOrder,
   newSortColumn,
 }: {
-  currentSortColumn: string;
-  currentSortOrder: SortOrder;
+  currentSortColumn?: string;
+  currentSortOrder?: SortOrder;
   newSortColumn: string;
 }) {
   return currentSortColumn === newSortColumn && currentSortOrder === 'ASC'

--- a/src/views/domains-page/config/domains-page-query-params.config.ts
+++ b/src/views/domains-page/config/domains-page-query-params.config.ts
@@ -4,8 +4,8 @@ import { SortingOrder } from '@/components/table/table.types';
 const domainsPageQueryParamsConfig: [
   PageQueryParam<'searchText', string>,
   PageQueryParam<'clusterName', string>,
-  PageQueryParam<'sortColumn', string>,
-  PageQueryParam<'sortOrder', SortingOrder>,
+  PageQueryParam<'sortColumn', string | undefined>,
+  PageQueryParam<'sortOrder', SortingOrder | undefined>,
 ] = [
   {
     key: 'searchText',
@@ -24,6 +24,12 @@ const domainsPageQueryParamsConfig: [
   {
     key: 'sortOrder',
     queryParamKey: 'so',
+    parseValue: (value: string) => {
+      if (value === 'ASC' || value === 'DESC') {
+        return value;
+      }
+      return undefined;
+    },
   },
 ] as const;
 

--- a/src/views/domains-page/domains-table/domains-table.tsx
+++ b/src/views/domains-page/domains-table/domains-table.tsx
@@ -48,16 +48,15 @@ function DomainsTable({
         domainsPageFiltersConfig.every((f) => f.filterFunc(d, queryParams))
     );
   }, [domains, queryParams]);
-  const sortedDomains = useMemo(
-    () =>
-      sortBy<DomainData>(
-        filteredDomains,
-        (d) =>
-          d[queryParams.sortColumn as keyof DomainData] as SortByReturnValue,
-        queryParams.sortOrder
-      ),
-    [filteredDomains, queryParams.sortColumn, queryParams.sortOrder]
-  );
+  const sortedDomains = useMemo(() => {
+    if (!queryParams.sortColumn || !queryParams.sortOrder)
+      return filteredDomains;
+    return sortBy<DomainData>(
+      filteredDomains,
+      (d) => d[queryParams.sortColumn as keyof DomainData] as SortByReturnValue,
+      queryParams.sortOrder
+    );
+  }, [filteredDomains, queryParams.sortColumn, queryParams.sortOrder]);
   const paginatedDomains = useMemo(
     () => sortedDomains.slice(0, visibleListItems),
     [sortedDomains, visibleListItems]


### PR DESCRIPTION
The queryParams type didn't have a way to add `undefined` to for the types of the configurations that doesn't provide a `defaultValue`. In order to fix that the user needs to explicitly define the type of the queryParams to accept `undefined` e.g `PageQueryParam<string | undefined>`. That fixes the issue but it depends on to add the `undefined` type if the `defaultValue` wasn't provided in the config. 

In order to automate this type check, this changes allow showing a type error if the `defaultValue` is not provided while the query param type doesn't allow `undefined`.

While doing this changes another changes were done to the `PageQueryParamMultiValue` in order to allow such check. Initially the Multivalue queryParam expected types that extends arrays in order to infer the type of the value returned from the `parseValue` as it was used to parse single values and the queryParam value is returned as an array of the parsed values. So with that behaviour it didn't make sense to support undefined in the types of the multival query params. To address this issue the api for `parseValue` was tweaked and with that tweak it became even more powerful and allows much more use cases than before. 

The change was to pass `parseValue` the whole array of values and make it responsible of parsing them at once. There is no expectation for the returned value for being of arrays. The parseValue can return any value that matches the defined types for the queryParam. For example a multiValue queryParam can be of type `string | undefined` which is derived by parsing the values in the url.

Finally the Modifications that were made exposed some issue with the typing we had we had with the domains page (for `sortBy` and `sortColumn`). The value was being returned as `undefined` if nothing is provided in the url while the types didn't treat the values as optional.


Test cases are provided in a separate PR #587