### PR TITLE
Add styles to snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "next-router-mock": "^0.9.13",
         "pino-pretty": "^11.2.2",
         "prettier": "3.2.5",
+        "styletron-engine-snapshot": "^1.0.2",
         "ts-jest": "^29.1.2",
         "typescript": "^5.3.3",
         "typescript-eslint": "^7.13.0",
@@ -7640,6 +7641,24 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -7656,6 +7675,15 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -10092,6 +10120,34 @@
       "dependencies": {
         "inline-style-prefixer": "^5.1.0",
         "styletron-standard": "^3.1.0"
+      }
+    },
+    "node_modules/styletron-engine-snapshot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/styletron-engine-snapshot/-/styletron-engine-snapshot-1.0.2.tgz",
+      "integrity": "sha512-ZVFJS+3cuXwD13/VNUP8xeAHxYBEwDX684PbjziucL78ewABRYw6tJTqnRBdR0Xr41O1tkWt/TQyKBwF9jbJfg==",
+      "dev": true,
+      "dependencies": {
+        "json-stable-stringify": "^1.0.1",
+        "prettier": "^2.6.2"
+      },
+      "peerDependencies": {
+        "styletron-standard": "^3.0.1"
+      }
+    },
+    "node_modules/styletron-engine-snapshot/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/styletron-react": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "next-router-mock": "^0.9.13",
     "pino-pretty": "^11.2.2",
     "prettier": "3.2.5",
+    "styletron-engine-snapshot": "^1.0.2",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3",
     "typescript-eslint": "^7.13.0",

--- a/src/providers/styletron-provider.tsx
+++ b/src/providers/styletron-provider.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { BaseProvider, type BaseProviderOverrides, createTheme } from 'baseui';
 import { Provider } from 'styletron-react';
+import { type StandardEngine } from 'styletron-standard';
 
 import themeLight from '@/config/theme/theme-light.config';
 import themeProviderOverrides from '@/config/theme/theme-provider-overrides.config';
@@ -14,12 +15,14 @@ const cadenceLightTheme = createTheme(themeLight);
 export default function StyletronProvider({
   children,
   baseProviderOverrides = themeProviderOverrides,
+  styletronEngine = styletron,
 }: {
   children: React.ReactNode;
   baseProviderOverrides?: BaseProviderOverrides;
+  styletronEngine?: StandardEngine;
 }) {
   return (
-    <Provider value={styletron}>
+    <Provider value={styletronEngine}>
       <BaseProvider overrides={baseProviderOverrides} theme={cadenceLightTheme}>
         {children}
       </BaseProvider>

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -6,6 +6,7 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
+import { StyletronSnapshotEngine } from 'styletron-engine-snapshot';
 
 import themeProviderOverrides from '@/config/theme/theme-provider-overrides.config';
 import StyletronProvider from '@/providers/styletron-provider';
@@ -14,6 +15,8 @@ import MSWMockHandlers from './msw-mock-handlers/msw-mock-handlers';
 import { type Props } from './test-provider.types';
 
 jest.mock('next/router', () => jest.requireActual('next-router-mock'));
+
+const snapshotEngine = new StyletronSnapshotEngine();
 
 const disableAnimationOverrides = {
   AppContainer: {
@@ -57,6 +60,7 @@ export const TestProvider = ({
   queryClientConfig = {},
   endpointsMocks,
   enableAnimations = false,
+  isSnapshotTest = false,
 }: Props) => {
   const [client] = useState(() => getQueryClient(queryClientConfig));
   const themeOverridesWithDisabledAnimations = useMemo(() => {
@@ -66,6 +70,9 @@ export const TestProvider = ({
   return (
     <StyletronProvider
       baseProviderOverrides={themeOverridesWithDisabledAnimations}
+      {...(isSnapshotTest && {
+        styletronEngine: snapshotEngine,
+      })}
     >
       <MSWMockHandlers endpointsMocks={endpointsMocks} />
       <MemoryRouterProvider url={router.initialUrl}>

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -6,6 +6,7 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
+// @ts-expect-error Could not find a declaration file for module 'styletron-engine-snapshot'
 import { StyletronSnapshotEngine } from 'styletron-engine-snapshot';
 
 import themeProviderOverrides from '@/config/theme/theme-provider-overrides.config';

--- a/src/test-utils/test-provider.types.tsx
+++ b/src/test-utils/test-provider.types.tsx
@@ -13,4 +13,5 @@ export type Props = {
   queryClientConfig?: QueryClientConfig;
   endpointsMocks?: MSWMocksHandlersProps['endpointsMocks'];
   enableAnimations?: boolean;
+  isSnapshotTest?: boolean;
 };

--- a/src/views/task-list-page/task-list-workers-table-handler-icon/__tests__/task-list-workers-table-handler-icon.test.tsx
+++ b/src/views/task-list-page/task-list-workers-table-handler-icon/__tests__/task-list-workers-table-handler-icon.test.tsx
@@ -33,7 +33,8 @@ describe(TaskListWorkersTableHandlerIcon.name, () => {
   tests.forEach((test) => {
     it(test.name, () => {
       const { container } = render(
-        <TaskListWorkersTableHandlerIcon hasHandler={test.hasHandler} />
+        <TaskListWorkersTableHandlerIcon hasHandler={test.hasHandler} />,
+        { isSnapshotTest: true }
       );
 
       expect(container).toMatchSnapshot();

--- a/src/views/task-list-page/task-list-workers-table-handler-icon/__tests__/task-list-workers-table-handler-icon.test.tsx.snapshot
+++ b/src/views/task-list-page/task-list-workers-table-handler-icon/__tests__/task-list-workers-table-handler-icon.test.tsx.snapshot
@@ -3,10 +3,20 @@
 exports[`TaskListWorkersTableHandlerIcon should render correctly if worker does not have handler 1`] = `
 <div>
   <div
-    class="css-cOgsKQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-gstZaV"
+      class="style={ color: '#CBCBCB', display: 'block' }
+"
     >
       <svg
         display="block"
@@ -29,7 +39,8 @@ exports[`TaskListWorkersTableHandlerIcon should render correctly if worker does 
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -37,10 +48,20 @@ exports[`TaskListWorkersTableHandlerIcon should render correctly if worker does 
 exports[`TaskListWorkersTableHandlerIcon should render correctly if worker has handler 1`] = `
 <div>
   <div
-    class="css-cOgsKQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-fbOyLS"
+      class="style={ color: '#009A51', display: 'block' }
+"
     >
       <svg
         display="block"
@@ -63,7 +84,8 @@ exports[`TaskListWorkersTableHandlerIcon should render correctly if worker has h
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;

--- a/src/views/workflow-history/workflow-history-event-status-badge/__tests__/workflow-history-tab-event-status-badge.test.tsx
+++ b/src/views/workflow-history/workflow-history-event-status-badge/__tests__/workflow-history-tab-event-status-badge.test.tsx
@@ -12,7 +12,8 @@ describe('WorkflowHistoryEventStatusBadge', () => {
   it('should match snapshot when status is not valid and badge should not be rendered', () => {
     const { container } = render(
       // @ts-expect-error invalid status
-      <WorkflowHistoryEventStatusBadge status="INVALID_STATUS" />
+      <WorkflowHistoryEventStatusBadge status="INVALID_STATUS" />,
+      { isSnapshotTest: true }
     );
     expect(container).toMatchSnapshot();
   });
@@ -29,7 +30,8 @@ describe('WorkflowHistoryEventStatusBadge', () => {
     for (const size of Object.values(WORKFLOW_EVENT_STATUS_BADGE_SIZES)) {
       it(`should match snapshot when status is ${status} and size is ${size}`, () => {
         const { container } = render(
-          <WorkflowHistoryEventStatusBadge status={status} size={size} />
+          <WorkflowHistoryEventStatusBadge status={status} size={size} />,
+          { isSnapshotTest: true }
         );
         expect(container).toMatchSnapshot();
       });

--- a/src/views/workflow-history/workflow-history-event-status-badge/__tests__/workflow-history-tab-event-status-badge.test.tsx.snapshot
+++ b/src/views/workflow-history/workflow-history-event-status-badge/__tests__/workflow-history-tab-event-status-badge.test.tsx.snapshot
@@ -14,10 +14,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when size is not 
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CANCELED and size is medium 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-imTrvB"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#FFE1DE',
+  borderRadius: '16px',
+  color: '#E11900',
+  display: 'flex',
+  flexShrink: 0,
+  height: '24px',
+  justifyContent: 'center',
+  width: '24px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -39,7 +59,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -47,10 +68,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CANCELED and size is small 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-bJbCmb"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#FFE1DE',
+  borderRadius: '16px',
+  color: '#E11900',
+  display: 'flex',
+  flexShrink: 0,
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -72,7 +113,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -80,10 +122,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is COMPLETED and size is medium 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-gxDomB"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#D3EFDA',
+  borderRadius: '16px',
+  color: '#009A51',
+  display: 'flex',
+  flexShrink: 0,
+  height: '24px',
+  justifyContent: 'center',
+  width: '24px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -105,7 +167,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CO
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -113,10 +176,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CO
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is COMPLETED and size is small 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-ljhiBX"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#D3EFDA',
+  borderRadius: '16px',
+  color: '#009A51',
+  display: 'flex',
+  flexShrink: 0,
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -138,7 +221,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CO
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -146,10 +230,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is CO
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FAILED and size is medium 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-imTrvB"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#FFE1DE',
+  borderRadius: '16px',
+  color: '#E11900',
+  display: 'flex',
+  flexShrink: 0,
+  height: '24px',
+  justifyContent: 'center',
+  width: '24px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -174,7 +278,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -182,10 +287,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FAILED and size is small 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-bJbCmb"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#FFE1DE',
+  borderRadius: '16px',
+  color: '#E11900',
+  display: 'flex',
+  flexShrink: 0,
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -210,7 +335,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -218,21 +344,64 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is FA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is ONGOING and size is medium 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-bXJwPs"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#DEE9FE',
+  borderRadius: '16px',
+  display: 'flex',
+  flexShrink: 0,
+  height: '24px',
+  justifyContent: 'center',
+  width: '24px',
+}
+"
     >
       <i
         aria-busy="true"
         aria-label="loading"
-        class="css-dVLAqi"
+        class="style={
+  animationDuration: '1000ms',
+  animationIterationCount: 'infinite',
+  animationName: "keyFrames={\\n  from: { transform: 'rotate(0deg)' },\\n  to: { transform: 'rotate(360deg)' },\\n}\\n",
+  animationTimingFunction: 'linear',
+  borderBottomColor: '#EEEEEE',
+  borderBottomStyle: 'solid',
+  borderBottomWidth: 'NaNpx',
+  borderLeftColor: '#EEEEEE',
+  borderLeftStyle: 'solid',
+  borderLeftWidth: 'NaNpx',
+  borderRadius: '50%',
+  borderRightColor: '#EEEEEE',
+  borderRightStyle: 'solid',
+  borderRightWidth: 'NaNpx',
+  borderTopColor: '#276EF1',
+  borderTopStyle: 'solid',
+  borderTopWidth: 'NaNpx',
+  cursor: 'wait',
+  display: 'block',
+  height: '14px',
+  width: '14px',
+}
+"
         role="progressbar"
       />
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -240,21 +409,64 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is ON
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is ONGOING and size is small 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-icIqWi"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#DEE9FE',
+  borderRadius: '16px',
+  display: 'flex',
+  flexShrink: 0,
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+"
     >
       <i
         aria-busy="true"
         aria-label="loading"
-        class="css-dQmCZe"
+        class="style={
+  animationDuration: '1000ms',
+  animationIterationCount: 'infinite',
+  animationName: "keyFrames={\\n  from: { transform: 'rotate(0deg)' },\\n  to: { transform: 'rotate(360deg)' },\\n}\\n",
+  animationTimingFunction: 'linear',
+  borderBottomColor: '#EEEEEE',
+  borderBottomStyle: 'solid',
+  borderBottomWidth: 'NaNpx',
+  borderLeftColor: '#EEEEEE',
+  borderLeftStyle: 'solid',
+  borderLeftWidth: 'NaNpx',
+  borderRadius: '50%',
+  borderRightColor: '#EEEEEE',
+  borderRightStyle: 'solid',
+  borderRightWidth: 'NaNpx',
+  borderTopColor: '#276EF1',
+  borderTopStyle: 'solid',
+  borderTopWidth: 'NaNpx',
+  cursor: 'wait',
+  display: 'block',
+  height: '10px',
+  width: '10px',
+}
+"
         role="progressbar"
       />
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -262,10 +474,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is ON
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WAITING and size is medium 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-fUSnSp"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#F3F3F3',
+  borderRadius: '16px',
+  color: '#000000',
+  display: 'flex',
+  flexShrink: 0,
+  height: '24px',
+  justifyContent: 'center',
+  width: '24px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -287,7 +519,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -295,10 +528,30 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WAITING and size is small 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   >
     <div
-      class="css-kGwihL"
+      class="style={
+  alignItems: 'center',
+  backgroundColor: '#F3F3F3',
+  borderRadius: '16px',
+  color: '#000000',
+  display: 'flex',
+  flexShrink: 0,
+  height: '16px',
+  justifyContent: 'center',
+  width: '16px',
+}
+"
     >
       <svg
         fill="currentColor"
@@ -320,7 +573,8 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WA
     </div>
   </div>
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;
@@ -328,10 +582,20 @@ exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is WA
 exports[`WorkflowHistoryEventStatusBadge should match snapshot when status is not valid and badge should not be rendered 1`] = `
 <div>
   <div
-    class="css-fWeknQ"
+    class="style={
+  '*, *::before, *::after': {
+    '-moz-animation': 'none !important',
+    '-moz-transition': ' none !important',
+    animation: 'none !important',
+    'caret-color': ' transparent !important',
+    transition: ' none !important',
+  },
+}
+"
   />
   <div
-    class="css-PKJb"
+    class="style={}
+"
   />
 </div>
 `;


### PR DESCRIPTION
### Summary
- Adds styles directly to the snapshot instead of the unstable classnames, this fixes the issue of failing snapshot tests

[Documentation](https://styletron.org/react#snapshot-testing) for the fix