### PR TITLE
Disable  executing  domains page during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p ${CADENCE_WEB_PORT-8088}",
     "lint": "next lint",
     "typecheck": "tsc --noemit",
-    "install-idl": "mkdir -p node_modules && cd node_modules && npx --yes tiged https://github.com/uber/cadence-idl#12f43fe756a0c97a676dcaa235f766d760b4b704 cadence-idl --force",
+    "install-idl": "mkdir -p node_modules && cd node_modules && npx --yes tiged https://github.com/uber/cadence-idl#9c848dcfdde56bb40f98897ce5b631aa2e0f2a6d cadence-idl --force",
     "generate:idl": "mkdir -p src/__generated__/idl && npm run generate:idl:proto && npm run generate:idl:proto:types",
     "generate:idl:proto": "rm -rf src/__generated__/idl/proto && cp -R node_modules/cadence-idl/proto src/__generated__/idl/proto",
     "generate:idl:proto:types": "rm -rf src/__generated__/proto-ts &&  ./node_modules/.bin/proto-loader-gen-types  --includeDirs=src/__generated__/idl/proto/  --enums=String --longs=Number --defaults --inputTemplate='%s__Input' --outputTemplate='%s' --oneofs --grpcLib=@grpc/grpc-js --outDir=src/__generated__/proto-ts/ $(npx glob --all --nodir --cwd=src/__generated__/idl/proto **/*.proto) ",

--- a/src/app/(Home)/(Domains)/domains/page.tsx
+++ b/src/app/(Home)/(Domains)/domains/page.tsx
@@ -1,5 +1,5 @@
 import DomainsPage from '@/views/domains-page/domains-page';
 
-export const dynamic = "force-dynamic"; // prevent executing the page during build
+export const dynamic = 'force-dynamic'; // prevent executing the page during build
 
 export default DomainsPage;

--- a/src/app/(Home)/(Domains)/domains/page.tsx
+++ b/src/app/(Home)/(Domains)/domains/page.tsx
@@ -1,3 +1,5 @@
 import DomainsPage from '@/views/domains-page/domains-page';
 
+export const dynamic = "force-dynamic"; // prevent executing the page during build
+
 export default DomainsPage;


### PR DESCRIPTION
Preventing pre-rendering and execution of the domains page during build.
There maybe no benefit from pre-rendering the page during build as each implementation would be connected to a specific data source.