### PR TITLE
Bump page size and add warning logs for ListDomains

### DIFF
--- a/src/views/domains-page/helpers/get-all-domains.ts
+++ b/src/views/domains-page/helpers/get-all-domains.ts
@@ -4,17 +4,29 @@ import { unstable_cache } from 'next/cache';
 
 import CLUSTERS_CONFIGS from '@/config/clusters/clusters.config';
 import * as grpcClient from '@/utils/grpc/grpc-client';
+import logger from '@/utils/logger';
 
 import filterDomainsIrrelevantToCluster from './filter-domains-irrelevant-to-cluster';
 import getUniqueDomains from './get-unique-domains';
+
+const MAX_DOMAINS_TO_FETCH = 2000;
 
 export const getAllDomains = async () => {
   const results = await Promise.all(
     CLUSTERS_CONFIGS.map(({ clusterName }) =>
       grpcClient
         .getClusterMethods(clusterName)
-        .listDomains({ pageSize: 1000 })
+        .listDomains({ pageSize: MAX_DOMAINS_TO_FETCH })
         .then(({ domains }) => {
+          if (domains.length >= MAX_DOMAINS_TO_FETCH - 100) {
+            logger.warn(
+              {
+                domainsCount: domains.length,
+                maxDomainsCount: MAX_DOMAINS_TO_FETCH,
+              },
+              'Number of domains in cluster approaching/exceeds max number of domains that can be fetched'
+            );
+          }
           return filterDomainsIrrelevantToCluster(clusterName, domains);
         })
     )


### PR DESCRIPTION
- Bump page size for ListDomains so that we fetch 2000 domains
- Emit a warning log if the number of domains is approaching or exceeds the configured fetch size