### PR TITLE
Implement logging for page-level errors in ErrorPanel

### DIFF
--- a/src/app/(Home)/(Domain)/domains/[domain]/[cluster]/[domainTab]/error.tsx
+++ b/src/app/(Home)/(Domain)/domains/[domain]/[cluster]/[domainTab]/error.tsx
@@ -1,13 +1,4 @@
 'use client';
-import ErrorPanel from '@/components/error-panel/error-panel';
-import { type RequestError } from '@/utils/request/request-error';
+import DomainPageTabsError from '@/views/domain-page/domain-page-tabs-error/domain-page-tabs-error';
 
-export default function DomainTabsError({
-  error,
-  reset,
-}: Readonly<{
-  error: RequestError;
-  reset: () => void;
-}>) {
-  return <ErrorPanel message="Failed to load domain content" reset={reset} />;
-}
+export default DomainPageTabsError;

--- a/src/app/(Home)/(Domain)/domains/error.tsx
+++ b/src/app/(Home)/(Domain)/domains/error.tsx
@@ -8,5 +8,7 @@ export default function DomainPageError({
   error: Error;
   reset: () => void;
 }>) {
-  return <ErrorPanel message="Failed to load domain" reset={reset} />;
+  return (
+    <ErrorPanel error={error} message="Failed to load domain" reset={reset} />
+  );
 }

--- a/src/app/(Home)/(Domain)/domains/error.tsx
+++ b/src/app/(Home)/(Domain)/domains/error.tsx
@@ -1,3 +1,4 @@
+'use client';
 import DomainPageError from '@/views/domain-page/domain-page-error/domain-page-error';
 
 export default DomainPageError;

--- a/src/app/(Home)/(Domain)/domains/error.tsx
+++ b/src/app/(Home)/(Domain)/domains/error.tsx
@@ -1,14 +1,3 @@
-'use client';
-import ErrorPanel from '@/components/error-panel/error-panel';
+import DomainPageError from '@/views/domain-page/domain-page-error/domain-page-error';
 
-export default function DomainPageError({
-  error,
-  reset,
-}: Readonly<{
-  error: Error;
-  reset: () => void;
-}>) {
-  return (
-    <ErrorPanel error={error} message="Failed to load domain" reset={reset} />
-  );
-}
+export default DomainPageError;

--- a/src/app/(Home)/(Domains)/domains/error.tsx
+++ b/src/app/(Home)/(Domains)/domains/error.tsx
@@ -8,5 +8,7 @@ export default function DomainsPageError({
   error: Error;
   reset: () => void;
 }>) {
-  return <ErrorPanel message="Failed to load domains" reset={reset} />;
+  return (
+    <ErrorPanel error={error} message="Failed to load domains" reset={reset} />
+  );
 }

--- a/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/[workflowTab]/error.tsx
+++ b/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/[workflowTab]/error.tsx
@@ -8,5 +8,11 @@ export default function WorkflowTabsError({
   error: Error;
   reset: () => void;
 }>) {
-  return <ErrorPanel message="Failed to load workflow content" reset={reset} />;
+  return (
+    <ErrorPanel
+      error={error}
+      message="Failed to load workflow content"
+      reset={reset}
+    />
+  );
 }

--- a/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/error.tsx
+++ b/src/app/(Home)/(Workflow)/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/error.tsx
@@ -8,5 +8,7 @@ export default function WorkflowPageError({
   error: Error;
   reset: () => void;
 }>) {
-  return <ErrorPanel message="Failed to load workflow" reset={reset} />;
+  return (
+    <ErrorPanel error={error} message="Failed to load workflow" reset={reset} />
+  );
 }

--- a/src/app/(Home)/error.tsx
+++ b/src/app/(Home)/error.tsx
@@ -8,5 +8,7 @@ export default function HomePageError({
   error: Error;
   reset: () => void;
 }>) {
-  return <ErrorPanel message="Something went wrong" reset={reset} />;
+  return (
+    <ErrorPanel error={error} message="Something went wrong" reset={reset} />
+  );
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { usePathname } from 'next/navigation';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+
+export default function NotFound() {
+  const path = usePathname();
+
+  return (
+    <ErrorPanel
+      message={`The page "${path}" could not be found`}
+      actions={[
+        {
+          kind: 'link-internal',
+          label: 'Go to domain overview',
+          link: '/domains',
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/error-panel/__tests__/error-panel.test.tsx
+++ b/src/components/error-panel/__tests__/error-panel.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { render, screen, act, fireEvent, within } from '@/test-utils/rtl';
 
-import { RequestError } from '@/utils/request/request-error';
-
 import ErrorPanel from '../error-panel';
 import { type ErrorAction } from '../error-panel.types';
 
@@ -23,7 +21,6 @@ jest.mock('next/navigation', () => ({
 
 const mockError = jest.fn();
 jest.mock('@/utils/logger', () => ({
-  ...jest.requireActual('@/utils/logger'),
   __esModule: true,
   default: {
     error: () => mockError(),
@@ -82,10 +79,11 @@ describe(ErrorPanel.name, () => {
     expect(mockError).toHaveBeenCalled();
   });
 
-  it('should not emit log if a 404 error is passed', async () => {
+  it('should not emit log if an error is passed but omitLogging is true', async () => {
     setup({
       message: 'Mock error message',
-      error: new RequestError('Something was not found', 404),
+      error: new Error('Something was not found'),
+      omitLogging: true,
     });
 
     expect(mockError).not.toHaveBeenCalled();
@@ -163,10 +161,12 @@ function setup({
   message,
   error,
   actions,
+  omitLogging,
 }: {
   message: string;
   error?: Error;
   actions?: Array<ErrorAction>;
+  omitLogging?: boolean;
 }) {
   const mockReset = jest.fn();
   const mockWindowOpen = jest.fn();
@@ -177,6 +177,7 @@ function setup({
       error={error}
       actions={actions}
       reset={mockReset}
+      omitLogging={omitLogging}
     />
   );
   return { mockReset, mockWindowOpen };

--- a/src/components/error-panel/__tests__/error-panel.test.tsx
+++ b/src/components/error-panel/__tests__/error-panel.test.tsx
@@ -23,7 +23,11 @@ jest.mock('next/navigation', () => ({
 
 const mockError = jest.fn();
 jest.mock('@/utils/logger', () => ({
-  error: mockError,
+  ...jest.requireActual('@/utils/logger'),
+  __esModule: true,
+  default: {
+    error: () => mockError(),
+  },
 }));
 
 const mockResetQueryErrors = jest.fn();

--- a/src/components/error-panel/error-panel.constants.ts
+++ b/src/components/error-panel/error-panel.constants.ts
@@ -1,1 +1,0 @@
-export const NO_LOG_ERROR_CODES = [404];

--- a/src/components/error-panel/error-panel.constants.ts
+++ b/src/components/error-panel/error-panel.constants.ts
@@ -1,0 +1,1 @@
+export const NO_LOG_ERROR_CODES = [404];

--- a/src/components/error-panel/error-panel.tsx
+++ b/src/components/error-panel/error-panel.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { Button, SIZE, KIND, SHAPE } from 'baseui/button';
 import Image from 'next/image';
@@ -6,9 +8,7 @@ import { MdRefresh, MdOpenInNew } from 'react-icons/md';
 
 import errorIcon from '@/assets/error-icon.svg';
 import logger from '@/utils/logger';
-import { RequestError } from '@/utils/request/request-error';
 
-import { NO_LOG_ERROR_CODES } from './error-panel.constants';
 import { styled } from './error-panel.styles';
 import { type Props } from './error-panel.types';
 
@@ -16,15 +16,11 @@ export default function ErrorPanel(props: Props) {
   const router = useRouter();
   const { reset: resetQueryErrors } = useQueryErrorResetBoundary();
 
-  if (
-    props.error &&
-    !(
-      props.error instanceof RequestError &&
-      NO_LOG_ERROR_CODES.includes(props.error.status)
-    )
-  ) {
-    logger.error(props.error, props.message);
-  }
+  useEffect(() => {
+    if (props.error && !props.omitLogging) {
+      logger.error(props.error, props.message);
+    }
+  }, [props.error, props.message, props.omitLogging]);
 
   return (
     <styled.ErrorContainer>

--- a/src/components/error-panel/error-panel.tsx
+++ b/src/components/error-panel/error-panel.tsx
@@ -5,13 +5,26 @@ import { useRouter } from 'next/navigation';
 import { MdRefresh, MdOpenInNew } from 'react-icons/md';
 
 import errorIcon from '@/assets/error-icon.svg';
+import logger from '@/utils/logger';
+import { RequestError } from '@/utils/request/request-error';
 
+import { NO_LOG_ERROR_CODES } from './error-panel.constants';
 import { styled } from './error-panel.styles';
 import { type Props } from './error-panel.types';
 
 export default function ErrorPanel(props: Props) {
   const router = useRouter();
   const { reset: resetQueryErrors } = useQueryErrorResetBoundary();
+
+  if (
+    props.error &&
+    !(
+      props.error instanceof RequestError &&
+      NO_LOG_ERROR_CODES.includes(props.error.status)
+    )
+  ) {
+    logger.error(props.error, props.message);
+  }
 
   return (
     <styled.ErrorContainer>
@@ -30,7 +43,7 @@ export default function ErrorPanel(props: Props) {
                   case 'retry':
                     resetQueryErrors();
                     router.refresh();
-                    props.reset();
+                    props.reset?.();
                     break;
                   case 'link-internal':
                     router.push(action.link);

--- a/src/components/error-panel/error-panel.types.ts
+++ b/src/components/error-panel/error-panel.types.ts
@@ -24,4 +24,5 @@ export type Props = {
   message: string;
   actions?: Array<ErrorAction>;
   reset?: () => void;
+  omitLogging?: boolean;
 };

--- a/src/components/error-panel/error-panel.types.ts
+++ b/src/components/error-panel/error-panel.types.ts
@@ -20,7 +20,8 @@ type ExternalLinkAction = BaseAction & {
 export type ErrorAction = RetryAction | InternalLinkAction | ExternalLinkAction;
 
 export type Props = {
+  error?: Error;
   message: string;
   actions?: Array<ErrorAction>;
-  reset: () => void;
+  reset?: () => void;
 };

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -56,23 +56,6 @@ export async function listWorkflows(
       nextPage: res.nextPageToken,
     };
 
-    if (
-      !queryParams.search &&
-      !queryParams.status &&
-      !queryParams.timeRangeStart &&
-      !queryParams.timeRangeEnd &&
-      response.workflows.length === 0
-    ) {
-      return NextResponse.json(
-        {
-          message: 'No workflows found for this domain',
-        },
-        {
-          status: 404,
-        }
-      );
-    }
-
     return NextResponse.json(response);
   } catch (e) {
     return NextResponse.json(

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -56,6 +56,23 @@ export async function listWorkflows(
       nextPage: res.nextPageToken,
     };
 
+    if (
+      !queryParams.search &&
+      !queryParams.status &&
+      !queryParams.timeRangeStart &&
+      !queryParams.timeRangeEnd &&
+      response.workflows.length === 0
+    ) {
+      return NextResponse.json(
+        {
+          message: 'No workflows found for this domain',
+        },
+        {
+          status: 404,
+        }
+      );
+    }
+
     return NextResponse.json(response);
   } catch (e) {
     return NextResponse.json(

--- a/src/views/domain-page/config/domain-page-tabs-error.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs-error.config.ts
@@ -1,0 +1,16 @@
+import { type DomainPageTabsErrorConfig } from '../domain-page-tabs-error/domain-page-tabs-error.types';
+import getDomainWorkflowsErrorConfig from '../helpers/get-domain-workflows-error-config';
+
+const domainPageTabsErrorConfig = {
+  workflows: getDomainWorkflowsErrorConfig,
+  metadata: () => ({
+    message: 'Failed to load metadata',
+    actions: [{ kind: 'retry', label: 'Retry' }],
+  }),
+  settings: () => ({
+    message: 'Failed to load settings',
+    actions: [{ kind: 'retry', label: 'Retry' }],
+  }),
+} as const satisfies DomainPageTabsErrorConfig;
+
+export default domainPageTabsErrorConfig;

--- a/src/views/domain-page/config/domain-page-tabs.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs.config.ts
@@ -3,9 +3,21 @@ import { MdListAlt, MdSettings, MdSort } from 'react-icons/md';
 import type { DomainPageTabs } from '../domain-page-tabs/domain-page-tabs.types';
 
 const domainPageTabsConfig = [
-  { key: 'workflows', title: 'Workflows', artwork: MdSort },
-  { key: 'metadata', title: 'Metadata', artwork: MdListAlt },
-  { key: 'settings', title: 'Settings', artwork: MdSettings },
+  {
+    key: 'workflows',
+    title: 'Workflows',
+    artwork: MdSort,
+  },
+  {
+    key: 'metadata',
+    title: 'Metadata',
+    artwork: MdListAlt,
+  },
+  {
+    key: 'settings',
+    title: 'Settings',
+    artwork: MdSettings,
+  },
 ] as const satisfies DomainPageTabs;
 
 export default domainPageTabsConfig;

--- a/src/views/domain-page/domain-page-content/domain-page-content.types.ts
+++ b/src/views/domain-page/domain-page-content/domain-page-content.types.ts
@@ -1,6 +1,6 @@
 import type domainPageTabsConfig from '../config/domain-page-tabs.config';
 
-type DomainTabName = (typeof domainPageTabsConfig)[number]['key'];
+export type DomainTabName = (typeof domainPageTabsConfig)[number]['key'];
 
 export type DomainPageContentParams = {
   domain: string;

--- a/src/views/domain-page/domain-page-error/__tests__/domain-page-error.test.tsx
+++ b/src/views/domain-page/domain-page-error/__tests__/domain-page-error.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import { RequestError } from '@/utils/request/request-error';
+
+import DomainPageError from '../domain-page-error';
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useParams: () => ({
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    domainTab: 'workflows',
+  }),
+}));
+
+jest.mock('@/components/error-panel/error-panel', () =>
+  jest.fn(({ message }: { message: string }) => <div>{message}</div>)
+);
+
+describe(DomainPageError.name, () => {
+  it('renders error page correctly', () => {
+    render(
+      <DomainPageError
+        error={new Error('something bad happened')}
+        reset={() => {}}
+      />
+    );
+    expect(screen.getByText('Failed to load domain')).toBeInTheDocument();
+  });
+
+  it('renders "not found" error page correctly', () => {
+    render(
+      <DomainPageError
+        error={new RequestError('Could not find domain', 404)}
+        reset={() => {}}
+      />
+    );
+    expect(
+      screen.getByText('The domain test-domain was not found')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/views/domain-page/domain-page-error/__tests__/domain-page-error.test.tsx
+++ b/src/views/domain-page/domain-page-error/__tests__/domain-page-error.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@/components/error-panel/error-panel', () =>
 );
 
 describe(DomainPageError.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders error page correctly', () => {
     render(
       <DomainPageError
@@ -38,7 +42,7 @@ describe(DomainPageError.name, () => {
       />
     );
     expect(
-      screen.getByText('The domain test-domain was not found')
+      screen.getByText('The domain "test-domain" was not found')
     ).toBeInTheDocument();
   });
 });

--- a/src/views/domain-page/domain-page-error/domain-page-error.tsx
+++ b/src/views/domain-page/domain-page-error/domain-page-error.tsx
@@ -3,7 +3,8 @@ import { useParams } from 'next/navigation';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
 import { RequestError } from '@/utils/request/request-error';
-import { Props } from './domain-page-error.types';
+
+import { type Props } from './domain-page-error.types';
 
 export default function DomainPageError({ error, reset }: Props) {
   const { domain } = useParams();
@@ -12,7 +13,7 @@ export default function DomainPageError({ error, reset }: Props) {
     return (
       <ErrorPanel
         error={error}
-        message={`The domain "${domain} was not found`}
+        message={`The domain "${domain}" was not found`}
         actions={[
           {
             kind: 'link-internal',

--- a/src/views/domain-page/domain-page-error/domain-page-error.tsx
+++ b/src/views/domain-page/domain-page-error/domain-page-error.tsx
@@ -3,14 +3,9 @@ import { useParams } from 'next/navigation';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
 import { RequestError } from '@/utils/request/request-error';
+import { Props } from './domain-page-error.types';
 
-export default function DomainPageError({
-  error,
-  reset,
-}: Readonly<{
-  error: Error;
-  reset: () => void;
-}>) {
+export default function DomainPageError({ error, reset }: Props) {
   const { domain } = useParams();
 
   if (error instanceof RequestError && error.status === 404) {

--- a/src/views/domain-page/domain-page-error/domain-page-error.tsx
+++ b/src/views/domain-page/domain-page-error/domain-page-error.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useParams } from 'next/navigation';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+import { RequestError } from '@/utils/request/request-error';
+
+export default function DomainPageError({
+  error,
+  reset,
+}: Readonly<{
+  error: Error;
+  reset: () => void;
+}>) {
+  const { domain } = useParams();
+
+  if (error instanceof RequestError && error.status === 404) {
+    return (
+      <ErrorPanel
+        error={error}
+        message={`The domain "${domain} was not found`}
+        actions={[
+          {
+            kind: 'link-internal',
+            label: 'Go to domain overview',
+            link: '/domains',
+          },
+        ]}
+        reset={reset}
+      />
+    );
+  }
+
+  return (
+    <ErrorPanel
+      error={error}
+      message="Failed to load domain"
+      actions={[
+        {
+          kind: 'retry',
+          label: 'Retry',
+        },
+      ]}
+      reset={reset}
+    />
+  );
+}

--- a/src/views/domain-page/domain-page-error/domain-page-error.types.ts
+++ b/src/views/domain-page/domain-page-error/domain-page-error.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  error: Error;
+  reset: () => void;
+};

--- a/src/views/domain-page/domain-page-tabs-error/__tests__/domain-page-tabs-error.test.tsx
+++ b/src/views/domain-page/domain-page-tabs-error/__tests__/domain-page-tabs-error.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import * as navigationModule from 'next/navigation';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import DomainPageTabsError from '../domain-page-tabs-error';
+import type { DomainPageTabsErrorConfig } from '../domain-page-tabs-error.types';
+
+jest.mock('@/components/error-panel/error-panel', () =>
+  jest.fn(({ message }: { message: string }) => <div>{message}</div>)
+);
+
+jest.mock(
+  '../../config/domain-page-tabs-error.config',
+  () =>
+    ({
+      workflows: () => ({
+        message: 'workflow error',
+      }),
+      metadata: () => ({
+        message: 'metadata error',
+      }),
+      settings: () => ({
+        message: 'settings error',
+      }),
+    }) as const satisfies DomainPageTabsErrorConfig
+);
+
+describe(DomainPageTabsError.name, () => {
+  it('renders tab error correctly when domain tab exists in config', () => {
+    setup();
+    expect(screen.getByText('workflow error')).toBeInTheDocument();
+  });
+
+  it('renders tab error with generic text when domain tab does not exist in config', () => {
+    jest
+      .spyOn(navigationModule, 'useParams')
+      .mockReturnValue({ domainTab: 'invalid-tab' });
+    setup();
+    expect(
+      screen.getByText('Failed to load domain content')
+    ).toBeInTheDocument();
+  });
+});
+
+function setup() {
+  render(
+    <DomainPageTabsError
+      error={new Error('something bad happened')}
+      reset={() => {}}
+    />
+  );
+}

--- a/src/views/domain-page/domain-page-tabs-error/__tests__/domain-page-tabs-error.test.tsx
+++ b/src/views/domain-page/domain-page-tabs-error/__tests__/domain-page-tabs-error.test.tsx
@@ -11,6 +11,15 @@ jest.mock('@/components/error-panel/error-panel', () =>
   jest.fn(({ message }: { message: string }) => <div>{message}</div>)
 );
 
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useParams: jest.fn(() => ({
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    domainTab: 'workflows',
+  })),
+}));
+
 jest.mock(
   '../../config/domain-page-tabs-error.config',
   () =>
@@ -28,15 +37,21 @@ jest.mock(
 );
 
 describe(DomainPageTabsError.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders tab error correctly when domain tab exists in config', () => {
     setup();
     expect(screen.getByText('workflow error')).toBeInTheDocument();
   });
 
   it('renders tab error with generic text when domain tab does not exist in config', () => {
-    jest
-      .spyOn(navigationModule, 'useParams')
-      .mockReturnValue({ domainTab: 'invalid-tab' });
+    jest.spyOn(navigationModule, 'useParams').mockReturnValue({
+      domain: 'test-domain',
+      cluster: 'test-cluster',
+      domainTab: 'invalid',
+    });
     setup();
     expect(
       screen.getByText('Failed to load domain content')

--- a/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
+++ b/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
@@ -1,0 +1,38 @@
+import { useParams } from 'next/navigation';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+import { type RequestError } from '@/utils/request/request-error';
+
+import domainPageTabsErrorConfig from '../config/domain-page-tabs-error.config';
+import { type DomainTabName } from '../domain-page-content/domain-page-content.types';
+
+export default function DomainPageContentError({
+  error,
+  reset,
+}: Readonly<{
+  error: RequestError;
+  reset: () => void;
+}>) {
+  const { domainTab } = useParams();
+  const getConfig = domainPageTabsErrorConfig[domainTab as DomainTabName];
+
+  if (typeof getConfig !== 'function') {
+    return (
+      <ErrorPanel
+        error={error}
+        message={'Failed to load domain content'}
+        reset={reset}
+      />
+    );
+  }
+
+  const errorConfig = getConfig(error);
+  return (
+    <ErrorPanel
+      error={error}
+      message={errorConfig.message}
+      actions={errorConfig.actions}
+      reset={reset}
+    />
+  );
+}

--- a/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
+++ b/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
@@ -1,18 +1,13 @@
 import { useParams } from 'next/navigation';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
-import { type RequestError } from '@/utils/request/request-error';
 
 import domainPageTabsErrorConfig from '../config/domain-page-tabs-error.config';
 import { type DomainTabName } from '../domain-page-content/domain-page-content.types';
 
-export default function DomainPageContentError({
-  error,
-  reset,
-}: Readonly<{
-  error: RequestError;
-  reset: () => void;
-}>) {
+import { type Props } from './domain-page-tabs-error.types';
+
+export default function DomainPageTabsError({ error, reset }: Props) {
   const { domainTab } = useParams();
   const getConfig = domainPageTabsErrorConfig[domainTab as DomainTabName];
 

--- a/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.types.ts
+++ b/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.types.ts
@@ -8,3 +8,8 @@ export type DomainPageTabsErrorConfig = Record<
   DomainTabName,
   (err: Error) => DomainPageTabErrorConfig
 >;
+
+export type Props = {
+  error: Error;
+  reset: () => void;
+};

--- a/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.types.ts
+++ b/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.types.ts
@@ -1,0 +1,10 @@
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+
+import { type DomainTabName } from '../domain-page-content/domain-page-content.types';
+
+export type DomainPageTabErrorConfig = Omit<ErrorPanelProps, 'error' | 'reset'>;
+
+export type DomainPageTabsErrorConfig = Record<
+  DomainTabName,
+  (err: Error) => DomainPageTabErrorConfig
+>;

--- a/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.constants.ts
+++ b/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.constants.ts
@@ -1,1 +1,3 @@
 export const PAGE_SIZE = 10;
+
+export const NO_WORKFLOWS_ERROR_MESSAGE = 'Domain has no workflows';

--- a/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
+++ b/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
@@ -67,6 +67,10 @@ export default function DomainPageWorkflowsTable(props: Props) {
     [data]
   );
 
+  if (workflows.length > 30) {
+    throw new Error('testing random UI bug');
+  }
+
   return (
     <PageSection>
       <Table

--- a/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
+++ b/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
@@ -67,10 +67,6 @@ export default function DomainPageWorkflowsTable(props: Props) {
     [data]
   );
 
-  if (workflows.length > 30) {
-    throw new Error('testing random UI bug');
-  }
-
   return (
     <PageSection>
       <Table

--- a/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
+++ b/src/views/domain-page/domain-page-workflows-table/domain-page-workflows-table.tsx
@@ -18,7 +18,10 @@ import domainPageWorkflowsTableConfig from '../config/domain-page-workflows-tabl
 import DomainPageWorkflowsTableEndMessage from '../domain-page-workflows-table-end-message/domain-page-workflows-table-end-message';
 import getNextSortOrder from '../helpers/get-next-sort-order';
 
-import { PAGE_SIZE } from './domain-page-workflows-table.constants';
+import {
+  NO_WORKFLOWS_ERROR_MESSAGE,
+  PAGE_SIZE,
+} from './domain-page-workflows-table.constants';
 import { type Props } from './domain-page-workflows-table.types';
 
 export default function DomainPageWorkflowsTable(props: Props) {
@@ -66,6 +69,16 @@ export default function DomainPageWorkflowsTable(props: Props) {
     () => data.pages.flatMap((page) => page.workflows ?? []),
     [data]
   );
+
+  if (
+    !queryParams.search &&
+    !queryParams.status &&
+    !queryParams.timeRangeStart &&
+    !queryParams.timeRangeEnd &&
+    workflows.length === 0
+  ) {
+    throw new Error(NO_WORKFLOWS_ERROR_MESSAGE);
+  }
 
   return (
     <PageSection>

--- a/src/views/domain-page/helpers/__tests__/get-domain-workflows-error-config.ts
+++ b/src/views/domain-page/helpers/__tests__/get-domain-workflows-error-config.ts
@@ -1,0 +1,26 @@
+import { NO_WORKFLOWS_ERROR_MESSAGE } from '../../domain-page-workflows-table/domain-page-workflows-table.constants';
+import getDomainWorkflowsErrorConfig from '../get-domain-workflows-error-config';
+
+describe(getDomainWorkflowsErrorConfig.name, () => {
+  it('returns default error config for regular error', () => {
+    expect(getDomainWorkflowsErrorConfig(new Error('Test error'))).toEqual({
+      message: 'Failed to load workflows',
+      actions: [{ kind: 'retry', label: 'Retry' }],
+    });
+  });
+
+  it('returns "not found" error config for workflows not found error', () => {
+    expect(
+      getDomainWorkflowsErrorConfig(new Error(NO_WORKFLOWS_ERROR_MESSAGE))
+    ).toEqual({
+      message: 'No workflows found for this domain',
+      actions: [
+        {
+          kind: 'link-external',
+          label: 'Get started on workflows',
+          link: 'https://cadenceworkflow.io/docs/concepts/workflows',
+        },
+      ],
+    });
+  });
+});

--- a/src/views/domain-page/helpers/get-domain-workflows-error-config.ts
+++ b/src/views/domain-page/helpers/get-domain-workflows-error-config.ts
@@ -1,11 +1,10 @@
-import { RequestError } from '@/utils/request/request-error';
-
 import { type DomainPageTabErrorConfig } from '../domain-page-tabs-error/domain-page-tabs-error.types';
+import { NO_WORKFLOWS_ERROR_MESSAGE } from '../domain-page-workflows-table/domain-page-workflows-table.constants';
 
 export default function getDomainWorkflowsErrorConfig(
   err: Error
 ): DomainPageTabErrorConfig {
-  if (err instanceof RequestError && err.status === 404) {
+  if (err.message === NO_WORKFLOWS_ERROR_MESSAGE) {
     return {
       message: 'No workflows found for this domain',
       actions: [
@@ -15,6 +14,7 @@ export default function getDomainWorkflowsErrorConfig(
           link: 'https://cadenceworkflow.io/docs/concepts/workflows',
         },
       ],
+      omitLogging: true,
     };
   }
 

--- a/src/views/domain-page/helpers/get-domain-workflows-error-config.ts
+++ b/src/views/domain-page/helpers/get-domain-workflows-error-config.ts
@@ -1,0 +1,25 @@
+import { RequestError } from '@/utils/request/request-error';
+
+import { type DomainPageTabErrorConfig } from '../domain-page-tabs-error/domain-page-tabs-error.types';
+
+export default function getDomainWorkflowsErrorConfig(
+  err: Error
+): DomainPageTabErrorConfig {
+  if (err instanceof RequestError && err.status === 404) {
+    return {
+      message: 'No workflows found for this domain',
+      actions: [
+        {
+          kind: 'link-external',
+          label: 'Get started on workflows',
+          link: 'https://cadenceworkflow.io/docs/concepts/workflows',
+        },
+      ],
+    };
+  }
+
+  return {
+    message: 'Failed to load workflows',
+    actions: [{ kind: 'retry', label: 'Retry' }],
+  };
+}


### PR DESCRIPTION
## Summary
- Add logging for page-level errors in ErrorPanel
- Add components for Domain Page Error and Domain Page Tab (content) Error
- Add generic not-found page

## Test plan
Unit tests + ran cadence-web locally.

![Screenshot 2024-08-21 at 7 12 55 PM](https://github.com/user-attachments/assets/333fe1b3-9997-4533-a98b-286e866d48b0)
![Screenshot 2024-08-21 at 7 13 10 PM](https://github.com/user-attachments/assets/de6c12c9-66a8-4d6b-bddb-f4094daeb826)

