### PR TITLE
Add scrollparent 2.0.1 dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "openid-client": "^5.6.5",
     "prismjs": "^1.14.0",
     "promise.prototype.finally": "^3.1.0",
+    "scrollparent": "2.0.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "tchannel": "3.10.1",


### PR DESCRIPTION
TL;DR - locking scrollparent version at 2.0.1 as a quick fix for https://github.com/uber/cadence-web/issues/632

The library vue-virtual-scroller 1.0.10 has some issues with scrollparent 2.1.0, which is the latest compatible version that gets automatically installed when cadence-web is used as an NPM package (and thus, the lockfile is absent). 

Upgrading to vue-virtual-scroller's latest stable release 1.1.2 would fix this problem, but doing so introduces a bug with the history scroller where the autoscroll breaks, snapping the history view all the way up whenever any history event is selected. (more context: https://github.com/uber/cadence-web/pull/624)

Fixing the snap-up issue with vue-virtual-scroller 1.1.2 would need us to rewrite a large portion of the History side panel code, so we are downgrading scrollparent as a quick fix for the issue.