### PR TITLE
Add error boundary component

### DIFF
--- a/src/components/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/components/error-boundary/__tests__/error-boundary.test.tsx
@@ -14,7 +14,6 @@ const BadComponent = ({ shouldThrow }: { shouldThrow?: boolean }) => {
 
 const mockError = jest.fn();
 jest.mock('@/utils/logger', () => ({
-  ...jest.requireActual('@/utils/logger'),
   __esModule: true,
   default: {
     error: () => mockError(),

--- a/src/components/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/components/error-boundary/__tests__/error-boundary.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { act, render, screen } from '@/test-utils/rtl';
+
+import ErrorBoundary from '../error-boundary';
+
+const BadComponent = ({ shouldThrow }: { shouldThrow?: boolean }) => {
+  if (shouldThrow) {
+    throw new Error('test error');
+  }
+
+  return <div>Test component</div>;
+};
+
+const mockError = jest.fn();
+jest.mock('@/utils/logger', () => ({
+  ...jest.requireActual('@/utils/logger'),
+  __esModule: true,
+  default: {
+    error: () => mockError(),
+  },
+}));
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe(ErrorBoundary.name, () => {
+  it('should render children without any problems', () => {
+    render(
+      <ErrorBoundary fallback={<div>Fallback</div>}>
+        <BadComponent />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Test component')).toBeInTheDocument();
+  });
+
+  it('should catch errors thrown in children', () => {
+    try {
+      act(() => {
+        render(
+          <ErrorBoundary fallback={<div>Fallback</div>}>
+            <BadComponent shouldThrow={true} />
+          </ErrorBoundary>
+        );
+      });
+    } catch {
+      expect(screen.getByText('Fallback')).toBeInTheDocument();
+      expect(mockError).toHaveBeenCalledWith(expect.any(Error), 'Test error');
+    }
+  });
+});

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -1,0 +1,16 @@
+import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
+
+import logger from '@/utils/logger';
+
+import { type Props } from './error-boundary.types';
+
+export default function ErrorBoundary({ children, ...restProps }: Props) {
+  return (
+    <ReactErrorBoundary
+      {...restProps}
+      onError={(error) => logger.error(error, error.message)}
+    >
+      {children}
+    </ReactErrorBoundary>
+  );
+}

--- a/src/components/error-boundary/error-boundary.types.ts
+++ b/src/components/error-boundary/error-boundary.types.ts
@@ -1,0 +1,3 @@
+import { type ErrorBoundaryProps } from 'react-error-boundary';
+
+export type Props = ErrorBoundaryProps;


### PR DESCRIPTION
## Summary
Add error boundary component that uses react-error-boundary and emits a log whenever it catches an error

## Test plan
Unit tests