### PR TITLE
Remove static param generation for Workflow page

### DIFF
--- a/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/[workflowTab]/page.tsx
+++ b/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/[workflowTab]/page.tsx
@@ -1,8 +1,3 @@
-import workflowPageTabsConfig from '@/views/workflow-page/config/workflow-page-tabs.config';
 import WorkflowPageTabContent from '@/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content';
 
 export default WorkflowPageTabContent;
-
-export async function generateStaticParams() {
-  return workflowPageTabsConfig.map(({ key }) => key);
-}


### PR DESCRIPTION
## Summary 
Remove static param generation for Workflow page. This fixes rendering issues at build time.

## Test plan
Ran a production build of cadence-web locally to ensure the fix works.