### PR TITLE
Migrate workflow APIs to route-handlers

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
@@ -1,25 +1,11 @@
-import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
+import { type NextRequest } from 'next/server';
 
-// TODO: @assem.hafez move api handlers implementations to another file
-type RouteParams = {
-  domain: string;
-  cluster: string;
-  workflowId: string;
-  runId: string;
-};
+import getWorkflowHistory from '@/route-handlers/get-workflow-history/get-workflow-history';
+import { type RouteParams } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
+
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: RouteParams }
 ) {
-  const decodedParams = decodeUrlParams(params);
-  const res = await grpcClient.clusterMethods[params.cluster].getHistory({
-    domain: decodedParams.domain,
-    workflowExecution: {
-      workflowId: decodedParams.workflowId,
-      runId: decodedParams.runId,
-    },
-  });
-
-  return Response.json(res);
+  return getWorkflowHistory(request, { params });
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
@@ -1,25 +1,11 @@
-import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
+import { type NextRequest } from 'next/server';
 
-// TODO: @assem.hafez move api handlers implementations to another file
-type RouteParams = {
-  domain: string;
-  cluster: string;
-  workflowId: string;
-  runId: string;
-};
+import describeWorkflow from '@/route-handlers/describe-workflow/describe-workflow';
+import { type RouteParams } from '@/route-handlers/describe-workflow/describe-workflow.types';
+
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: RouteParams }
 ) {
-  const decodedParams = decodeUrlParams(params);
-  const res = await grpcClient.clusterMethods[params.cluster].describeWorkflow({
-    domain: decodedParams.domain,
-    workflowExecution: {
-      workflowId: decodedParams.workflowId,
-      runId: decodedParams.runId,
-    },
-  });
-
-  return Response.json(res);
+  return describeWorkflow(request, { params });
 }

--- a/src/route-handlers/describe-workflow/describe-workflow.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import * as grpcClient from '@/utils/grpc/grpc-client';
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import { type RequestParams } from './describe-workflow.types';
+
+export default async function describeWorkflow(
+  _: NextRequest,
+  requestParams: RequestParams
+) {
+  const decodedParams = decodeUrlParams(requestParams.params);
+
+  try {
+    const res = await grpcClient.clusterMethods[
+      decodedParams.cluster
+    ].describeWorkflow({
+      domain: decodedParams.domain,
+      workflowExecution: {
+        workflowId: decodedParams.workflowId,
+        runId: decodedParams.runId,
+      },
+    });
+
+    return NextResponse.json(res);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, cause: e },
+      'Error fetching workflow info'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error fetching workflow info',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/describe-workflow/describe-workflow.types.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.types.ts
@@ -1,0 +1,14 @@
+import { type WorkflowExecutionInfo } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionInfo';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type DescribeWorkflowResponse = WorkflowExecutionInfo;

--- a/src/route-handlers/get-workflow-history/get-workflow-history.ts
+++ b/src/route-handlers/get-workflow-history/get-workflow-history.ts
@@ -1,0 +1,45 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import * as grpcClient from '@/utils/grpc/grpc-client';
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import { type RequestParams } from './get-workflow-history.types';
+
+export default async function getWorkflowHistory(
+  _: NextRequest,
+  requestParams: RequestParams
+) {
+  const decodedParams = decodeUrlParams(requestParams.params);
+
+  try {
+    const res = await grpcClient.clusterMethods[
+      decodedParams.cluster
+    ].getHistory({
+      domain: decodedParams.domain,
+      workflowExecution: {
+        workflowId: decodedParams.workflowId,
+        runId: decodedParams.runId,
+      },
+    });
+
+    return Response.json(res);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, cause: e },
+      'Error fetching workflow history'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError
+            ? e.message
+            : 'Error fetching workflow history',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/get-workflow-history/get-workflow-history.types.ts
+++ b/src/route-handlers/get-workflow-history/get-workflow-history.types.ts
@@ -1,0 +1,14 @@
+import { type GetWorkflowExecutionHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryResponse';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type GetWorkflowHistoryResponse = GetWorkflowExecutionHistoryResponse;

--- a/src/views/workflow-summary-tab/workflow-summary-tab.tsx
+++ b/src/views/workflow-summary-tab/workflow-summary-tab.tsx
@@ -4,8 +4,10 @@ import React from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import useStyletronClasses from '@/hooks/use-styletron-classes';
+import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
 import formatWorkflowHistory from '@/utils/data-formatters/format-workflow-history';
 import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
 import type { WorkflowPageTabContentProps } from '@/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types';
 
 import getWorkflowIsCompleted from '../workflow-page/helpers/get-workflow-is-completed';
@@ -19,9 +21,14 @@ export default function WorkflowSummaryTab({
 }: WorkflowPageTabContentProps) {
   const { cls } = useStyletronClasses(cssStyles);
 
-  const { workflowTab, ...histroyQueryParams } = params;
-  const { data: workflowHistory } = useSuspenseQuery({
-    queryKey: ['workflow_history', histroyQueryParams] as const,
+  const { workflowTab, ...historyQueryParams } = params;
+  const { data: workflowHistory } = useSuspenseQuery<
+    GetWorkflowHistoryResponse,
+    RequestError,
+    GetWorkflowHistoryResponse,
+    [string, typeof historyQueryParams]
+  >({
+    queryKey: ['workflow_history', historyQueryParams] as const,
     queryFn: ({ queryKey: [_, qp] }) =>
       request(
         `/api/domains/${qp.domain}/${qp.cluster}/workflows/${qp.workflowId}/${qp.runId}/history`


### PR DESCRIPTION
## Summary
- Move existing Workflow APIs (History and Describe) to src/route-handlers
- Add more descriptive errors, logging, and response types
- Add a type annotation to useSuspenseQuery in the workflow summary page

## Test plan
Ran locally and sanity-checked the Workflow Summary page for a sample workflow.