### PR TITLE
Add configuration options to enable OIDC middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ Set these environment variables if you need to change their defaults
 | CADENCE_WEB_PORT           | HTTP port to serve on                        | 8088             |
 | CADENCE_EXTERNAL_SCRIPTS   | Addtional JavaScript tags to serve in the UI |                  |
 | ENABLE_AUTH                | Enable auth feature                          | false            |
-| AUTH_TYPE                  | concurrently supports ADMIN_JWT              | ''               |
+| AUTH_TYPE                  | supports ADMIN_JWT and OIDC                  | ''               |
 | AUTH_ADMIN_JWT_PRIVATE_KEY | JWT signing private key for ADMIN_JWT type   | ''               |
+| OPENID_CLIENT_ID           | Client ID for OIDC type authentication       | ''               |
+| OPENID_CLIENT_SECRET       | Client secret for OIDC type authentication   | ''               |
+| OPENID_CALLBACK_URL        | URL redirect to Cadence WEB after OIDC auth  | ''               |
+| OPENID_DISCOVER_URL        | Link to provider .well-known configuration   | ''               |
+| OPENID_SCOPE               | Scope to request from idp                    | openid           |
 
 ### Running locally
 

--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,7 @@ const jwt = require('jsonwebtoken');
 const webpackConfig = require('../webpack.config');
 const grpcClient = require('./middleware/grpc-client');
 const tchannelClient = require('./middleware/tchannel-client');
+const oidc = require('./middleware/oidc')
 const router = require('./router');
 const config = require('./config/config');
 const staticRoot = path.join(__dirname, '../dist');
@@ -80,6 +81,12 @@ app.init = function({
   process.on('unhandledRejection', (reason, promise) => {
     console.log('Unhandled Rejection at:', promise, 'reason:', reason);
   });
+
+  if (enableAuth && authType === 'OIDC') {
+    oidc.setupAuth(app, router)
+    app.use(oidc.middleware)
+  }
+
 
   app
     .use(async (ctx, next) => {

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ const jwt = require('jsonwebtoken');
 const webpackConfig = require('../webpack.config');
 const grpcClient = require('./middleware/grpc-client');
 const tchannelClient = require('./middleware/tchannel-client');
-const oidc = require('./middleware/oidc')
+const oidc = require('./middleware/oidc');
 const router = require('./router');
 const config = require('./config/config');
 const staticRoot = path.join(__dirname, '../dist');
@@ -83,10 +83,9 @@ app.init = function({
   });
 
   if (enableAuth && authType === 'OIDC') {
-    oidc.setupAuth(app, router)
-    app.use(oidc.middleware)
+    oidc.setupAuth(app, router);
+    app.use(oidc.middleware);
   }
-
 
   app
     .use(async (ctx, next) => {

--- a/server/middleware/oidc/README.md
+++ b/server/middleware/oidc/README.md
@@ -1,0 +1,14 @@
+### OIDC
+When enabled, Cadence WEB will check if auth token is set in session, if not, user will be redirected to login page to aquire new token. Then token will be attached to all requests sent to Cadence server. Cadence server has to be configured to check and validate those tokens. If OAuth is not enabled on Cadence server side, no tokens sent by Cadence WEB will be validated. 
+
+### Configuration
+
+OIDC can be configured using `server/config/oidc.js` or providing environment variables with values.
+
+| oidc.js variable| Environment Key| Description |
+|--|--|--|
+| clientID| OPENID_CLIENT_ID | The client ID provided by your OpenID Connect provider. |
+| clientSecret | OPENID_CLIENT_SECRET | The client secret provided by your OpenID Connect provider. |
+| callbackURL | OPENID_CALLBACK_URL | The callback URL that your OpenID provider will redirect to after authentication.|
+| discoverURL | OPENID_DISCOVER_URL | The discovery URL of your OpenID provider, used to retrieve metadata (issuer, token endpoints, etc.)|
+

--- a/server/middleware/oidc/index.js
+++ b/server/middleware/oidc/index.js
@@ -117,7 +117,7 @@ const setupAuth = async function(app, router) {
     passReqToCallback: false,
   };
 
-  passport.use('oidc', OpenIDClient.Strategy(strategyOptions, verifyCallback));
+  passport.use('oidc', new OpenIDClient.Strategy(strategyOptions, verifyCallback));
 };
 
 module.exports = {

--- a/server/middleware/oidc/index.js
+++ b/server/middleware/oidc/index.js
@@ -117,7 +117,10 @@ const setupAuth = async function(app, router) {
     passReqToCallback: false,
   };
 
-  passport.use('oidc', new OpenIDClient.Strategy(strategyOptions, verifyCallback));
+  passport.use(
+    'oidc',
+    new OpenIDClient.Strategy(strategyOptions, verifyCallback)
+  );
 };
 
 module.exports = {


### PR DESCRIPTION
Adding configuration support to enable `oidc` middleware.

Configuration supports config file variables and environment variables. 