### PR TITLE
Misc changes to Domain Page

### DIFF
--- a/src/views/domain-page/config/domain-page-tabs.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs.config.ts
@@ -1,9 +1,11 @@
+import { MdListAlt, MdSettings, MdSort } from 'react-icons/md';
+
 import type { DomainPageTabs } from '../domain-page-tabs/domain-page-tabs.types';
 
 const domainPageTabsConfig = [
-  { key: 'workflows', title: 'Workflows' },
-  { key: 'metadata', title: 'Metadata' },
-  { key: 'settings', title: 'Settings' },
+  { key: 'workflows', title: 'Workflows', artwork: MdSort },
+  { key: 'metadata', title: 'Metadata', artwork: MdListAlt },
+  { key: 'settings', title: 'Settings', artwork: MdSettings },
 ] as const satisfies DomainPageTabs;
 
 export default domainPageTabsConfig;

--- a/src/views/domain-page/config/domain-page-workflows-table.config.ts
+++ b/src/views/domain-page/config/domain-page-workflows-table.config.ts
@@ -12,7 +12,7 @@ const domainPageWorkflowsTableConfig: Array<TableColumn<DomainWorkflow>> = [
     name: 'Workflow ID',
     id: 'WorkflowID',
     renderCell: (row: DomainWorkflow) => row.workflowID,
-    width: '27.5%',
+    width: '25.5%',
   },
   {
     name: 'Status',
@@ -32,7 +32,7 @@ const domainPageWorkflowsTableConfig: Array<TableColumn<DomainWorkflow>> = [
         },
         row.runID
       ),
-    width: '20%',
+    width: '22%',
   },
   {
     name: 'Workflow type',

--- a/src/views/domain-page/config/domain-page-workflows-table.config.ts
+++ b/src/views/domain-page/config/domain-page-workflows-table.config.ts
@@ -11,14 +11,7 @@ const domainPageWorkflowsTableConfig: Array<TableColumn<DomainWorkflow>> = [
   {
     name: 'Workflow ID',
     id: 'WorkflowID',
-    renderCell: (row: DomainWorkflow) =>
-      createElement(
-        Link,
-        {
-          href: `workflows/${encodeURIComponent(row.workflowID)}/${encodeURIComponent(row.runID)}`,
-        },
-        row.workflowID
-      ),
+    renderCell: (row: DomainWorkflow) => row.workflowID,
     width: '27.5%',
   },
   {
@@ -31,7 +24,14 @@ const domainPageWorkflowsTableConfig: Array<TableColumn<DomainWorkflow>> = [
   {
     name: 'Run ID',
     id: 'RunID',
-    renderCell: (row: DomainWorkflow) => row.runID,
+    renderCell: (row: DomainWorkflow) =>
+      createElement(
+        Link,
+        {
+          href: `workflows/${encodeURIComponent(row.workflowID)}/${encodeURIComponent(row.runID)}`,
+        },
+        row.runID
+      ),
     width: '20%',
   },
   {


### PR DESCRIPTION
## Summary
- Add icons to Domain Page tabs
- Move workflow link from Workflow ID to Run ID
- Widen Run ID column slightly to ensure that Run IDs stay in one line

## Test plan
Ran cadence-web locally.

![Screenshot 2024-07-25 at 3 26 15 PM](https://github.com/user-attachments/assets/534be7e1-86a3-46f6-b59f-058c8e3ffd32)
 