### PR TITLE
Add TaskListLabel component

### DIFF
--- a/src/route-handlers/describe-task-list/describe-task-list.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.ts
@@ -39,14 +39,14 @@ export async function describeTaskList(
         taskListType: 'TASK_LIST_TYPE_ACTIVITY',
       });
 
-    const res: TaskList = {
+    const taskList: TaskList = {
       name: decodedParams.taskListName,
       pollers: getPollersForTaskList({ decisionTaskList, activityTaskList }),
       decisionTaskListStatus: decisionTaskList.taskListStatus,
       activityTaskListStatus: activityTaskList.taskListStatus,
     };
 
-    return NextResponse.json(res);
+    return NextResponse.json({ taskList });
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: decodedParams, cause: e },

--- a/src/route-handlers/describe-task-list/describe-task-list.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.ts
@@ -46,7 +46,7 @@ export async function describeTaskList(
       activityTaskListStatus: activityTaskList.taskListStatus,
     };
 
-    return NextResponse.json({ taskList: res });
+    return NextResponse.json(res);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: decodedParams, cause: e },

--- a/src/route-handlers/describe-task-list/describe-task-list.types.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.types.ts
@@ -22,3 +22,7 @@ export type TaskList = {
   activityTaskListStatus: TaskListStatus | null;
   decisionTaskListStatus: TaskListStatus | null;
 };
+
+export type DescribeTaskListResponse = {
+  taskList: TaskList;
+};

--- a/src/views/shared/task-list-label/__tests__/task-list-label.test.tsx
+++ b/src/views/shared/task-list-label/__tests__/task-list-label.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { type TagKind } from 'baseui/tag';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import { mockTaskList } from '@/views/task-list-page/__fixtures__/mock-task-list';
+
+import TaskListLabel from '../task-list-label';
+
+jest.mock('baseui/tag', () => ({
+  ...jest.requireActual('baseui/tag'),
+  Tag: jest.fn(({ kind, children }) => (
+    <div data-testid={`mock-tag-${kind}`}>{children}</div>
+  )),
+}));
+
+describe(TaskListLabel.name, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const tests: Array<{
+    name: string;
+    numWorkers: number;
+    text: string;
+    kind: TagKind;
+  }> = [
+    {
+      name: 'should render multiple workers correctly',
+      numWorkers: 2,
+      text: '2 workers',
+      kind: 'accent',
+    },
+    {
+      name: 'should render one worker correctly',
+      numWorkers: 1,
+      text: '1 worker',
+      kind: 'accent',
+    },
+    {
+      name: 'should render no workers correctly',
+      numWorkers: 0,
+      text: '0 workers',
+      kind: 'negative',
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(test.name, () => {
+      render(
+        <TaskListLabel
+          taskList={{
+            ...mockTaskList,
+            pollers: mockTaskList.pollers.slice(0, test.numWorkers),
+          }}
+        />
+      );
+
+      expect(screen.getByText(test.text)).toBeInTheDocument();
+      expect(screen.getByTestId(`mock-tag-${test.kind}`)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/views/shared/task-list-label/task-list-label.styles.ts
+++ b/src/views/shared/task-list-label/task-list-label.styles.ts
@@ -1,0 +1,44 @@
+import { type Theme, styled as createStyled } from 'baseui';
+import type { TagKind, TagOverrides } from 'baseui/tag/types';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  LabelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: $theme.sizing.scale500,
+    ...$theme.typography.LabelSmall,
+  })),
+};
+
+export const overrides = {
+  tag: {
+    Root: {
+      style: ({
+        $theme,
+        $kind,
+      }: {
+        $theme: Theme;
+        $kind: TagKind;
+      }): StyleObject => ({
+        color:
+          $kind === 'negative' ? $theme.colors.red900 : $theme.colors.blue900,
+        backgroundColor:
+          $kind === 'negative' ? $theme.colors.red100 : $theme.colors.blue100,
+        height: $theme.sizing.scale700,
+        borderRadius: $theme.borders.radius400,
+        paddingRight: $theme.sizing.scale300,
+        paddingLeft: $theme.sizing.scale300,
+        paddingTop: $theme.sizing.scale0,
+        paddingBottom: $theme.sizing.scale0,
+        margin: 0,
+      }),
+    },
+    Text: {
+      style: ({ $theme }: { $theme: Theme }) => ({
+        ...$theme.typography.LabelXSmall,
+      }),
+    },
+  } satisfies TagOverrides,
+};

--- a/src/views/shared/task-list-label/task-list-label.styles.ts
+++ b/src/views/shared/task-list-label/task-list-label.styles.ts
@@ -3,13 +3,23 @@ import type { TagKind, TagOverrides } from 'baseui/tag/types';
 import { type StyleObject } from 'styletron-react';
 
 export const styled = {
-  LabelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    columnGap: $theme.sizing.scale500,
-    ...$theme.typography.LabelSmall,
-  })),
+  LabelContainer: createStyled<'div', { $isHighlighted?: boolean }>(
+    'div',
+    ({
+      $theme,
+      $isHighlighted,
+    }: {
+      $theme: Theme;
+      $isHighlighted?: boolean;
+    }) => ({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      columnGap: $theme.sizing.scale500,
+      ...$theme.typography.LabelSmall,
+      ...($isHighlighted && { fontWeight: 700 }),
+    })
+  ),
 };
 
 export const overrides = {

--- a/src/views/shared/task-list-label/task-list-label.styles.ts
+++ b/src/views/shared/task-list-label/task-list-label.styles.ts
@@ -33,7 +33,7 @@ export const overrides = {
         $kind: TagKind;
       }): StyleObject => ({
         color:
-          $kind === 'negative' ? $theme.colors.red900 : $theme.colors.blue900,
+          $kind === 'negative' ? $theme.colors.red700 : $theme.colors.blue700,
         backgroundColor:
           $kind === 'negative' ? $theme.colors.red100 : $theme.colors.blue100,
         height: $theme.sizing.scale700,
@@ -46,7 +46,7 @@ export const overrides = {
       }),
     },
     Text: {
-      style: ({ $theme }: { $theme: Theme }) => ({
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
         ...$theme.typography.LabelXSmall,
       }),
     },

--- a/src/views/shared/task-list-label/task-list-label.tsx
+++ b/src/views/shared/task-list-label/task-list-label.tsx
@@ -1,13 +1,9 @@
 import { Tag, KIND, VARIANT } from 'baseui/tag';
 
-import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
-
 import { styled, overrides } from './task-list-label.styles';
+import { type Props } from './task-list-label.types';
 
-export default function TaskListLabel(props: {
-  taskList: TaskList;
-  isHighlighted?: boolean;
-}) {
+export default function TaskListLabel(props: Props) {
   const numWorkers = props.taskList.pollers.length;
   return (
     <styled.LabelContainer $isHighlighted={props.isHighlighted}>

--- a/src/views/shared/task-list-label/task-list-label.tsx
+++ b/src/views/shared/task-list-label/task-list-label.tsx
@@ -4,17 +4,21 @@ import { type TaskList } from '@/route-handlers/describe-task-list/describe-task
 
 import { styled, overrides } from './task-list-label.styles';
 
-export default function TaskListLabel(props: { taskList: TaskList }) {
+export default function TaskListLabel(props: {
+  taskList: TaskList;
+  isHighlighted?: boolean;
+}) {
+  const numWorkers = props.taskList.pollers.length;
   return (
-    <styled.LabelContainer>
+    <styled.LabelContainer $isHighlighted={props.isHighlighted}>
       {props.taskList.name}
       <Tag
-        kind={KIND.accent}
+        kind={numWorkers === 0 ? KIND.negative : KIND.accent}
         variant={VARIANT.solid}
         closeable={false}
         overrides={overrides.tag}
       >
-        {props.taskList.pollers.length} workers
+        {`${numWorkers} ${numWorkers === 1 ? 'worker' : 'workers'}`}
       </Tag>
     </styled.LabelContainer>
   );

--- a/src/views/shared/task-list-label/task-list-label.tsx
+++ b/src/views/shared/task-list-label/task-list-label.tsx
@@ -1,0 +1,21 @@
+import { Tag, KIND, VARIANT } from 'baseui/tag';
+
+import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
+
+import { styled, overrides } from './task-list-label.styles';
+
+export default function TaskListLabel(props: { taskList: TaskList }) {
+  return (
+    <styled.LabelContainer>
+      {props.taskList.name}
+      <Tag
+        kind={KIND.accent}
+        variant={VARIANT.solid}
+        closeable={false}
+        overrides={overrides.tag}
+      >
+        {props.taskList.pollers.length} workers
+      </Tag>
+    </styled.LabelContainer>
+  );
+}

--- a/src/views/shared/task-list-label/task-list-label.types.ts
+++ b/src/views/shared/task-list-label/task-list-label.types.ts
@@ -1,0 +1,6 @@
+import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
+
+export type Props = {
+  taskList: TaskList;
+  isHighlighted?: boolean;
+};

--- a/src/views/task-list-page/task-list-loader/__tests__/task-list-loader.test.tsx
+++ b/src/views/task-list-page/task-list-loader/__tests__/task-list-loader.test.tsx
@@ -4,14 +4,25 @@ import { HttpResponse } from 'msw';
 
 import { render, screen, act } from '@/test-utils/rtl';
 
+import { type DescribeTaskListResponse } from '@/route-handlers/describe-task-list/describe-task-list.types';
+import type { Props as TaskListLabelProps } from '@/views/shared/task-list-label/task-list-label.types';
+
 import TaskListLoader from '../task-list-loader';
+
+jest.mock('@/views/shared/task-list-label/task-list-label', () =>
+  jest.fn(({ taskList }: TaskListLabelProps) => (
+    <div>
+      {taskList.name}: {taskList.pollers.length} workers
+    </div>
+  ))
+);
 
 describe(TaskListLoader.name, () => {
   it('renders task list without error', async () => {
     await setup({});
 
     expect(
-      await screen.findByText('Placeholder for Task List table')
+      await screen.findByText('tasklist-1: 2 workers')
     ).toBeInTheDocument();
 
     expect(
@@ -61,6 +72,7 @@ async function setup({ error }: { error?: boolean }) {
             : {
                 jsonResponse: {
                   taskList: {
+                    name: 'tasklist-1',
                     pollers: [
                       {
                         activityHandler: true,
@@ -77,8 +89,10 @@ async function setup({ error }: { error?: boolean }) {
                         ratePerSecond: 100000,
                       },
                     ],
+                    activityTaskListStatus: null,
+                    decisionTaskListStatus: null,
                   },
-                },
+                } satisfies DescribeTaskListResponse,
               }),
         },
       ],

--- a/src/views/task-list-page/task-list-loader/task-list-loader.styles.ts
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.styles.ts
@@ -1,0 +1,10 @@
+import { styled as createStyled } from 'baseui';
+
+export const styled = {
+  TaskListContainer: createStyled('div', ({ $theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    paddingTop: $theme.sizing.scale600,
+    rowGap: $theme.sizing.scale600,
+  })),
+};

--- a/src/views/task-list-page/task-list-loader/task-list-loader.tsx
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.tsx
@@ -8,6 +8,7 @@ import { type TaskList } from '@/route-handlers/describe-task-list/describe-task
 import request from '@/utils/request';
 import TaskListLabel from '@/views/shared/task-list-label/task-list-label';
 
+import { styled } from './task-list-loader.styles';
 import { type Props } from './task-list-loader.types';
 
 export default function TaskListLoader(props: Props) {
@@ -21,9 +22,10 @@ export default function TaskListLoader(props: Props) {
 
   return (
     <PageSection>
-      <div>Placeholder for Task List table</div>
-      <TaskListLabel taskList={taskList} />
-      <div>{JSON.stringify(taskList)}</div>
+      <styled.TaskListContainer>
+        <TaskListLabel taskList={taskList} isHighlighted={true} />
+        <div>{'Task List Table placeholder: ' + JSON.stringify(taskList)}</div>
+      </styled.TaskListContainer>
     </PageSection>
   );
 }

--- a/src/views/task-list-page/task-list-loader/task-list-loader.tsx
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.tsx
@@ -6,6 +6,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import PageSection from '@/components/page-section/page-section';
 import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
 import request from '@/utils/request';
+import TaskListLabel from '@/views/shared/task-list-label/task-list-label';
 
 import { type Props } from './task-list-loader.types';
 
@@ -21,6 +22,7 @@ export default function TaskListLoader(props: Props) {
   return (
     <PageSection>
       <div>Placeholder for Task List table</div>
+      <TaskListLabel taskList={taskList} />
       <div>{JSON.stringify(taskList)}</div>
     </PageSection>
   );

--- a/src/views/task-list-page/task-list-loader/task-list-loader.tsx
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import PageSection from '@/components/page-section/page-section';
-import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
+import { type DescribeTaskListResponse } from '@/route-handlers/describe-task-list/describe-task-list.types';
 import request from '@/utils/request';
 import TaskListLabel from '@/views/shared/task-list-label/task-list-label';
 
@@ -12,7 +12,9 @@ import { styled } from './task-list-loader.styles';
 import { type Props } from './task-list-loader.types';
 
 export default function TaskListLoader(props: Props) {
-  const { data: taskList } = useSuspenseQuery<TaskList>({
+  const {
+    data: { taskList },
+  } = useSuspenseQuery<DescribeTaskListResponse>({
     queryKey: ['describeTaskList', props],
     queryFn: () =>
       request(


### PR DESCRIPTION
## Summary
- Add TaskListLabel component in `src/views/shared/` since we plan to use it in the Workflow Summary as well
- Use it in TaskListLoader

### Misc
- Very minor renaming in DescribeTaskList route handler
- Add type for DescribeTaskListResponse to use in the task list loader
- Update TaskListLoader styles and tests

## Test plan
Unit tests + ran locally.

![Screenshot 2024-09-10 at 4 21 46 PM](https://github.com/user-attachments/assets/b4ad2eaa-dbaa-4400-b5ac-152b9862ef1c)
![Screenshot 2024-09-10 at 4 21 38 PM](https://github.com/user-attachments/assets/3cf26192-0131-4365-b3e3-2cd25e56346d)

