### PR TITLE
Modify overflow CSS to fix issues with JSON going off-screen

### DIFF
--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -98,7 +98,7 @@ dl.details
     &:nth-child(2n)
       background-color rgba(0,0,0,0.03)
   dt
-    flex 0 1 300px
+    flex 0 0 300px
     font-family monospace-font-family
     font-weight 200
     margin-right 1em

--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -107,5 +107,6 @@ dl.details
     max-width calc(100vw - 700px)
     @media (max-width: 1000px)
       max-width 500px
-    one-liner-ellipsis()
+    overflow-y: auto;
+    max-height: 16vh;
 </style>

--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -793,6 +793,7 @@ section.history {
     .vue-recycle-scroller__slot, .vue-recycle-scroller__item-view, .scroller-item {
       display: flex;
       width: 100%;
+      overflow-wrap: anywhere;
     }
 
     .col-id {


### PR DESCRIPTION
- Use `overflow-wrap: anywhere` so that RecycleScroller items grow to fill the screen instead of expanding outwards
  - The JSON viewer won't grow too big since its size is capped at 15vh and it already has a "full preview" button
- Remove the one-liner-ellipsis() style from detail-list so that bigger fields grow to fill the cell instead of getting cut off with no way to preview them
- Give the detail-list label a flex-shrink of 0 to prevent it from shrinking if the cell value is large
- Give the detail-list cell a max height of 16vh (1 more than the JSON viewer size, to prevent clipping in the Compact view)