### PR TITLE
Propagate omit-logging field correctly for Domain Tabs

### DIFF
--- a/src/views/domain-page/config/domain-page-tabs-error.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs-error.config.ts
@@ -1,7 +1,7 @@
 import { type DomainPageTabsErrorConfig } from '../domain-page-tabs-error/domain-page-tabs-error.types';
 import getDomainWorkflowsErrorConfig from '../helpers/get-domain-workflows-error-config';
 
-const domainPageTabsErrorConfig = {
+const domainPageTabsErrorConfig: DomainPageTabsErrorConfig = {
   workflows: getDomainWorkflowsErrorConfig,
   metadata: () => ({
     message: 'Failed to load metadata',
@@ -11,6 +11,6 @@ const domainPageTabsErrorConfig = {
     message: 'Failed to load settings',
     actions: [{ kind: 'retry', label: 'Retry' }],
   }),
-} as const satisfies DomainPageTabsErrorConfig;
+} as const;
 
 export default domainPageTabsErrorConfig;

--- a/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
+++ b/src/views/domain-page/domain-page-tabs-error/domain-page-tabs-error.tsx
@@ -27,6 +27,7 @@ export default function DomainPageTabsError({ error, reset }: Props) {
       error={error}
       message={errorConfig.message}
       actions={errorConfig.actions}
+      omitLogging={errorConfig.omitLogging}
       reset={reset}
     />
   );


### PR DESCRIPTION
## Summary
Propagate omit-logging field correctly in the Domain Page Tabs so that "not found" errors are not logged for the Domain Workflows Tab

## Test plan
Ran locally and verified that logs are not printed for the Workflows Not Found case