### PR TITLE
grpc types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ignorePatterns: ['src/__generated__/'],
   extends: [
     'next/core-web-vitals',
     'plugin:react/recommended',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       with:
         node-version: '18'
     - run: npm ci
+    - run: npm run install-idl && npm run generate:idl
     - run: npm run lint
     - run: npm run typecheck
     - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-#idl
-src/idl
+#generated
+src/__generated__

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,6 +852,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -7377,11 +7382,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8319,6 +8319,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "start": "next start -p ${CADENCE_WEB_PORT-8088}",
     "lint": "next lint",
     "typecheck": "tsc --noemit",
-    "install-idl": "mkdir -p node_modules && cd node_modules && npx --yes tiged  https://github.com/uber/cadence-idl#83d5cae7fc5176f73486ffe82144044711930073 cadence-idl",
-    "generate:idl": "mkdir -p src/idl; npm run generate:idl:proto",
-    "generate:idl:proto": "rm -rf src/idl/proto && cp -R node_modules/cadence-idl/proto src/idl/proto",
+    "install-idl": "mkdir -p node_modules && cd node_modules && npx --yes tiged https://github.com/uber/cadence-idl#264791c3b9ced99ec96a37fc5cacfc03a634e9ee cadence-idl --force",
+    "generate:idl": "mkdir -p src/__generated__/idl && npm run generate:idl:proto && npm run generate:idl:proto:types",
+    "generate:idl:proto": "rm -rf src/__generated__/idl/proto && cp -R node_modules/cadence-idl/proto src/__generated__/idl/proto",
+    "generate:idl:proto:types": "rm -rf src/__generated__/proto-ts &&  ./node_modules/.bin/proto-loader-gen-types  --includeDirs=src/__generated__/idl/proto/  --enums=String --defaults --inputTemplate='%s__Input' --outputTemplate='%s' --oneofs --grpcLib=@grpc/grpc-js --outDir=src/__generated__/proto-ts/ $(npx glob --all --nodir --cwd=src/__generated__/idl/proto **/*.proto) ",
     "test": "npm run test:types && npm run test:unit",
     "test:unit": "jest --config jest.config.ts",
     "test:types": "jest --config jest.config.tsd.ts"
@@ -71,6 +72,7 @@
     "react-window": "1.8.7",
     "react-uid": "2.3.2",
     "react-map-gl": "5.3.19",
-    "react-virtualized-auto-sizer": "1.0.22"
+    "react-virtualized-auto-sizer": "1.0.22",
+    "long":"5.2.1"
   }
 }

--- a/src/config/grpc/grpc-proto-dir-base-path.ts
+++ b/src/config/grpc/grpc-proto-dir-base-path.ts
@@ -1,3 +1,3 @@
-const GRPC_PROTO_DIR_BASE_PATH = 'src/idl/proto';
+const GRPC_PROTO_DIR_BASE_PATH = 'src/__generated__/idl/proto';
 
 export default GRPC_PROTO_DIR_BASE_PATH;

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -1,3 +1,31 @@
+import { type DescribeClusterRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterRequest';
+import { type DescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
+import { type DescribeWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeWorkflowExecutionRequest';
+import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeWorkflowExecutionResponse';
+import { type DescribeDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainRequest';
+import { type DescribeDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainResponse';
+import { type DescribeTaskListRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListRequest';
+import { type DescribeTaskListResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListResponse';
+import { type GetWorkflowExecutionHistoryRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryRequest';
+import { type GetWorkflowExecutionHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryResponse';
+import { type ListArchivedWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListArchivedWorkflowExecutionsRequest';
+import { type ListArchivedWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListArchivedWorkflowExecutionsResponse';
+import { type ListClosedWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListClosedWorkflowExecutionsRequest';
+import { type ListClosedWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListClosedWorkflowExecutionsResponse';
+import { type ListDomainsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListDomainsRequest';
+import { type ListDomainsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListDomainsResponse';
+import { type ListOpenWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsRequest';
+import { type ListOpenWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsResponse';
+import { type ListTaskListPartitionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsRequest';
+import { type ListTaskListPartitionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsResponse';
+import { type ListWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsRequest';
+import { type ListWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsResponse';
+import { type QueryWorkflowRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryWorkflowRequest';
+import { type QueryWorkflowResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryWorkflowResponse';
+import { type SignalWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalWorkflowExecutionRequest';
+import { type SignalWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalWorkflowExecutionResponse';
+import { type TerminateWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/TerminateWorkflowExecutionRequest';
+import { type TerminateWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/TerminateWorkflowExecutionResponse';
 import CLUSTERS_CONFIGS from '@/config/clusters/clusters.config';
 
 import grpcServiceConfigurations from '../../config/grpc/grpc-services-config';
@@ -33,35 +61,56 @@ const clusterServicesMethods = CLUSTERS_CONFIGS.reduce(
     });
 
     result[c.clusterName] = {
-      archivedWorkflows: visibilityService.request({
+      archivedWorkflows: visibilityService.request<
+        ListArchivedWorkflowExecutionsRequest__Input,
+        ListArchivedWorkflowExecutionsResponse
+      >({
         method: 'ListArchivedWorkflowExecutions',
         //formatResponse: formatResponseWorkflowList,
         //transform: combine(withDomain(ctx), withPagination(ctx)),
       }),
-      closedWorkflows: visibilityService.request({
+      closedWorkflows: visibilityService.request<
+        ListClosedWorkflowExecutionsRequest__Input,
+        ListClosedWorkflowExecutionsResponse
+      >({
         method: 'ListClosedWorkflowExecutions',
         // formatRequest: formatRequestWorkflowList,
         // formatResponse: formatResponseWorkflowList,
         // transform: combine(withDomain(ctx), withPagination(ctx)),
       }),
-      describeCluster: adminService.request({
+      describeCluster: adminService.request<
+        DescribeClusterRequest__Input,
+        DescribeClusterResponse
+      >({
         method: 'DescribeCluster',
       }),
-      describeDomain: domainService.request({
+      describeDomain: domainService.request<
+        DescribeDomainRequest__Input,
+        DescribeDomainResponse
+      >({
         method: 'DescribeDomain',
         // formatResponse: formatResponseDomain,
       }),
-      describeTaskList: workflowService.request({
+      describeTaskList: workflowService.request<
+        DescribeTaskListRequest__Input,
+        DescribeTaskListResponse
+      >({
         // formatRequest: formatRequestDescribeTaskList,
         // formatResponse: formatResponseDescribeTaskList,
         method: 'DescribeTaskList',
       }),
-      describeWorkflow: workflowService.request({
+      describeWorkflow: workflowService.request<
+        DescribeWorkflowExecutionRequest__Input,
+        DescribeWorkflowExecutionResponse
+      >({
         method: 'DescribeWorkflowExecution',
         //formatResponse: formatResponseDescribeWorkflow,
         //transform: combine(withDomain(ctx), withWorkflowExecution(ctx)),
       }),
-      exportHistory: workflowService.request({
+      exportHistory: workflowService.request<
+        GetWorkflowExecutionHistoryRequest__Input,
+        GetWorkflowExecutionHistoryResponse
+      >({
         method: 'GetWorkflowExecutionHistory',
         //formatRequest: formatRequestGetHistory,
         //formatResponse: formatResponseExportHistory,
@@ -71,7 +120,10 @@ const clusterServicesMethods = CLUSTERS_CONFIGS.reduce(
               withWorkflowExecution(ctx)
             ), */
       }),
-      getHistory: workflowService.request({
+      getHistory: workflowService.request<
+        GetWorkflowExecutionHistoryRequest__Input,
+        GetWorkflowExecutionHistoryResponse
+      >({
         method: 'GetWorkflowExecutionHistory',
         /* formatRequest: formatRequestGetHistory,
             formatResponse: formatResponseGetHistory,
@@ -81,43 +133,113 @@ const clusterServicesMethods = CLUSTERS_CONFIGS.reduce(
                 withWorkflowExecution(ctx)
             ), */
       }),
-      listDomains: domainService.request({
+      listDomains: domainService.request<
+        ListDomainsRequest__Input,
+        ListDomainsResponse
+      >({
         method: 'ListDomains',
         //formatResponse: formatResponseListDomains,
       }),
-      listTaskListPartitions: workflowService.request({
+      listTaskListPartitions: workflowService.request<
+        ListTaskListPartitionsRequest__Input,
+        ListTaskListPartitionsResponse
+      >({
         method: 'ListTaskListPartitions',
       }),
-      listWorkflows: visibilityService.request({
+      listWorkflows: visibilityService.request<
+        ListWorkflowExecutionsRequest__Input,
+        ListWorkflowExecutionsResponse
+      >({
         method: 'ListWorkflowExecutions',
         /* formatResponse: formatResponseWorkflowList,
              transform: combine(withDomain(ctx), withPagination(ctx)), */
       }),
-      openWorkflows: visibilityService.request({
+      openWorkflows: visibilityService.request<
+        ListOpenWorkflowExecutionsRequest__Input,
+        ListOpenWorkflowExecutionsResponse
+      >({
         method: 'ListOpenWorkflowExecutions',
         /* formatRequest: formatRequestWorkflowList,
             formatResponse: formatResponseWorkflowList,
             transform: combine(withDomain(ctx), withPagination(ctx)), */
       }),
-      queryWorkflow: workflowService.request({
+      queryWorkflow: workflowService.request<
+        QueryWorkflowRequest__Input,
+        QueryWorkflowResponse
+      >({
         method: 'QueryWorkflow',
         /* formatResponse: formatResponseQueryWorkflow,
             transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
       }),
-      signalWorkflow: workflowService.request({
+      signalWorkflow: workflowService.request<
+        SignalWorkflowExecutionRequest__Input,
+        SignalWorkflowExecutionResponse
+      >({
         method: 'SignalWorkflowExecution',
         /* formatResponse: formatResponseSignalWorkflowExecution,
             transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
       }),
-      terminateWorkflow: workflowService.request({
+      terminateWorkflow: workflowService.request<
+        TerminateWorkflowExecutionRequest__Input,
+        TerminateWorkflowExecutionResponse
+      >({
         method: 'TerminateWorkflowExecution',
         /* formatResponse: formatResponseTerminateWorkflowExecution,
             transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
       }),
     };
+    result[c.clusterName].describeWorkflow;
     return result;
   },
-  {} as { [k: string]: any }
+  {} as {
+    [k: string]: {
+      archivedWorkflows: (
+        payload: ListArchivedWorkflowExecutionsRequest__Input
+      ) => Promise<ListArchivedWorkflowExecutionsResponse>;
+      closedWorkflows: (
+        payload: ListClosedWorkflowExecutionsRequest__Input
+      ) => Promise<ListClosedWorkflowExecutionsResponse>;
+      describeCluster: (
+        payload: DescribeClusterRequest__Input
+      ) => Promise<DescribeClusterResponse>;
+      describeDomain: (
+        payload: DescribeDomainRequest__Input
+      ) => Promise<DescribeDomainResponse>;
+      describeTaskList: (
+        paload: DescribeTaskListRequest__Input
+      ) => Promise<DescribeTaskListResponse>;
+      describeWorkflow: (
+        payload: DescribeWorkflowExecutionRequest__Input
+      ) => Promise<DescribeWorkflowExecutionResponse>;
+      exportHistory: (
+        payload: GetWorkflowExecutionHistoryRequest__Input
+      ) => Promise<GetWorkflowExecutionHistoryResponse>;
+      getHistory: (
+        payload: GetWorkflowExecutionHistoryRequest__Input
+      ) => Promise<GetWorkflowExecutionHistoryResponse>;
+      listDomains: (
+        payload: ListDomainsRequest__Input
+      ) => Promise<ListDomainsResponse>;
+      listTaskListPartitions: (
+        payload: ListTaskListPartitionsRequest__Input
+      ) => Promise<ListTaskListPartitionsResponse>;
+      listWorkflows: (
+        payload: ListWorkflowExecutionsRequest__Input
+      ) => Promise<ListWorkflowExecutionsResponse>;
+      openWorkflows: (
+        payload: ListOpenWorkflowExecutionsRequest__Input
+      ) => Promise<ListOpenWorkflowExecutionsResponse>;
+      queryWorkflow: (
+        payload: QueryWorkflowRequest__Input
+      ) => Promise<QueryWorkflowResponse>;
+      signalWorkflow: (
+        payload: SignalWorkflowExecutionRequest__Input
+      ) => Promise<SignalWorkflowExecutionResponse>;
+      terminateWorkflow: (
+        payload: TerminateWorkflowExecutionRequest__Input
+      ) => Promise<TerminateWorkflowExecutionResponse>;
+    };
+  }
 );
 
 export const clusterMethods = clusterServicesMethods;

--- a/src/utils/grpc/grpc-service.ts
+++ b/src/utils/grpc/grpc-service.ts
@@ -84,22 +84,12 @@ class GRPCService {
     this.requestConfig = requestConfig;
   }
 
-  request({
-    formatRequest = (req) => req,
-    formatResponse = (res) => res,
-    method,
-    transform = (payload) => payload,
-  }: {
-    method: string;
-    formatRequest?: (req: any) => any;
-    formatResponse?: (res: any) => any;
-    transform?: (payload: any) => any;
-  }) {
-    return (payload: any) => {
+  request<Req, Res>({ method }: { method: string }) {
+    return (payload: Req) => {
       const deadline = new Date();
 
       deadline.setSeconds(deadline.getSeconds() + 2);
-      return new Promise((resolve, reject) => {
+      return new Promise<Res>((resolve, reject) => {
         this.service.waitForReady(deadline, (error) => {
           if (error) {
             return reject(error);
@@ -107,7 +97,7 @@ class GRPCService {
 
           deadline.setSeconds(deadline.getSeconds() + 50);
           this.service[method](
-            formatRequest(transform(payload)),
+            payload,
             this.meta(),
             { deadline },
             (
@@ -130,7 +120,7 @@ class GRPCService {
                   customError.grpcStatusCode = error.code;
                   throw customError;
                 }
-                return resolve(formatResponse(response));
+                return resolve(response);
               } catch (e) {
                 reject(e);
               }

--- a/src/views/domain-page/__fixtures__/domain-info.ts
+++ b/src/views/domain-page/__fixtures__/domain-info.ts
@@ -1,3 +1,5 @@
+import { Long } from '@grpc/proto-loader';
+
 import { type DomainInfo } from '../domain-page.types';
 
 export const mockDomainInfo: DomainInfo = {
@@ -10,6 +12,16 @@ export const mockDomainInfo: DomainInfo = {
   description: 'This is a mock domain used for test fixtures',
   ownerEmail: 'mockdomainowner@gmail.com',
   isGlobalDomain: true,
+  badBinaries: null,
+  asyncWorkflowConfig: null,
+  historyArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  failoverInfo: null,
+  isolationGroups: null,
+  visibilityArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  visibilityArchivalUri: '',
+  workflowExecutionRetentionPeriod: null,
+  historyArchivalUri: '',
+  failoverVersion: new Long(123456),
 };
 
 export const mockDomainInfoSingleCluster: DomainInfo = {
@@ -23,4 +35,14 @@ export const mockDomainInfoSingleCluster: DomainInfo = {
     'This is a mock domain with single cluster used for test fixtures',
   ownerEmail: 'mockdomainowner@gmail.com',
   isGlobalDomain: true,
+  badBinaries: null,
+  asyncWorkflowConfig: null,
+  historyArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  failoverInfo: null,
+  isolationGroups: null,
+  visibilityArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  visibilityArchivalUri: '',
+  workflowExecutionRetentionPeriod: null,
+  historyArchivalUri: '',
+  failoverVersion: new Long(123456),
 };

--- a/src/views/domain-page/domain-page-header-info/domain-page-header-info.tsx
+++ b/src/views/domain-page/domain-page-header-info/domain-page-header-info.tsx
@@ -21,6 +21,7 @@ export default function DomainPageHeaderInfo(props: Props) {
             loading={props.loading}
             content={
               !props.loading &&
+              !!props.domainInfo &&
               (configItem.component ? (
                 <configItem.component
                   domainInfo={props.domainInfo}

--- a/src/views/domain-page/domain-page-header-info/domain-page-header-info.types.ts
+++ b/src/views/domain-page/domain-page-header-info/domain-page-header-info.types.ts
@@ -8,7 +8,7 @@ type LoadingProps = {
 
 type LoadedProps = {
   loading: false;
-  domainInfo: DomainInfo;
+  domainInfo: DomainInfo | null;
   cluster: string;
 };
 

--- a/src/views/domain-page/domain-page.types.ts
+++ b/src/views/domain-page/domain-page.types.ts
@@ -1,3 +1,4 @@
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
 import type { WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 export type Props = {
@@ -5,18 +6,7 @@ export type Props = {
   children: React.ReactNode;
 };
 
-// TODO @adhitya.mamallan - use GRPC types when they are ready
-export type DomainInfo = {
-  name: string;
-  status: string;
-  description?: string;
-  ownerEmail?: string;
-  data?: { [x: string]: string };
-  id: string;
-  activeClusterName: string;
-  clusters: ClusterReplicationConfiguration[];
-  isGlobalDomain: boolean;
-};
+export type DomainInfo = Domain;
 
 export type ClusterReplicationConfiguration = {
   clusterName: string;

--- a/src/views/domains-page/__fixtures__/domains.ts
+++ b/src/views/domains-page/__fixtures__/domains.ts
@@ -1,6 +1,31 @@
+import { Long } from '@grpc/proto-loader';
+
 import { type DomainData } from '../domains-page.types';
 
-export const globalDomain: DomainData = {
+export const getDomainObj = (
+  overrides: Pick<DomainData, 'id' | 'name'> & Partial<DomainData>
+): DomainData => ({
+  status: 'DOMAIN_STATUS_REGISTERED',
+  badBinaries: null,
+  data: {},
+  description: '',
+  asyncWorkflowConfig: null,
+  historyArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  failoverInfo: null,
+  isGlobalDomain: true,
+  ownerEmail: 'test@test.uber.com',
+  isolationGroups: null,
+  visibilityArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  visibilityArchivalUri: '',
+  workflowExecutionRetentionPeriod: null,
+  historyArchivalUri: '',
+  failoverVersion: new Long(123456),
+  activeClusterName: 'ClusterA',
+  clusters: [{ clusterName: 'clusterA' }, { clusterName: 'clusterB' }],
+  ...overrides,
+});
+
+export const globalDomain: DomainData = getDomainObj({
   id: 'test-global-domain-id',
   name: 'test-global-domain',
   activeClusterName: 'test-global-cluster-2',
@@ -8,11 +33,11 @@ export const globalDomain: DomainData = {
     { clusterName: 'test-global-cluster-1' },
     { clusterName: 'test-global-cluster-2' },
   ],
-};
+});
 
-export const localDomain: DomainData = {
+export const localDomain: DomainData = getDomainObj({
   id: 'test-local-domain-id',
   name: 'test-local-domain',
   activeClusterName: 'test-local-cluster-1',
   clusters: [{ clusterName: 'test-local-cluster-1' }],
-};
+});

--- a/src/views/domains-page/domains-page.types.ts
+++ b/src/views/domains-page/domains-page.types.ts
@@ -1,6 +1,3 @@
-export type DomainData = {
-  activeClusterName: string;
-  clusters: Array<{ clusterName: string }>;
-  id: string;
-  name: string;
-};
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+
+export type DomainData = Domain;

--- a/src/views/domains-page/helpers/__tests__/filter-domains-irrelevant-to-cluster.test.ts
+++ b/src/views/domains-page/helpers/__tests__/filter-domains-irrelevant-to-cluster.test.ts
@@ -1,33 +1,45 @@
+import { getDomainObj } from '../../__fixtures__/domains';
 import type { DomainData } from '../../domains-page.types';
 import filterDomainsIrrelevantToCluster from '../filter-domains-irrelevant-to-cluster';
 
 describe('filterDomainsIrrelevantToCluster', () => {
   it('should return domains relevant to the specified cluster', () => {
     // picking few domains data as clusters is the only required
-    const domains: Pick<DomainData, 'clusters' | 'name'>[] = [
-      { name: '1', clusters: [{ clusterName: 'ClusterA' }] },
-      { name: '2', clusters: [{ clusterName: 'ClusterB' }] },
-      {
+    const domains = [
+      getDomainObj({
+        id: '1',
+        name: '1',
+        clusters: [{ clusterName: 'ClusterA' }],
+      }),
+      getDomainObj({
+        id: '1',
+        name: '2',
+        clusters: [{ clusterName: 'ClusterB' }],
+      }),
+      getDomainObj({
+        id: '3',
         name: '3',
         clusters: [{ clusterName: 'ClusterA' }, { clusterName: 'ClusterC' }],
-      },
+      }),
     ];
 
     const result = filterDomainsIrrelevantToCluster('ClusterA', domains);
 
-    expect(result).toEqual([
-      { name: '1', clusters: [{ clusterName: 'ClusterA' }] },
-      {
-        name: '3',
-        clusters: [{ clusterName: 'ClusterA' }, { clusterName: 'ClusterC' }],
-      },
-    ]);
+    expect(result).toEqual([domains[0], domains[2]]);
   });
 
   it('should return an empty array if no domains are relevant to the specified cluster', () => {
-    const domains: Pick<DomainData, 'clusters'>[] = [
-      { clusters: [{ clusterName: 'ClusterB' }] },
-      { clusters: [{ clusterName: 'ClusterC' }] },
+    const domains = [
+      getDomainObj({
+        id: '1',
+        name: '1',
+        clusters: [{ clusterName: 'ClusterB' }],
+      }),
+      getDomainObj({
+        id: '2',
+        name: '2',
+        clusters: [{ clusterName: 'ClusterC' }],
+      }),
     ];
 
     const result = filterDomainsIrrelevantToCluster('ClusterA', domains);

--- a/src/views/domains-page/helpers/__tests__/get-unique-domains.test.ts
+++ b/src/views/domains-page/helpers/__tests__/get-unique-domains.test.ts
@@ -1,53 +1,66 @@
+import { getDomainObj } from '../../__fixtures__/domains';
 import { type DomainData } from '../../domains-page.types';
 import getUniqueDomains from '../get-unique-domains';
 
 describe('getUniqueDomains', () => {
   it('should return unique domains based on id-name-activeClusterName', () => {
     const domains: DomainData[] = [
-      {
+      getDomainObj({
         id: '1',
         name: 'Domain1',
         activeClusterName: 'ClusterA',
         clusters: [{ clusterName: 'clusterA' }, { clusterName: 'clusterB' }],
-      },
-      {
+      }),
+      getDomainObj({
         id: '2',
         name: 'Domain2',
         activeClusterName: 'ClusterB',
         clusters: [{ clusterName: 'clusterA' }, { clusterName: 'clusterB' }],
-      },
-      { id: '1', name: 'Domain1', activeClusterName: 'ClusterA', clusters: [] },
+      }),
+      getDomainObj({
+        id: '1',
+        name: 'Domain1',
+        activeClusterName: 'ClusterA',
+        clusters: [],
+      }),
     ];
 
     const uniqueDomains = getUniqueDomains(domains);
 
-    expect(uniqueDomains).toEqual([
-      {
-        id: '1',
-        name: 'Domain1',
-        activeClusterName: 'ClusterA',
-        clusters: [{ clusterName: 'clusterA' }, { clusterName: 'clusterB' }],
-      },
-      {
-        id: '2',
-        name: 'Domain2',
-        activeClusterName: 'ClusterB',
-        clusters: [{ clusterName: 'clusterA' }, { clusterName: 'clusterB' }],
-      },
-    ]);
+    expect(uniqueDomains).toEqual([domains[0], domains[1]]);
   });
 
   it('should handle all domains being duplicates', () => {
     const domains: DomainData[] = [
-      { id: '1', name: 'Domain1', activeClusterName: 'ClusterA', clusters: [] },
-      { id: '1', name: 'Domain1', activeClusterName: 'ClusterA', clusters: [] },
-      { id: '1', name: 'Domain1', activeClusterName: 'ClusterA', clusters: [] },
+      getDomainObj({
+        id: '1',
+        name: 'Domain1',
+        activeClusterName: 'ClusterA',
+        clusters: [],
+      }),
+      getDomainObj({
+        id: '1',
+        name: 'Domain1',
+        activeClusterName: 'ClusterA',
+        clusters: [],
+      }),
+      getDomainObj({
+        id: '1',
+        name: 'Domain1',
+        activeClusterName: 'ClusterA',
+        clusters: [],
+      }),
     ];
 
     const uniqueDomains = getUniqueDomains(domains);
 
     expect(uniqueDomains).toEqual([
-      { id: '1', name: 'Domain1', activeClusterName: 'ClusterA', clusters: [] },
+      getDomainObj({
+        id: '1',
+        name: 'Domain1',
+        activeClusterName: 'ClusterA',
+        clusters: [],
+      }),
     ]);
   });
 });

--- a/src/views/domains-page/helpers/filter-domains-irrelevant-to-cluster.ts
+++ b/src/views/domains-page/helpers/filter-domains-irrelevant-to-cluster.ts
@@ -2,7 +2,7 @@ import type { DomainData } from '../domains-page.types';
 
 export default function filterDomainsIrrelevantToCluster(
   clusterName: string,
-  domains: Pick<DomainData, 'clusters'>[]
+  domains: DomainData[]
 ) {
   return (domains || []).filter(({ clusters }) =>
     clusters.some(({ clusterName: c }) => clusterName === c)

--- a/src/views/domains-page/helpers/get-all-domains.ts
+++ b/src/views/domains-page/helpers/get-all-domains.ts
@@ -5,8 +5,6 @@ import { unstable_cache } from 'next/cache';
 import CLUSTERS_CONFIGS from '@/config/clusters/clusters.config';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 
-import { type DomainData } from '../domains-page.types';
-
 import filterDomainsIrrelevantToCluster from './filter-domains-irrelevant-to-cluster';
 import getUniqueDomains from './get-unique-domains';
 
@@ -15,7 +13,7 @@ export const getAllDomains = async () => {
     CLUSTERS_CONFIGS.map(({ clusterName }) =>
       grpcClient.clusterMethods[clusterName]
         .listDomains({ pageSize: 1000 })
-        .then(({ domains }: { domains: DomainData[] }) => {
+        .then(({ domains }) => {
           return filterDomainsIrrelevantToCluster(clusterName, domains);
         })
     )


### PR DESCRIPTION
- use `proto-loader-gen-types` to generate types
-  The library creates two types for each payload, one with optional fields that is usually used when inputing values to the grpc client, those values are optional since the grpc can fill them with defaults. The second type is the output types which are retruned from the library and they will include default values if the value is missing.
- create a `__generated__` directory to have idls and their types
- ingnored the generated directory from eslint as it doesn't follow our rules.
