### PR TITLE
Add browser-specific fields to browser error payload

### DIFF
--- a/src/utils/logger/pino/helpers/get-log-body.ts
+++ b/src/utils/logger/pino/helpers/get-log-body.ts
@@ -13,6 +13,10 @@ export default function getLogBody(
       'Log from browser',
     payload: {
       browserTimestamp: event.ts,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      userAgent: navigator.userAgent,
+      // TODO @adhitya.mamallan: add a field for "userUuid" once we start sending it for auth
+      url: window.location.href,
       messages: event.messages,
       bindings: event.bindings,
       source: 'browser',

--- a/src/utils/logger/pino/helpers/get-log-body.ts
+++ b/src/utils/logger/pino/helpers/get-log-body.ts
@@ -16,7 +16,14 @@ export default function getLogBody(
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       userAgent: navigator.userAgent,
       // TODO @adhitya.mamallan: add a field for "userUuid" once we start sending it for auth
-      url: window.location.href,
+      // userUuid: ...
+      url: {
+        base: window.location.origin + window.location.pathname,
+        searchParams: Object.fromEntries(
+          new URLSearchParams(window.location.search)
+        ),
+        hash: window.location.hash,
+      },
       messages: event.messages,
       bindings: event.bindings,
       source: 'browser',


### PR DESCRIPTION
## Summary
Add the following browser-specific fields to browser error payload:
- Full URL
- User agent
- Browzer timezone

## Test plan
Tested the logs by running locally and printing a sample warn log.