### PR TITLE
Use vue-virtual-scroller 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13641,7 +13641,7 @@
     },
     "vue-virtual-scroller": {
       "version": "1.0.10",
-      "resolved": "https://unpm.uberinternal.com/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
       "integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
       "requires": {
         "scrollparent": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13641,7 +13641,7 @@
     },
     "vue-virtual-scroller": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
+      "resolved": "https://unpm.uberinternal.com/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
       "integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
       "requires": {
         "scrollparent": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "vue-split-panel": "^1.0.4",
     "vue-style-loader": "^3.1.2",
     "vue-template-compiler": "^2.5.2",
-    "vue-virtual-scroller": "^1.0.0-rc.2",
+    "vue-virtual-scroller": "1.0.10",
     "vue2-datepicker": "^3.4.1",
     "vuex": "^3.5.1",
     "vuex-connect": "^2.2.0",


### PR DESCRIPTION
The latest compatible (with package.json) release of vue-virtual-scroller (1.1.2) has an issue where scrollToItem breaks if a gridSize is not mentioned. This causes a bug on the Workflow History page where selecting any item in the activity list causes the entire list to snap back up, which adversely affects UX with longer activity lists.

Since the lockfile already uses 1.0.10, this PR downgrades the version in package.json to match it, so that anyone using cadence-web as an NPM package also gets vue-virtual-scroller 1.0.10.