### PR TITLE
Misc error changes + additional usages

### DIFF
--- a/src/components/error-boundary/__tests__/error-boundary.test.tsx
+++ b/src/components/error-boundary/__tests__/error-boundary.test.tsx
@@ -49,4 +49,19 @@ describe(ErrorBoundary.name, () => {
       expect(mockError).toHaveBeenCalledWith(expect.any(Error), 'Test error');
     }
   });
+
+  it('should not log errors thrown in children if omitLogging is passed', () => {
+    try {
+      act(() => {
+        render(
+          <ErrorBoundary fallback={<div>Fallback</div>} omitLogging>
+            <BadComponent shouldThrow={true} />
+          </ErrorBoundary>
+        );
+      });
+    } catch {
+      expect(screen.getByText('Fallback')).toBeInTheDocument();
+      expect(mockError).not.toHaveBeenCalled();
+    }
+  });
 });

--- a/src/components/error-boundary/error-boundary.tsx
+++ b/src/components/error-boundary/error-boundary.tsx
@@ -4,11 +4,24 @@ import logger from '@/utils/logger';
 
 import { type Props } from './error-boundary.types';
 
-export default function ErrorBoundary({ children, ...restProps }: Props) {
+export default function ErrorBoundary({
+  children,
+  omitLogging,
+  ...restProps
+}: Props) {
   return (
     <ReactErrorBoundary
       {...restProps}
-      onError={(error) => logger.error(error, error.message)}
+      onError={(error) => {
+        const shouldOmitLogging =
+          typeof omitLogging === 'function'
+            ? omitLogging(error)
+            : Boolean(omitLogging);
+
+        if (!shouldOmitLogging) {
+          logger.error(error, error.message);
+        }
+      }}
     >
       {children}
     </ReactErrorBoundary>

--- a/src/components/error-boundary/error-boundary.types.ts
+++ b/src/components/error-boundary/error-boundary.types.ts
@@ -1,3 +1,5 @@
 import { type ErrorBoundaryProps } from 'react-error-boundary';
 
-export type Props = ErrorBoundaryProps;
+export type Props = ErrorBoundaryProps & {
+  omitLogging?: boolean | ((err: Error) => boolean);
+};

--- a/src/route-handlers/describe-domain/describe-domain.ts
+++ b/src/route-handlers/describe-domain/describe-domain.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import decodeUrlParams from '@/utils/decode-url-params';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
-import logger from '@/utils/logger';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import { type RequestParams, type RouteParams } from './describe-domain.types';
 
@@ -20,8 +20,8 @@ export async function describeDomain(
 
     return NextResponse.json(res.domain);
   } catch (e) {
-    logger.error(
-      { requestParams: decodedParams, error: e },
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, cause: e },
       'Error fetching domain info'
     );
 

--- a/src/route-handlers/describe-domain/describe-domain.ts
+++ b/src/route-handlers/describe-domain/describe-domain.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import decodeUrlParams from '@/utils/decode-url-params';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
 
 import { type RequestParams, type RouteParams } from './describe-domain.types';
 
@@ -19,9 +20,14 @@ export async function describeDomain(
 
     return NextResponse.json(res.domain);
   } catch (e) {
+    logger.error(
+      { requestParams: decodedParams, error: e },
+      'Error fetching domain info'
+    );
+
     return NextResponse.json(
       {
-        error:
+        message:
           e instanceof GRPCError ? e.message : 'Error fetching domain info',
         cause: e,
       },

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import decodeUrlParams from '@/utils/decode-url-params';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
 
 import getListWorkflowExecutionsQuery from './helpers/get-list-workflow-executions-query';
 import mapExecutionsToWorkflows from './helpers/map-executions-to-workflows';
@@ -58,6 +59,12 @@ export async function listWorkflows(
 
     return NextResponse.json(response);
   } catch (e) {
+    logger.error(
+      { requestParams: decodedParams, queryParams, error: e },
+      'Error fetching workflows' +
+        (e instanceof GRPCError ? ': ' + e.message : '')
+    );
+
     return NextResponse.json(
       {
         message:

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -3,7 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import decodeUrlParams from '@/utils/decode-url-params';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
-import logger from '@/utils/logger';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import getListWorkflowExecutionsQuery from './helpers/get-list-workflow-executions-query';
 import mapExecutionsToWorkflows from './helpers/map-executions-to-workflows';
@@ -59,8 +59,8 @@ export async function listWorkflows(
 
     return NextResponse.json(response);
   } catch (e) {
-    logger.error(
-      { requestParams: decodedParams, queryParams, error: e },
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, queryParams, cause: e },
       'Error fetching workflows' +
         (e instanceof GRPCError ? ': ' + e.message : '')
     );

--- a/src/route-handlers/log-to-server/log-to-server.ts
+++ b/src/route-handlers/log-to-server/log-to-server.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-import logger from '@/utils/logger';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import logToServerPayloadSchema from './schemas/log-to-server-payload-schema';
 
@@ -8,11 +8,15 @@ export async function logToServer(request: NextRequest) {
   const requestBodyJSON = await request.json();
   const { data, error } = logToServerPayloadSchema.safeParse(requestBodyJSON);
   if (error) {
-    logger.error(error, 'Failed to parse log from browser');
+    logger.error<RouteHandlerErrorPayload>(
+      { cause: error },
+      'Failed to parse log from browser'
+    );
 
     return NextResponse.json(
       {
         message: 'Could not log browser log on server',
+        cause: error.errors,
       },
       {
         status: 400,

--- a/src/route-handlers/log-to-server/log-to-server.ts
+++ b/src/route-handlers/log-to-server/log-to-server.ts
@@ -8,10 +8,11 @@ export async function logToServer(request: NextRequest) {
   const requestBodyJSON = await request.json();
   const { data, error } = logToServerPayloadSchema.safeParse(requestBodyJSON);
   if (error) {
+    logger.error(error, 'Failed to parse log from browser');
+
     return NextResponse.json(
       {
-        error: 'Invalid argument(s) for logging to server',
-        validationErrors: error.errors,
+        message: 'Could not log browser log on server',
       },
       {
         status: 400,

--- a/src/utils/logger/index.ts
+++ b/src/utils/logger/index.ts
@@ -10,5 +10,6 @@ export const LOG_LEVELS = Object.values(logger.levels.labels);
 
 // Types
 export { type LogLevel as LogLevel } from './pino/pino.types';
+export * from './logger.types';
 
 export default logger;

--- a/src/utils/logger/logger.types.ts
+++ b/src/utils/logger/logger.types.ts
@@ -1,0 +1,5 @@
+export type RouteHandlerErrorPayload = {
+  cause?: any;
+  requestParams?: object;
+  queryParams?: object;
+};

--- a/src/utils/logger/pino/pino.config.ts
+++ b/src/utils/logger/pino/pino.config.ts
@@ -7,9 +7,10 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 
 const LOGGER_CONFIG: LoggerOptions<CustomLevels> = {
   level: isDevelopment ? 'trace' : 'info',
+  messageKey: 'message',
   formatters: {
-    level(label, number) {
-      return { level: isDevelopment ? number : label };
+    level(label) {
+      return { level: label };
     },
   },
   // To add custom levels, update the corresponding type and add the level values here

--- a/src/utils/logger/pino/pino.config.ts
+++ b/src/utils/logger/pino/pino.config.ts
@@ -7,7 +7,6 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 
 const LOGGER_CONFIG: LoggerOptions<CustomLevels> = {
   level: isDevelopment ? 'trace' : 'info',
-  messageKey: 'message',
   formatters: {
     level(label) {
       return { level: label };

--- a/src/utils/request/__tests__/request.test.ts
+++ b/src/utils/request/__tests__/request.test.ts
@@ -36,7 +36,7 @@ describe('request on browser env', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: false,
-        json: async () => ({ error: 'test error' }),
+        json: async () => ({ message: 'test error' }),
         status: 500,
       } as Response)
     );

--- a/src/utils/request/request.ts
+++ b/src/utils/request/request.ts
@@ -14,7 +14,9 @@ export default function request(
     async (res) => {
       if (!res.ok) {
         const error = await res.json();
-        throw new RequestError(error.message, res.status);
+        throw new RequestError(error.message, res.status, {
+          cause: error.cause,
+        });
       }
       return res;
     }

--- a/src/utils/request/request.ts
+++ b/src/utils/request/request.ts
@@ -14,7 +14,7 @@ export default function request(
     async (res) => {
       if (!res.ok) {
         const error = await res.json();
-        throw new RequestError(error.error, res.status);
+        throw new RequestError(error.message, res.status);
       }
       return res;
     }

--- a/src/views/domain-page/domain-page-error/domain-page-error.tsx
+++ b/src/views/domain-page/domain-page-error/domain-page-error.tsx
@@ -22,6 +22,7 @@ export default function DomainPageError({ error, reset }: Props) {
           },
         ]}
         reset={reset}
+        omitLogging={true}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Change Pino config to always output level as a label
- Add "omitLogging" function to omit logging in error boundaries for certain cases
- Add logs to route handlers
- Fix route handler error responses to pass the error message in "message" instead of "error" (this was inconsistent, I've made it standard)
- Fix request util to read the "message" prop for error message
- Omit logging for "domain not found"
- Add RouteHandlerErrorPayload to standardize fields we log in route handler errors