### PR TITLE
Domain Page Settings - Editable form UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^15.0.2",
+        "@testing-library/user-event": "^14.5.2",
         "@tsd/typescript": "^5.4.5",
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^29.5.12",
@@ -1943,6 +1944,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "query-string": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.52.0",
         "react-icons": "^5.1.0",
         "react-intersection-observer": "^9.8.1",
         "react-json-view-lite": "^1.4.0",
@@ -8482,9 +8483,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.0.tgz",
-      "integrity": "sha512-BggOy5j58RdhdMzzRUHGOYhSz1oeylFAv6jUSG86OvCIvlAvS7KvnRY7yoAf2pfEiPN7BesnR0xx73nEk3qIiw==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -8493,7 +8494,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.10.0",
         "@grpc/proto-loader": "^0.7.10",
+        "@hookform/resolvers": "^3.6.0",
         "@tanstack/react-query": "^5.45.0",
         "@tanstack/react-query-next-experimental": "^5.45.0",
         "baseui": "^14.0.0",
@@ -857,6 +858,14 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
       "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.6.0.tgz",
+      "integrity": "sha512-UBcpyOX3+RR+dNnqBd0lchXpoL8p4xC21XP8H6Meb8uve5Br1GCnmg0PcBoKKqPKgGu9GHQ/oygcmPrQhetwqw==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.52.0",
     "react-icons": "^5.1.0",
     "react-intersection-observer": "^9.8.1",
     "react-json-view-lite": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.10.0",
     "@grpc/proto-loader": "^0.7.10",
+    "@hookform/resolvers": "^3.6.0",
     "@tanstack/react-query": "^5.45.0",
     "@tanstack/react-query-next-experimental": "^5.45.0",
     "baseui": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^15.0.2",
+    "@testing-library/user-event": "^14.5.2",
     "@tsd/typescript": "^5.4.5",
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.12",

--- a/src/components/form/__fixtures__/form.fixtures.ts
+++ b/src/components/form/__fixtures__/form.fixtures.ts
@@ -1,0 +1,45 @@
+import { createElement } from 'react';
+
+import { z } from 'zod';
+
+import { type FormField } from '../form.types';
+
+export const mockZodSchema = z.object({
+  field1: z.string(),
+  field2: z.number().positive(),
+  field3: z.boolean(),
+});
+
+export const mockData = {
+  fieldA: 'mock_data_A',
+  fieldB: 1234,
+  fieldC: 'MOCK_ENUM_VALID',
+};
+
+export const mockFormConfig: [
+  FormField<typeof mockData, typeof mockZodSchema, 'field1'>,
+  FormField<typeof mockData, typeof mockZodSchema, 'field2'>,
+  FormField<typeof mockData, typeof mockZodSchema, 'field3'>,
+] = [
+  {
+    path: 'field1',
+    title: 'Field 1',
+    description: 'Mock field #1',
+    getDefaultValue: (d) => d.fieldA,
+    component: (props) => createElement('input', props),
+  },
+  {
+    path: 'field2',
+    title: 'Field 2',
+    description: 'Mock field #2',
+    getDefaultValue: (d) => d.fieldB,
+    component: (props) => createElement('input', props),
+  },
+  {
+    path: 'field3',
+    title: 'Field 3',
+    description: 'Mock field #3',
+    getDefaultValue: (d) => d.fieldC === 'MOCK_ENUM_VALID',
+    component: (props) => createElement('input', props),
+  },
+] as const;

--- a/src/components/form/__tests__/form.test.tsx
+++ b/src/components/form/__tests__/form.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+
+import { userEvent } from '@testing-library/user-event';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import {
+  mockZodSchema,
+  mockData,
+  mockFormConfig,
+} from '../__fixtures__/form.fixtures';
+import Form from '../form';
+
+describe(Form.name, () => {
+  it('should render form correctly', () => {
+    setup({});
+
+    const formFields = screen.getAllByRole('textbox');
+    expect(formFields).toHaveLength(3);
+
+    expect(formFields[0]).toHaveValue('mock_data_A');
+    expect(formFields[1]).toHaveValue('1234');
+    expect(formFields[2]).toHaveValue('true');
+
+    const submitButton = screen.getByRole('button');
+    expect(submitButton).toHaveTextContent('Submit form');
+    expect(submitButton).toHaveAttribute('type', 'submit');
+    expect(submitButton).toHaveAttribute('disabled');
+  });
+
+  it('should accept form submission once any of the fields are modified', async () => {
+    const { user, mockOnSubmit } = setup({});
+
+    const submitButton = screen.getByRole('button');
+    expect(submitButton).toHaveAttribute('disabled');
+
+    const formFieldA = screen.getByDisplayValue('mock_data_A');
+
+    await user.clear(formFieldA);
+    await user.type(formFieldA, 'new_mock_data_A');
+
+    expect(formFieldA).toHaveValue('new_mock_data_A');
+    expect(submitButton).not.toHaveAttribute('disabled');
+
+    await user.click(submitButton);
+
+    expect(mockOnSubmit).toHaveBeenCalledWith(
+      {
+        field1: 'new_mock_data_A',
+        field2: 1234,
+        field3: true,
+      },
+      expect.anything()
+    );
+  });
+
+  it('should disable submit button if a field is reset to original value', async () => {
+    const { user } = setup({});
+
+    const submitButton = screen.getByRole('button');
+    expect(submitButton).toHaveAttribute('disabled');
+
+    const formFieldA = screen.getByDisplayValue('mock_data_A');
+
+    await user.clear(formFieldA);
+    await user.type(formFieldA, 'new_mock_data_A');
+
+    expect(formFieldA).toHaveValue('new_mock_data_A');
+    expect(submitButton).not.toHaveAttribute('disabled');
+
+    await user.clear(formFieldA);
+    await user.type(formFieldA, 'mock_data_A');
+
+    expect(submitButton).toHaveAttribute('disabled');
+  });
+
+  it('should show an error and disable submit if a field has an invalid value', async () => {
+    const { user } = setup({});
+
+    const formFieldC = screen.getByDisplayValue('true');
+
+    await user.clear(formFieldC);
+    await user.type(formFieldC, 'definitely_not_a_boolean');
+
+    const submitButton = screen.getByRole('button');
+    await user.click(submitButton);
+    expect(submitButton).toHaveAttribute('disabled');
+
+    expect(formFieldC).toHaveAttribute(
+      'error',
+      'Expected boolean, received string'
+    );
+
+    expect(
+      screen.getByText('Expected boolean, received string')
+    ).toBeInTheDocument();
+  });
+});
+
+function setup({}) {
+  const user = userEvent.setup();
+  const mockOnSubmit = jest.fn();
+
+  render(
+    <Form
+      data={mockData}
+      zodSchema={mockZodSchema}
+      formConfig={mockFormConfig}
+      onSubmit={mockOnSubmit}
+      submitButtonText="Submit form"
+    />
+  );
+
+  return { user, mockOnSubmit };
+}

--- a/src/components/form/form.styles.ts
+++ b/src/components/form/form.styles.ts
@@ -2,12 +2,19 @@ import { type Theme, styled as createStyled } from 'baseui';
 import { type StyleObject } from 'styletron-react';
 
 export const styled = {
+  FieldsContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      display: 'flex',
+      flexDirection: 'column',
+      rowGap: $theme.sizing.scale800,
+    })
+  ),
   FieldContainer: createStyled(
     'div',
     ({ $theme }: { $theme: Theme }): StyleObject => ({
       display: 'flex',
       gap: $theme.sizing.scale1200,
-      paddingBottom: $theme.sizing.scale800,
     })
   ),
   Info: createStyled(
@@ -32,6 +39,12 @@ export const styled = {
       ...$theme.typography.LabelXSmall,
       color: $theme.colors.contentTertiary,
       fontWeight: '400',
+    })
+  ),
+  ButtonContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      paddingTop: $theme.sizing.scale900,
     })
   ),
 };

--- a/src/components/form/form.styles.ts
+++ b/src/components/form/form.styles.ts
@@ -1,0 +1,37 @@
+import { type Theme, styled as createStyled } from 'baseui';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  FieldContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      display: 'flex',
+      gap: $theme.sizing.scale1200,
+      paddingBottom: $theme.sizing.scale800,
+    })
+  ),
+  Info: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      display: 'flex',
+      flexDirection: 'column',
+      width: '300px',
+      gap: $theme.sizing.scale200,
+    })
+  ),
+  Title: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      ...$theme.typography.LabelSmall,
+      color: $theme.colors.contentPrimary,
+    })
+  ),
+  Description: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      ...$theme.typography.LabelXSmall,
+      color: $theme.colors.contentTertiary,
+      fontWeight: '400',
+    })
+  ),
+};

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -1,0 +1,69 @@
+'use client';
+import React from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { FormControl } from 'baseui/form-control';
+import { type SubmitHandler, useForm, Controller } from 'react-hook-form';
+import { type z } from 'zod';
+
+import { styled } from './form.styles';
+import { type FormValues, type FormConfig } from './form.types';
+import getDefaultValues from './helpers/get-default-values';
+
+export default function Form<D extends object, Z extends z.ZodTypeAny>({
+  data,
+  zodSchema,
+  formConfig,
+  onSubmit,
+}: {
+  data: D;
+  zodSchema: Z;
+  formConfig: FormConfig<D, Z>;
+  onSubmit: SubmitHandler<FormValues<Z>>;
+}) {
+  const { control, handleSubmit, formState } = useForm<FormValues<Z>>({
+    mode: 'onBlur',
+    defaultValues: getDefaultValues({ data, formConfig }),
+    resolver: zodResolver(zodSchema),
+  });
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        handleSubmit(onSubmit)(event);
+      }}
+    >
+      {formConfig.map((field) => {
+        return (
+          <styled.FieldContainer key={field.path}>
+            <styled.Info>
+              <styled.Title>{field.title}</styled.Title>
+              <styled.Description>{field.description}</styled.Description>
+            </styled.Info>
+            <FormControl
+              error={formState.errors[field.path]?.message?.toString()}
+            >
+              <Controller
+                control={control}
+                name={field.path}
+                render={({
+                  field: { onChange, onBlur, value },
+                  fieldState: { error },
+                }) => (
+                  <field.component
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    value={value}
+                    error={error?.message}
+                  />
+                )}
+              />
+            </FormControl>
+          </styled.FieldContainer>
+        );
+      })}
+      <input type="submit" />
+    </form>
+  );
+}

--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -2,12 +2,13 @@
 import React from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, SIZE } from 'baseui/button';
 import { FormControl } from 'baseui/form-control';
-import { type SubmitHandler, useForm, Controller } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { type z } from 'zod';
 
 import { styled } from './form.styles';
-import { type FormValues, type FormConfig } from './form.types';
+import { type FormValues, type Props } from './form.types';
 import getDefaultValues from './helpers/get-default-values';
 
 export default function Form<D extends object, Z extends z.ZodTypeAny>({
@@ -15,12 +16,8 @@ export default function Form<D extends object, Z extends z.ZodTypeAny>({
   zodSchema,
   formConfig,
   onSubmit,
-}: {
-  data: D;
-  zodSchema: Z;
-  formConfig: FormConfig<D, Z>;
-  onSubmit: SubmitHandler<FormValues<Z>>;
-}) {
+  submitButtonText,
+}: Props<D, Z>) {
   const { control, handleSubmit, formState } = useForm<FormValues<Z>>({
     mode: 'onBlur',
     defaultValues: getDefaultValues({ data, formConfig }),
@@ -30,40 +27,52 @@ export default function Form<D extends object, Z extends z.ZodTypeAny>({
   return (
     <form
       onSubmit={(event) => {
+        // Prevent form from clearing itself on submit
         event.preventDefault();
         handleSubmit(onSubmit)(event);
       }}
     >
-      {formConfig.map((field) => {
-        return (
-          <styled.FieldContainer key={field.path}>
-            <styled.Info>
-              <styled.Title>{field.title}</styled.Title>
-              <styled.Description>{field.description}</styled.Description>
-            </styled.Info>
-            <FormControl
-              error={formState.errors[field.path]?.message?.toString()}
-            >
-              <Controller
-                control={control}
-                name={field.path}
-                render={({
-                  field: { onChange, onBlur, value },
-                  fieldState: { error },
-                }) => (
-                  <field.component
-                    onChange={onChange}
-                    onBlur={onBlur}
-                    value={value}
-                    error={error?.message}
-                  />
-                )}
-              />
-            </FormControl>
-          </styled.FieldContainer>
-        );
-      })}
-      <input type="submit" />
+      <styled.FieldsContainer>
+        {formConfig.map((field) => {
+          return (
+            <styled.FieldContainer key={field.path}>
+              <styled.Info>
+                <styled.Title>{field.title}</styled.Title>
+                <styled.Description>{field.description}</styled.Description>
+              </styled.Info>
+              <FormControl
+                error={formState.errors[field.path]?.message?.toString()}
+              >
+                <Controller
+                  control={control}
+                  name={field.path}
+                  render={({
+                    field: { onChange, onBlur, value },
+                    fieldState: { error },
+                  }) => (
+                    <field.component
+                      onChange={onChange}
+                      onBlur={onBlur}
+                      value={value}
+                      error={error?.message}
+                    />
+                  )}
+                />
+              </FormControl>
+            </styled.FieldContainer>
+          );
+        })}
+      </styled.FieldsContainer>
+      <styled.ButtonContainer>
+        <Button
+          type="submit"
+          size={SIZE.compact}
+          disabled={!formState.isDirty || !formState.isValid}
+          isLoading={formState.isSubmitting}
+        >
+          {submitButtonText}
+        </Button>
+      </styled.ButtonContainer>
     </form>
   );
 }

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,0 +1,29 @@
+import type React from 'react';
+
+import { type Path } from 'react-hook-form';
+import { type z } from 'zod';
+
+export type FieldComponentProps<V> = {
+  onBlur: (e: any) => void;
+  onChange: (e: any) => void;
+  value: V;
+  error?: string;
+};
+
+export type FormValues<Z extends z.ZodTypeAny> = z.infer<Z>;
+
+export type FormField<
+  D extends object,
+  Z extends z.ZodTypeAny,
+  K extends keyof FormValues<Z>,
+> = {
+  path: K extends Path<FormValues<Z>> ? K : never;
+  title: string;
+  description: string;
+  getDefaultValue: (data: D) => FormValues<Z>[K];
+  component: React.ComponentType<FieldComponentProps<FormValues<Z>[K]>>;
+};
+
+export type FormConfig<D extends object, Z extends z.ZodTypeAny> = Array<
+  FormField<D, Z, any>
+>;

--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { type Path } from 'react-hook-form';
+import { type SubmitHandler, type Path } from 'react-hook-form';
 import { type z } from 'zod';
 
 export type FieldComponentProps<V> = {
@@ -27,3 +27,11 @@ export type FormField<
 export type FormConfig<D extends object, Z extends z.ZodTypeAny> = Array<
   FormField<D, Z, any>
 >;
+
+export type Props<D extends object, Z extends z.ZodTypeAny> = {
+  data: D;
+  zodSchema: Z;
+  formConfig: FormConfig<D, Z>;
+  onSubmit: SubmitHandler<FormValues<Z>>;
+  submitButtonText: string;
+};

--- a/src/components/form/helpers/__tests__/get-default-values.test.ts
+++ b/src/components/form/helpers/__tests__/get-default-values.test.ts
@@ -1,0 +1,17 @@
+import { mockData, mockFormConfig } from '../../__fixtures__/form.fixtures';
+import getDefaultValues from '../get-default-values';
+
+describe(getDefaultValues.name, () => {
+  it('returns expected values', () => {
+    const result = getDefaultValues({
+      data: mockData,
+      formConfig: mockFormConfig,
+    });
+
+    expect(result).toEqual({
+      field1: 'mock_data_A',
+      field2: 1234,
+      field3: true,
+    });
+  });
+});

--- a/src/components/form/helpers/get-default-values.ts
+++ b/src/components/form/helpers/get-default-values.ts
@@ -1,0 +1,18 @@
+import { type z } from 'zod';
+
+import { type FormValues, type FormConfig } from '../form.types';
+
+export default function getDefaultValues<
+  D extends object,
+  Z extends z.ZodTypeAny,
+>({
+  data,
+  formConfig,
+}: {
+  data: D;
+  formConfig: FormConfig<D, Z>;
+}): FormValues<Z> {
+  return Object.fromEntries(
+    formConfig.map((field) => [field.path, field.getDefaultValue(data)])
+  );
+}

--- a/src/utils/data-formatters/__tests__/format-duration-to-days.test.ts
+++ b/src/utils/data-formatters/__tests__/format-duration-to-days.test.ts
@@ -1,0 +1,15 @@
+import formatDurationToDays from '../format-duration-to-days';
+
+describe(formatDurationToDays.name, () => {
+  test('should return correct value for valid duration', () => {
+    expect(formatDurationToDays({ seconds: 172800, nanos: 0 })).toBe(2);
+  });
+
+  test('should return null for null input', () => {
+    expect(formatDurationToDays(null)).toBeNull();
+  });
+
+  test('should round down duration to nearest whole day', () => {
+    expect(formatDurationToDays({ seconds: 90000, nanos: 321 })).toBe(1);
+  });
+});

--- a/src/utils/data-formatters/format-duration-to-days.ts
+++ b/src/utils/data-formatters/format-duration-to-days.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { type Duration } from '@/__generated__/proto-ts/google/protobuf/Duration';
+
+const formatDurationToDays = (duration: Duration | null) =>
+  duration ? Math.floor(duration.seconds / 86400) : null;
+
+export default formatDurationToDays;

--- a/src/views/domain-page/config/domain-page-settings-form.config.ts
+++ b/src/views/domain-page/config/domain-page-settings-form.config.ts
@@ -10,7 +10,7 @@ import formatDurationToDays from '@/utils/data-formatters/format-duration-to-day
 import DomainPageSettingsRetentionPeriod from '../domain-page-settings-retention-period/domain-page-settings-retention-period';
 import { type DomainInfo } from '../domain-page.types';
 
-export const settingsValuesConfig = z.object({
+export const settingsFormSchema = z.object({
   description: z.string(),
   retentionPeriodDays: z
     .number({ message: 'Retention period must be a positive integer' })
@@ -20,10 +20,10 @@ export const settingsValuesConfig = z.object({
 });
 
 export const settingsFormConfig: [
-  FormField<DomainInfo, typeof settingsValuesConfig, 'description'>,
-  FormField<DomainInfo, typeof settingsValuesConfig, 'retentionPeriodDays'>,
-  FormField<DomainInfo, typeof settingsValuesConfig, 'visibilityArchival'>,
-  FormField<DomainInfo, typeof settingsValuesConfig, 'historyArchival'>,
+  FormField<DomainInfo, typeof settingsFormSchema, 'description'>,
+  FormField<DomainInfo, typeof settingsFormSchema, 'retentionPeriodDays'>,
+  FormField<DomainInfo, typeof settingsFormSchema, 'visibilityArchival'>,
+  FormField<DomainInfo, typeof settingsFormSchema, 'historyArchival'>,
 ] = [
   {
     path: 'description',

--- a/src/views/domain-page/config/domain-page-settings-form.config.ts
+++ b/src/views/domain-page/config/domain-page-settings-form.config.ts
@@ -1,0 +1,78 @@
+import { createElement } from 'react';
+
+import { STYLE_TYPE, Checkbox } from 'baseui/checkbox';
+import { Textarea, SIZE } from 'baseui/textarea';
+import { z } from 'zod';
+
+import { type FormField } from '@/components/form/form.types';
+import formatDurationToDays from '@/utils/data-formatters/format-duration-to-days';
+
+import DomainPageSettingsRetentionPeriod from '../domain-page-settings-retention-period/domain-page-settings-retention-period';
+import { type DomainInfo } from '../domain-page.types';
+
+export const settingsValuesConfig = z.object({
+  description: z.string(),
+  retentionPeriodDays: z.number(),
+  visibilityArchival: z.boolean(),
+  historyArchival: z.boolean(),
+});
+
+export const settingsFieldsConfig: [
+  FormField<DomainInfo, typeof settingsValuesConfig, 'description'>,
+  FormField<DomainInfo, typeof settingsValuesConfig, 'retentionPeriodDays'>,
+  FormField<DomainInfo, typeof settingsValuesConfig, 'visibilityArchival'>,
+  FormField<DomainInfo, typeof settingsValuesConfig, 'historyArchival'>,
+] = [
+  {
+    path: 'description',
+    title: 'Description',
+    description: 'Brief, high-level description of the Cadence domain',
+    getDefaultValue: (data) => data.description,
+    component: ({ onBlur, onChange, value, error }) =>
+      createElement(Textarea, {
+        onBlur,
+        onChange,
+        value,
+        error: Boolean(error),
+        size: SIZE.compact,
+      }),
+  },
+  {
+    path: 'retentionPeriodDays',
+    title: 'Retention Period',
+    description: 'Brief, high-level description of the Cadence domain',
+    getDefaultValue: (data) =>
+      formatDurationToDays(data.workflowExecutionRetentionPeriod) ?? 0,
+    component: DomainPageSettingsRetentionPeriod,
+  },
+  {
+    path: 'visibilityArchival',
+    title: 'Visibility Archival',
+    description: 'Brief, high-level description of the Cadence domain',
+    getDefaultValue: (data) =>
+      data.visibilityArchivalStatus === 'ARCHIVAL_STATUS_ENABLED',
+    component: ({ onBlur, onChange, value, error }) =>
+      createElement(Checkbox, {
+        onBlur,
+        onChange,
+        checked: value,
+        error: Boolean(error),
+        checkmarkType: STYLE_TYPE.toggle_round,
+      }),
+  },
+  {
+    path: 'historyArchival',
+    title: 'History Archival',
+    description: 'Brief, high-level description of the Cadence domain',
+    getDefaultValue: (data) =>
+      data.historyArchivalStatus === 'ARCHIVAL_STATUS_ENABLED',
+    component: ({ onBlur, onChange, value, error }) =>
+      createElement(Checkbox, {
+        onBlur,
+        onChange,
+        checked: value,
+        error: Boolean(error),
+        checkmarkType: STYLE_TYPE.toggle_round,
+      }),
+  },
+] as const;

--- a/src/views/domain-page/config/domain-page-settings-form.config.ts
+++ b/src/views/domain-page/config/domain-page-settings-form.config.ts
@@ -12,12 +12,14 @@ import { type DomainInfo } from '../domain-page.types';
 
 export const settingsValuesConfig = z.object({
   description: z.string(),
-  retentionPeriodDays: z.number(),
+  retentionPeriodDays: z
+    .number({ message: 'Retention period must be a positive integer' })
+    .positive({ message: 'Retention period must be positive' }),
   visibilityArchival: z.boolean(),
   historyArchival: z.boolean(),
 });
 
-export const settingsFieldsConfig: [
+export const settingsFormConfig: [
   FormField<DomainInfo, typeof settingsValuesConfig, 'description'>,
   FormField<DomainInfo, typeof settingsValuesConfig, 'retentionPeriodDays'>,
   FormField<DomainInfo, typeof settingsValuesConfig, 'visibilityArchival'>,
@@ -40,7 +42,8 @@ export const settingsFieldsConfig: [
   {
     path: 'retentionPeriodDays',
     title: 'Retention Period',
-    description: 'Brief, high-level description of the Cadence domain',
+    description:
+      'Duration for which the workflow execution history is kept in primary persistence store',
     getDefaultValue: (data) =>
       formatDurationToDays(data.workflowExecutionRetentionPeriod) ?? 0,
     component: DomainPageSettingsRetentionPeriod,
@@ -48,7 +51,7 @@ export const settingsFieldsConfig: [
   {
     path: 'visibilityArchival',
     title: 'Visibility Archival',
-    description: 'Brief, high-level description of the Cadence domain',
+    description: 'Flag to enable archival for visibility records',
     getDefaultValue: (data) =>
       data.visibilityArchivalStatus === 'ARCHIVAL_STATUS_ENABLED',
     component: ({ onBlur, onChange, value, error }) =>
@@ -63,7 +66,7 @@ export const settingsFieldsConfig: [
   {
     path: 'historyArchival',
     title: 'History Archival',
-    description: 'Brief, high-level description of the Cadence domain',
+    description: 'Flag to enable archival for workflow history data',
     getDefaultValue: (data) =>
       data.historyArchivalStatus === 'ARCHIVAL_STATUS_ENABLED',
     component: ({ onBlur, onChange, value, error }) =>

--- a/src/views/domain-page/domain-page-settings-retention-period/__tests__/domain-page-settings-retention-period.test.tsx
+++ b/src/views/domain-page/domain-page-settings-retention-period/__tests__/domain-page-settings-retention-period.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@/test-utils/rtl';
+
+import DomainPageSettingsRetentionPeriod from '../domain-page-settings-retention-period';
+
+// Note: We use fireEvent instead of userEvent for this test file since userEvent
+// is not able to properly trigger events for input changes in Form components
+describe(DomainPageSettingsRetentionPeriod.name, () => {
+  it('renders correctly for retention period of multiple days', () => {
+    setup({ retentionPeriod: 5 });
+
+    expect(screen.getByRole('spinbutton')).toHaveDisplayValue('5');
+    expect(screen.getByText('Days')).toBeInTheDocument();
+  });
+
+  it('renders correctly for retention period of 1 day', () => {
+    setup({ retentionPeriod: 1 });
+
+    expect(screen.getByRole('spinbutton')).toHaveDisplayValue('1');
+    expect(screen.getByText('Day')).toBeInTheDocument();
+  });
+
+  it('calls onChange when value is changed', async () => {
+    const { mockOnChange } = setup({ retentionPeriod: 5 });
+
+    const input = screen.getByRole('spinbutton');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 10 } });
+    fireEvent.blur(input);
+
+    expect(mockOnChange).toHaveBeenCalledWith(10);
+  });
+
+  it('changes value to the empty string when cleared', async () => {
+    const { mockOnChange } = setup({ retentionPeriod: 5 });
+
+    const input = screen.getByRole('spinbutton');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    expect(mockOnChange).toHaveBeenCalledWith(NaN);
+  });
+});
+
+function setup({
+  retentionPeriod,
+  error,
+}: {
+  retentionPeriod: number;
+  error?: string;
+}) {
+  const mockOnBlur = jest.fn();
+  const mockOnChange = jest.fn();
+
+  render(
+    <DomainPageSettingsRetentionPeriod
+      onBlur={mockOnBlur}
+      onChange={mockOnChange}
+      value={retentionPeriod}
+      error={error}
+    />
+  );
+
+  return { mockOnChange };
+}

--- a/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.styles.ts
+++ b/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.styles.ts
@@ -7,7 +7,7 @@ export const overrides = {
     Root: {
       style: ({ $theme }: { $theme: Theme }): StyleObject => ({
         ...$theme.typography.ParagraphSmall,
-        maxWidth: '132px',
+        maxWidth: '160px',
       }),
     },
   } satisfies InputOverrides,

--- a/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.styles.ts
+++ b/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.styles.ts
@@ -1,0 +1,14 @@
+import { type Theme } from 'baseui';
+import type { InputOverrides } from 'baseui/input';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  input: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        ...$theme.typography.ParagraphSmall,
+        maxWidth: '132px',
+      }),
+    },
+  } satisfies InputOverrides,
+};

--- a/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.tsx
+++ b/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.tsx
@@ -1,0 +1,26 @@
+import { Input, SIZE } from 'baseui/input';
+import { LabelSmall } from 'baseui/typography';
+
+import { type FieldComponentProps } from '@/components/form/form.types';
+
+import { overrides } from './domain-page-settings-retention-period.styles';
+
+export default function DomainPageSettingsRetentionPeriod(
+  props: FieldComponentProps<number>
+) {
+  return (
+    <Input
+      onBlur={props.onBlur}
+      onChange={(e) => {
+        props.onChange(parseInt(e.target.value));
+      }}
+      value={props.value}
+      error={Boolean(props.error)}
+      endEnhancer={<LabelSmall>{props.value == 1 ? 'Day' : 'Days'}</LabelSmall>}
+      size={SIZE.compact}
+      type="number"
+      pattern="^d*$"
+      overrides={overrides.input}
+    />
+  );
+}

--- a/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.tsx
+++ b/src/views/domain-page/domain-page-settings-retention-period/domain-page-settings-retention-period.tsx
@@ -14,11 +14,12 @@ export default function DomainPageSettingsRetentionPeriod(
       onChange={(e) => {
         props.onChange(parseInt(e.target.value));
       }}
-      value={props.value}
+      value={!isNaN(props.value) ? props.value : ''}
       error={Boolean(props.error)}
       endEnhancer={<LabelSmall>{props.value == 1 ? 'Day' : 'Days'}</LabelSmall>}
       size={SIZE.compact}
       type="number"
+      min={1}
       pattern="^d*$"
       overrides={overrides.input}
     />

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.styles.ts
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.styles.ts
@@ -1,0 +1,7 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  SettingsContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    paddingTop: $theme.sizing.scale950,
+  })),
+};

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
@@ -8,7 +8,7 @@ import PageSection from '@/components/page-section/page-section';
 import request from '@/utils/request';
 
 import {
-  settingsFieldsConfig,
+  settingsFormConfig,
   settingsValuesConfig,
 } from '../config/domain-page-settings-form.config';
 import { type DomainPageTabContentProps } from '../domain-page-content/domain-page-content.types';
@@ -31,9 +31,14 @@ export default function DomainPageSettings(props: DomainPageTabContentProps) {
         <Form
           data={domainInfo}
           zodSchema={settingsValuesConfig}
-          formConfig={settingsFieldsConfig}
+          formConfig={settingsFormConfig}
           // TODO @adhitya.mamallan: Update this with the domain update server action
-          onSubmit={(data) => console.log('Submitted values', data)}
+          onSubmit={async (data) => {
+            // Simulating an async request to cadence-frontend to set domain info for now
+            await new Promise((resolve) => setTimeout(resolve, 4000));
+            console.log('Submitted values', data);
+          }}
+          submitButtonText="Save settings"
         />
       </styled.SettingsContainer>
     </PageSection>

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
@@ -9,7 +9,7 @@ import request from '@/utils/request';
 
 import {
   settingsFormConfig,
-  settingsValuesConfig,
+  settingsFormSchema,
 } from '../config/domain-page-settings-form.config';
 import { type DomainPageTabContentProps } from '../domain-page-content/domain-page-content.types';
 import { type DomainInfo } from '../domain-page.types';
@@ -30,7 +30,7 @@ export default function DomainPageSettings(props: DomainPageTabContentProps) {
       <styled.SettingsContainer>
         <Form
           data={domainInfo}
-          zodSchema={settingsValuesConfig}
+          zodSchema={settingsFormSchema}
           formConfig={settingsFormConfig}
           // TODO @adhitya.mamallan: Update this with the domain update server action
           onSubmit={async (data) => {

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.tsx
@@ -1,7 +1,41 @@
+'use client';
 import React from 'react';
 
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import Form from '@/components/form/form';
+import PageSection from '@/components/page-section/page-section';
+import request from '@/utils/request';
+
+import {
+  settingsFieldsConfig,
+  settingsValuesConfig,
+} from '../config/domain-page-settings-form.config';
 import { type DomainPageTabContentProps } from '../domain-page-content/domain-page-content.types';
+import { type DomainInfo } from '../domain-page.types';
+
+import { styled } from './domain-page-settings.styles';
 
 export default function DomainPageSettings(props: DomainPageTabContentProps) {
-  return <div>Settings tab</div>;
+  const { data: domainInfo } = useSuspenseQuery<DomainInfo>({
+    queryKey: ['describeDomain', props],
+    queryFn: () =>
+      request(`/api/domains/${props.domain}/${props.cluster}`).then((res) =>
+        res.json()
+      ),
+  });
+
+  return (
+    <PageSection>
+      <styled.SettingsContainer>
+        <Form
+          data={domainInfo}
+          zodSchema={settingsValuesConfig}
+          formConfig={settingsFieldsConfig}
+          // TODO @adhitya.mamallan: Update this with the domain update server action
+          onSubmit={(data) => console.log('Submitted values', data)}
+        />
+      </styled.SettingsContainer>
+    </PageSection>
+  );
 }

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.types.ts
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.types.ts
@@ -1,0 +1,5 @@
+import { type z } from 'zod';
+
+import { type settingsValuesConfig } from '../config/domain-page-settings-form.config';
+
+export type SettingsValues = z.infer<typeof settingsValuesConfig>;

--- a/src/views/domain-page/domain-page-settings/domain-page-settings.types.ts
+++ b/src/views/domain-page/domain-page-settings/domain-page-settings.types.ts
@@ -1,5 +1,5 @@
 import { type z } from 'zod';
 
-import { type settingsValuesConfig } from '../config/domain-page-settings-form.config';
+import { type settingsFormSchema } from '../config/domain-page-settings-form.config';
 
-export type SettingsValues = z.infer<typeof settingsValuesConfig>;
+export type SettingsValues = z.infer<typeof settingsFormSchema>;


### PR DESCRIPTION
## Summary
### Reusable form component
- Add reusable Form component that uses react-hook-form with zod-based validation
- Install react-hook-form and @hookform/resolvers for validation resolvers
- Install @testing-library/user-event for testing user interactions

### Domain Page settings
- Add Domain Page Settings zod config and components config
- Add Domain Page Settings that uses the form
- Add formatDurationToDays data formatter
- Add special component for Retention Period

## Test plan
Unit tests + ran cadence-web locally.

### Screenshots

#### Happy path cases
Before editing
<img width="1701" alt="Screenshot 2024-07-04 at 9 37 52 AM" src="https://github.com/uber/cadence-web/assets/26538200/5e2cd658-5280-4559-aa79-84fbdd415f98">

After editing
<img width="1697" alt="Screenshot 2024-07-04 at 9 38 03 AM" src="https://github.com/uber/cadence-web/assets/26538200/9789e3f8-d97e-4e0f-aedd-cff64985e2bf">

On submission (for now, onSubmit just logs the new settings to console)
<img width="500" alt="Screenshot 2024-07-04 at 9 39 32 AM" src="https://github.com/uber/cadence-web/assets/26538200/87eeeaef-588c-4705-8421-7351c39df7cf">

#### Error cases

Incorrect value for Retention Period
<img width="1720" alt="Screenshot 2024-07-04 at 9 38 13 AM" src="https://github.com/uber/cadence-web/assets/26538200/e8a99df6-f977-4e46-9dd8-33da4c58f5ac">

Invalid/missing value for Retention Period
<img width="1717" alt="Screenshot 2024-07-04 at 9 38 26 AM" src="https://github.com/uber/cadence-web/assets/26538200/eb07cde4-f4d4-40b4-bd6b-f0c60b229767">


