### PR TITLE
Group history events

### DIFF
--- a/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
@@ -1,0 +1,153 @@
+import {
+  fireTimerTaskEvent,
+  startTimerTaskEvent,
+} from '../../__fixtures__/workflow-history-timer-events';
+import type {
+  HistoryGroupEventMetadata,
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  TimerHistoryEvent,
+  TimerHistoryGroup,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+describe('getCommonHistoryGroupFields', () => {
+  it('should return group eventsMetadata with correct labels', () => {
+    const group = setup({});
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Started',
+      'Fired',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    const group = setup({});
+    expect(group.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeMs', () => {
+    const group = setup({});
+    expect(group.eventsMetadata.map(({ timeMs }) => timeMs)).toEqual([
+      1725748370632.0728, 1725748470005.1672,
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const group = setup({});
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Started at 07 Sep, 22:32:50 GMT+0',
+      'Fired at 07 Sep, 22:34:30 GMT+0',
+    ]);
+  });
+
+  it('should override group eventsMetadata timeLabel when eventToTimeLabelPrefixMap is passed', () => {
+    const group = setup({
+      eventToTimeLabelPrefixMap: {
+        timerStartedEventAttributes: 'Happend at',
+      },
+    });
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Happend at 07 Sep, 22:32:50 GMT+0',
+      'Fired at 07 Sep, 22:34:30 GMT+0',
+    ]);
+  });
+
+  it('should return the result of the function call if a function is passed for a stastus key', () => {
+    const singleEvent = [startTimerTaskEvent];
+    const mockedGetStatusFunc = jest.fn().mockReturnValue('ONGOING');
+    const eventToStatus: HistoryGroupEventToStatusMap<TimerHistoryGroup> = {
+      timerStartedEventAttributes: mockedGetStatusFunc,
+      timerFiredEventAttributes: 'COMPLETED',
+      timerCanceledEventAttributes: 'CANCELED',
+    };
+    const group = setup({
+      events: singleEvent,
+      eventToStatus,
+    });
+    expect(group.eventsMetadata.map(({ status }) => status)).toEqual([
+      'ONGOING',
+    ]);
+
+    expect(mockedGetStatusFunc).toHaveBeenCalledWith(
+      startTimerTaskEvent,
+      singleEvent,
+      0
+    );
+  });
+
+  const groupFieldsExtractedFromEventsMetadaTests: {
+    name: string;
+    groupField: 'events' | 'eventsMetadata' | 'status' | 'timeMs' | 'timeLabel';
+    eventsMetadataField: keyof HistoryGroupEventMetadata;
+  }[] = [
+    {
+      name: 'should return group with status equal to last event status',
+      groupField: 'status',
+      eventsMetadataField: 'status',
+    },
+    {
+      name: 'should return group with timeMs equal to last event timeMs',
+      groupField: 'timeMs',
+      eventsMetadataField: 'timeMs',
+    },
+    {
+      name: 'should return group with timeMs equal to last event timeLabel',
+      groupField: 'timeLabel',
+      eventsMetadataField: 'timeLabel',
+    },
+  ];
+
+  groupFieldsExtractedFromEventsMetadaTests.map(
+    ({ name, groupField, eventsMetadataField }) => {
+      it(name, () => {
+        const group = setup({});
+        const groupLastIndex = group.eventsMetadata.length - 1;
+        expect(group[groupField]).toBe(
+          group.eventsMetadata[groupLastIndex][eventsMetadataField]
+        );
+      });
+    }
+  );
+});
+
+// using timer events for testing
+function setup({
+  events,
+  eventToTimeLabelPrefixMap = {},
+  eventToLabel,
+  eventToStatus,
+}: {
+  events?: TimerHistoryEvent[];
+  eventToStatus?: HistoryGroupEventToStatusMap<TimerHistoryGroup>;
+  eventToLabel?: HistoryGroupEventToStringMap<TimerHistoryGroup>;
+  eventToTimeLabelPrefixMap?: Partial<
+    HistoryGroupEventToStringMap<TimerHistoryGroup>
+  >;
+}) {
+  const mockEvents: TimerHistoryEvent[] = events || [
+    startTimerTaskEvent,
+    fireTimerTaskEvent,
+  ];
+
+  const mockedEventToStatus = eventToStatus || {
+    timerStartedEventAttributes: 'COMPLETED',
+    timerFiredEventAttributes: 'COMPLETED',
+    timerCanceledEventAttributes: 'CANCELED',
+  };
+
+  const mockedEventToLabel = eventToLabel || {
+    timerStartedEventAttributes: 'Started',
+    timerFiredEventAttributes: 'Fired',
+    timerCanceledEventAttributes: 'Canceled',
+  };
+
+  return getCommonHistoryGroupFields(
+    mockEvents,
+    mockedEventToStatus,
+    mockedEventToLabel,
+    eventToTimeLabelPrefixMap
+  );
+}

--- a/src/views/workflow-history/helpers/__tests__/group-history-events.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/group-history-events.test.ts
@@ -1,0 +1,109 @@
+import type { HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import logger from '@/utils/logger';
+
+import {
+  scheduleActivityTaskEvent,
+  startActivityTaskEvent,
+} from '../../__fixtures__/workflow-history-activity-events';
+import { startDecisionTaskEvent } from '../../__fixtures__/workflow-history-decision-events';
+import type { ActivityHistoryEvent } from '../../workflow-history.types';
+import getHistoryEventGroupId from '../get-history-event-group-id';
+import { groupHistoryEvents } from '../group-history-events';
+
+jest.mock('../get-history-event-group-id', () => jest.fn());
+jest.mock('../place-event-in-group-events', () =>
+  jest.fn().mockImplementation((event, events) => [...events, event])
+);
+
+const mockedGetHistoryEventGroupId =
+  getHistoryEventGroupId as jest.MockedFunction<typeof getHistoryEventGroupId>;
+
+describe('groupHistoryEvents', () => {
+  let mockLoggerWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLoggerWarn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return initial groups if no events are passed', () => {
+    const result = groupHistoryEvents([]);
+    expect(result).toEqual({});
+  });
+
+  it('should warn if groupId cannot be extracted from an event', () => {
+    const events: HistoryEvent[] = [scheduleActivityTaskEvent];
+    mockedGetHistoryEventGroupId.mockReturnValue(undefined);
+    groupHistoryEvents(events);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      {
+        eventId: scheduleActivityTaskEvent.eventId,
+        eventTime: scheduleActivityTaskEvent.eventTime,
+      },
+      "Couldn't extract groupId from event, check event payload and extraction logic"
+    );
+  });
+
+  it('should warn if events are grouped together while they are not the same group type', () => {
+    const events: HistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startDecisionTaskEvent,
+    ];
+    mockedGetHistoryEventGroupId.mockReturnValue('group1');
+
+    groupHistoryEvents(events);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      {
+        eventId: startDecisionTaskEvent.eventId,
+        eventTime: startDecisionTaskEvent.eventTime,
+        events: events.map(({ eventId, eventTime }) => ({
+          eventId,
+          eventTime,
+        })),
+      },
+      'No handler for grouping this event'
+    );
+  });
+
+  it('should group events as activity group when all events are of the same group', () => {
+    const events: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+    ];
+    (getHistoryEventGroupId as jest.Mock).mockReturnValue('group1');
+
+    const result = groupHistoryEvents(events);
+    expect(result.group1.events).toEqual(events);
+  });
+
+  it('should warn when no event handler matches the event type', () => {
+    const events: HistoryEvent[] = [
+      {
+        ...scheduleActivityTaskEvent,
+        //@ts-expect-error Type '"fakeAttribute"' is not assignable to type
+        attributes: 'fakeAttribute',
+      },
+    ];
+    (getHistoryEventGroupId as jest.Mock).mockReturnValue('group3');
+
+    const result = groupHistoryEvents(events);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      {
+        eventId: scheduleActivityTaskEvent.eventId,
+        eventTime: scheduleActivityTaskEvent.eventTime,
+        events: [
+          {
+            eventId: scheduleActivityTaskEvent.eventId,
+            eventTime: scheduleActivityTaskEvent.eventTime,
+          },
+        ],
+      },
+      'No handler for grouping this event'
+    );
+    expect(result).toEqual({});
+  });
+});

--- a/src/views/workflow-history/helpers/get-common-history-group-fields.ts
+++ b/src/views/workflow-history/helpers/get-common-history-group-fields.ts
@@ -1,0 +1,52 @@
+import formatDate from '@/utils/data-formatters/format-date';
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+
+import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+import {
+  type HistoryEventsGroup,
+  type HistoryGroupEventToStatusMap,
+  type HistoryGroupEventToStringMap,
+} from '../workflow-history.types';
+
+export default function getCommonHistoryGroupFields<
+  GroupT extends HistoryEventsGroup,
+>(
+  events: GroupT['events'],
+  HistoryGroupEventToStatusMap: HistoryGroupEventToStatusMap<GroupT>,
+  eventToLabelMap: HistoryGroupEventToStringMap<GroupT>,
+  eventToTimeLabelPrefixMap: Partial<HistoryGroupEventToStringMap<GroupT>>
+): Pick<
+  GroupT,
+  'eventsMetadata' | 'events' | 'status' | 'timeMs' | 'timeLabel'
+> {
+  const eventsMetadata = events.map((event, index) => {
+    const attrs = event.attributes as GroupT['events'][number]['attributes'];
+    const getEventStatus = HistoryGroupEventToStatusMap[attrs];
+    const eventStatus: WorkflowEventStatus =
+      typeof getEventStatus === 'function'
+        ? getEventStatus(event, events, index)
+        : getEventStatus;
+    const timeMs = event.eventTime ? parseGrpcTimestamp(event.eventTime) : null;
+    const prefix = eventToTimeLabelPrefixMap.hasOwnProperty(attrs)
+      ? eventToTimeLabelPrefixMap[attrs]
+      : `${eventToLabelMap[attrs]} at`;
+    return {
+      label: eventToLabelMap[attrs],
+      status: eventStatus,
+      timeMs,
+      timeLabel: timeMs ? `${prefix} ${formatDate(timeMs)}` : '',
+    };
+  });
+
+  const groupStatus = eventsMetadata[eventsMetadata.length - 1].status;
+  const groupTimeMs = eventsMetadata[eventsMetadata.length - 1].timeMs;
+  const groupTimeLabel = eventsMetadata[eventsMetadata.length - 1].timeLabel;
+
+  return {
+    eventsMetadata,
+    events,
+    status: groupStatus,
+    timeMs: groupTimeMs,
+    timeLabel: groupTimeLabel,
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-event-group-id.ts
+++ b/src/views/workflow-history/helpers/get-history-event-group-id.ts
@@ -1,0 +1,48 @@
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+import isActivityEvent from './check-history-event-group/is-activity-event';
+import isChildWorkflowExecutionEvent from './check-history-event-group/is-child-workflow-execution-event';
+import isDecisionEvent from './check-history-event-group/is-decision-event';
+import isRequestCancelExternalWorkflowExecutionEvent from './check-history-event-group/is-request-cancel-external-workflow-execution-event';
+import isSignalExternalWorkflowExecutionEvent from './check-history-event-group/is-signal-external-workflow-execution-event';
+import isTimerEvent from './check-history-event-group/is-timer-event';
+
+export default function getHistoryEventGroupId(
+  event: HistoryEvent
+): string | undefined {
+  if (
+    isActivityEvent(event) &&
+    event.attributes !== 'activityTaskScheduledEventAttributes'
+  ) {
+    return event[event.attributes]?.scheduledEventId;
+  } else if (
+    isDecisionEvent(event) &&
+    event.attributes !== 'decisionTaskScheduledEventAttributes'
+  ) {
+    return event[event.attributes]?.scheduledEventId;
+  } else if (
+    isTimerEvent(event) &&
+    event.attributes !== 'timerStartedEventAttributes'
+  ) {
+    return event[event.attributes]?.startedEventId;
+  } else if (
+    isChildWorkflowExecutionEvent(event) &&
+    event.attributes !== 'startChildWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    return event[event.attributes]?.initiatedEventId;
+  } else if (
+    isSignalExternalWorkflowExecutionEvent(event) &&
+    event.attributes !==
+      'signalExternalWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    return event[event.attributes]?.initiatedEventId;
+  } else if (
+    isRequestCancelExternalWorkflowExecutionEvent(event) &&
+    event.attributes !==
+      'requestCancelExternalWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    return event[event.attributes]?.initiatedEventId;
+  } else {
+    return event?.eventId;
+  }
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -1,0 +1,187 @@
+import {
+  cancelActivityTaskEvent,
+  completeActivityTaskEvent,
+  failedActivityTaskEvent,
+  scheduleActivityTaskEvent,
+  startActivityTaskEvent,
+  timeoutActivityTaskEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-activity-events';
+
+import type { ActivityHistoryEvent } from '../../../workflow-history.types';
+import getActivityGroupFromEvents from '../get-activity-group-from-events';
+
+describe('getActivityGroupFromEvents', () => {
+  it('should return a group with a proper label when scheduled event exists', () => {
+    const events: ActivityHistoryEvent[] = [scheduleActivityTaskEvent];
+
+    const scheduelAttrs =
+      scheduleActivityTaskEvent.activityTaskScheduledEventAttributes;
+    const expectedLabel = `Activity ${scheduelAttrs?.activityId}: ${scheduelAttrs?.activityType?.name}`;
+
+    const group = getActivityGroupFromEvents(events);
+
+    expect(group.label).toBe(expectedLabel);
+  });
+
+  it('should return a group with empty label when scheduled event is missing', () => {
+    const completeEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const completedActivitygroup = getActivityGroupFromEvents(completeEvents);
+    expect(completedActivitygroup.label).toBe('');
+
+    const failureEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      failedActivityTaskEvent,
+    ];
+    const failedActivitygroup = getActivityGroupFromEvents(failureEvents);
+    expect(failedActivitygroup.label).toBe('');
+
+    const timeoutEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      timeoutActivityTaskEvent,
+    ];
+    const timedoutActivitygroup = getActivityGroupFromEvents(timeoutEvents);
+    expect(timedoutActivitygroup.label).toBe('');
+  });
+
+  it('should return a group with hasMissingEvents set to true when scheduled event is missing', () => {
+    const completeEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const completedActivitygroup = getActivityGroupFromEvents(completeEvents);
+    expect(completedActivitygroup.hasMissingEvents).toBe(true);
+
+    const failureEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      failedActivityTaskEvent,
+    ];
+    const failedActivitygroup = getActivityGroupFromEvents(failureEvents);
+    expect(failedActivitygroup.hasMissingEvents).toBe(true);
+
+    const timeoutEvents: ActivityHistoryEvent[] = [
+      startActivityTaskEvent,
+      timeoutActivityTaskEvent,
+    ];
+    const timedoutActivitygroup = getActivityGroupFromEvents(timeoutEvents);
+    expect(timedoutActivitygroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to Activity', () => {
+    const events: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const group = getActivityGroupFromEvents(events);
+    expect(group.groupType).toBe('Activity');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+      failedActivityTaskEvent,
+      timeoutActivityTaskEvent,
+      cancelActivityTaskEvent,
+    ];
+    const group = getActivityGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Scheduled',
+      'Started',
+      'Completed',
+      'Failed',
+      'Timed out',
+      'Canceled',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // just scheduled
+    const scheduleEvents: ActivityHistoryEvent[] = [scheduleActivityTaskEvent];
+    const scheduledGroup = getActivityGroupFromEvents(scheduleEvents);
+    expect(scheduledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'WAITING',
+    ]);
+
+    // started
+    const startEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+    ];
+    const startedGroup = getActivityGroupFromEvents(startEvents);
+    expect(startedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'ONGOING',
+    ]);
+
+    // Completed
+    const completeEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const completedGroup = getActivityGroupFromEvents(completeEvents);
+    expect(completedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+
+    // Failed
+    const failureEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      failedActivityTaskEvent,
+    ];
+    const failedGroup = getActivityGroupFromEvents(failureEvents);
+    expect(failedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+
+    // Canceled
+    const cancelEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      cancelActivityTaskEvent,
+    ];
+    const canceledGroup = getActivityGroupFromEvents(cancelEvents);
+    expect(canceledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'CANCELED',
+    ]);
+
+    // Timed out
+    const timeoutEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      timeoutActivityTaskEvent,
+    ];
+    const timedoutGroup = getActivityGroupFromEvents(timeoutEvents);
+    expect(timedoutGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const group = getActivityGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Scheduled at 07 Sep, 22:16:10 GMT+0',
+      'Started at 07 Sep, 22:16:10 GMT+0',
+      'Completed at 07 Sep, 22:16:10 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -1,0 +1,211 @@
+import {
+  cancelChildWorkflowEvent,
+  completeChildWorkflowEvent,
+  failChildWorkflowEvent,
+  initiateChildWorkflowEvent,
+  initiateFailureChildWorkflowEvent,
+  startChildWorkflowEvent,
+  timeoutChildWorkflowEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-child-workflow-events';
+
+import type { ChildWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
+import getChildWorkflowExecutionGroupFromEvents from '../get-child-workflow-execution-group-from-events';
+
+describe('getChildWorkflowExecutionGroupFromEvents', () => {
+  it('should return a group with a proper label', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+    ];
+
+    const expectedLabel = `Child Workflow: ${initiateChildWorkflowEvent.startChildWorkflowExecutionInitiatedEventAttributes?.workflowType?.name}`;
+
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    expect(group.label).toBe(expectedLabel);
+  });
+
+  it('should return a group with hasMissingEvents set to true when initiate event is missing', () => {
+    const intiateFailedEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateFailureChildWorkflowEvent,
+    ];
+    const intiateFailedChildWorkflowgroup =
+      getChildWorkflowExecutionGroupFromEvents(intiateFailedEvents);
+    expect(intiateFailedChildWorkflowgroup.hasMissingEvents).toBe(true);
+
+    const completeEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+    ];
+    const completedChildWorkflowgroup =
+      getChildWorkflowExecutionGroupFromEvents(completeEvents);
+    expect(completedChildWorkflowgroup.hasMissingEvents).toBe(true);
+
+    const failureEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      startChildWorkflowEvent,
+      failChildWorkflowEvent,
+    ];
+    const failedChildWorkflowgroup =
+      getChildWorkflowExecutionGroupFromEvents(failureEvents);
+    expect(failedChildWorkflowgroup.hasMissingEvents).toBe(true);
+
+    const timeoutEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      startChildWorkflowEvent,
+      timeoutChildWorkflowEvent,
+    ];
+    const timedoutChildWorkflowgroup =
+      getChildWorkflowExecutionGroupFromEvents(timeoutEvents);
+    expect(timedoutChildWorkflowgroup.hasMissingEvents).toBe(true);
+
+    const cancelEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      startChildWorkflowEvent,
+      cancelChildWorkflowEvent,
+    ];
+    const cancelChildWorkflowgroup =
+      getChildWorkflowExecutionGroupFromEvents(cancelEvents);
+    expect(cancelChildWorkflowgroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to ChildWorkflow', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+    expect(group.groupType).toBe('ChildWorkflowExecution');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+      failChildWorkflowEvent,
+      timeoutChildWorkflowEvent,
+      cancelChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Initiated',
+      'Initiation failed',
+      'Started',
+      'Completed',
+      'Failed',
+      'Timed out',
+      'Canceled',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // initiated
+    const scheduleEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+    ];
+    const scheduledGroup =
+      getChildWorkflowExecutionGroupFromEvents(scheduleEvents);
+    expect(scheduledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'WAITING',
+    ]);
+
+    // started
+    const initiationFailedEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      failChildWorkflowEvent,
+    ];
+    const initiationFailedGroup = getChildWorkflowExecutionGroupFromEvents(
+      initiationFailedEvents
+    );
+    expect(
+      initiationFailedGroup.eventsMetadata.map(({ status }) => status)
+    ).toEqual(['COMPLETED', 'FAILED']);
+
+    // started
+    const startEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+    ];
+    const startedGroup = getChildWorkflowExecutionGroupFromEvents(startEvents);
+    expect(startedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'ONGOING',
+    ]);
+
+    // Completed
+    const completeEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+    ];
+    const completedGroup =
+      getChildWorkflowExecutionGroupFromEvents(completeEvents);
+    expect(completedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+
+    // Failed
+    const failureEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      failChildWorkflowEvent,
+    ];
+    const failedGroup = getChildWorkflowExecutionGroupFromEvents(failureEvents);
+    expect(failedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+
+    // Canceled
+    const cancelEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      cancelChildWorkflowEvent,
+    ];
+    const canceledGroup =
+      getChildWorkflowExecutionGroupFromEvents(cancelEvents);
+    expect(canceledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'CANCELED',
+    ]);
+
+    // Timed out
+    const timeoutEvents: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      timeoutChildWorkflowEvent,
+    ];
+    const timedoutGroup =
+      getChildWorkflowExecutionGroupFromEvents(timeoutEvents);
+    expect(timedoutGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+      failChildWorkflowEvent,
+      timeoutChildWorkflowEvent,
+      cancelChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Initiated at 21 Jun 1975, 10:47:51 GMT+0',
+      'Initiation failed at 08 Sep, 04:27:52 GMT+0',
+      'Started at 08 Sep, 04:27:53 GMT+0',
+      'Completed at 08 Sep, 04:27:54 GMT+0',
+      'Failed at 08 Sep, 04:27:58 GMT+0',
+      'Timed out at 08 Sep, 04:27:57 GMT+0',
+      'Canceled at 08 Sep, 04:27:55 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -1,0 +1,144 @@
+import {
+  completeDecisionTaskEvent,
+  failedDecisionTaskEvent,
+  scheduleDecisionTaskEvent,
+  startDecisionTaskEvent,
+  timeoutDecisionTaskEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-decision-events';
+
+import type { DecisionHistoryEvent } from '../../../workflow-history.types';
+import getDecisionGroupFromEvents from '../get-decision-group-from-events';
+
+describe('getDecisionGroupFromEvents', () => {
+  it('should return a group with a proper label when scheduled event exists', () => {
+    const events: DecisionHistoryEvent[] = [scheduleDecisionTaskEvent];
+
+    const group = getDecisionGroupFromEvents(events);
+
+    expect(group.label).toBe('Decision Task');
+  });
+
+  it('should return a group with hasMissingEvents set to true when scheduled event is missing', () => {
+    const completeEvents: DecisionHistoryEvent[] = [
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const completedDecisiongroup = getDecisionGroupFromEvents(completeEvents);
+    expect(completedDecisiongroup.hasMissingEvents).toBe(true);
+
+    const failureEvents: DecisionHistoryEvent[] = [
+      startDecisionTaskEvent,
+      failedDecisionTaskEvent,
+    ];
+    const failedDecisiongroup = getDecisionGroupFromEvents(failureEvents);
+    expect(failedDecisiongroup.hasMissingEvents).toBe(true);
+
+    const timeoutEvents: DecisionHistoryEvent[] = [
+      startDecisionTaskEvent,
+      timeoutDecisionTaskEvent,
+    ];
+    const timedoutDecisiongroup = getDecisionGroupFromEvents(timeoutEvents);
+    expect(timedoutDecisiongroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to Decision', () => {
+    const events: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const group = getDecisionGroupFromEvents(events);
+    expect(group.groupType).toBe('Decision');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+      failedDecisionTaskEvent,
+      timeoutDecisionTaskEvent,
+    ];
+    const group = getDecisionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Scheduled',
+      'Started',
+      'Completed',
+      'Failed',
+      'Timed out',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // just scheduled
+    const scheduleEvents: DecisionHistoryEvent[] = [scheduleDecisionTaskEvent];
+    const scheduledGroup = getDecisionGroupFromEvents(scheduleEvents);
+    expect(scheduledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'WAITING',
+    ]);
+
+    // started
+    const startEvents: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+    ];
+    const startedGroup = getDecisionGroupFromEvents(startEvents);
+    expect(startedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'ONGOING',
+    ]);
+
+    // Completed
+    const completeEvents: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const completedGroup = getDecisionGroupFromEvents(completeEvents);
+    expect(completedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+
+    // Failed
+    const failureEvents: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      failedDecisionTaskEvent,
+    ];
+    const failedGroup = getDecisionGroupFromEvents(failureEvents);
+    expect(failedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+
+    // Timed out
+    const timeoutEvents: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      timeoutDecisionTaskEvent,
+    ];
+    const timedoutGroup = getDecisionGroupFromEvents(timeoutEvents);
+    expect(timedoutGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+      'FAILED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: DecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const group = getDecisionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Scheduled at 07 Sep, 22:16:10 GMT+0',
+      'Started at 07 Sep, 22:16:10 GMT+0',
+      'Completed at 07 Sep, 22:16:10 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -1,0 +1,90 @@
+import {
+  initiateRequestCancelExternalWorkflowEvent,
+  requestCancelExternalWorkflowEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-request-cancel-external-workflow-events';
+
+import type { RequestCancelExternalWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
+import getRequestCancelExternalWorkflowExecutionGroupFromEvents from '../get-request-cancel-external-workflow-execution-group-from-events';
+
+describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
+  it('should return a group with a correct label', () => {
+    const events: RequestCancelExternalWorkflowExecutionHistoryEvent[] = [
+      requestCancelExternalWorkflowEvent,
+    ];
+
+    const expectedLabel = `Request Cancel External Workflow`;
+
+    const group =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
+
+    expect(group.label).toBe(expectedLabel);
+  });
+
+  it('should return a group with hasMissingEvents set to true when initiated event is missing', () => {
+    const requestEvents: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+      [requestCancelExternalWorkflowEvent];
+    const requestGroup =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(requestEvents);
+    expect(requestGroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to RequestCancelExternalWorkflowExecution', () => {
+    const events: RequestCancelExternalWorkflowExecutionHistoryEvent[] = [
+      initiateRequestCancelExternalWorkflowEvent,
+      requestCancelExternalWorkflowEvent,
+    ];
+    const group =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.groupType).toBe('RequestCancelExternalWorkflowExecution');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: RequestCancelExternalWorkflowExecutionHistoryEvent[] = [
+      initiateRequestCancelExternalWorkflowEvent,
+      requestCancelExternalWorkflowEvent,
+    ];
+    const group =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Initiated',
+      'Requested',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // initiated
+    const initiateEvents: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+      [initiateRequestCancelExternalWorkflowEvent];
+    const initiatedGroup =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(initiateEvents);
+    expect(initiatedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'WAITING',
+    ]);
+
+    // requested
+    const requestEvents: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+      [
+        initiateRequestCancelExternalWorkflowEvent,
+        requestCancelExternalWorkflowEvent,
+      ];
+    const requestedGroup =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(requestEvents);
+    expect(requestedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: RequestCancelExternalWorkflowExecutionHistoryEvent[] = [
+      initiateRequestCancelExternalWorkflowEvent,
+      requestCancelExternalWorkflowEvent,
+    ];
+    const group =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Initiated at 07 Sep, 22:51:10 GMT+0',
+      'Requested at 07 Sep, 22:52:50 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -1,0 +1,109 @@
+import {
+  initiateSignalExternalWorkflowEvent,
+  signalExternalWorkflowEvent,
+  failSignalExternalWorkflowEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-singal-external-workflow-events';
+
+import type { SignalExternalWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
+import getSignalExternalWorkflowExecutionGroupFromEvents from '../get-signal-external-workflow-execution-group-from-events';
+
+describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
+  it('should return a group with a correct label', () => {
+    const events: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+    ];
+
+    const expectedLabel = `External Workflow Signal: ${initiateSignalExternalWorkflowEvent.signalExternalWorkflowExecutionInitiatedEventAttributes?.signalName}`;
+
+    const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+
+    expect(group.label).toBe(expectedLabel);
+  });
+
+  it('should return a group with hasMissingEvents set to true when initiate event is missing', () => {
+    const signalEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      signalExternalWorkflowEvent,
+    ];
+    const signalGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(signalEvents);
+    expect(signalGroup.hasMissingEvents).toBe(true);
+
+    const failEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      failSignalExternalWorkflowEvent,
+    ];
+    const failedGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(failEvents);
+    expect(failedGroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to SignalExternalWorkflowExecution', () => {
+    const events: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+    ];
+    const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.groupType).toBe('SignalExternalWorkflowExecution');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+      failSignalExternalWorkflowEvent,
+    ];
+    const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Initiated',
+      'Signaled',
+      'Failed',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // initiated
+    const startEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+    ];
+    const startedGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(startEvents);
+    expect(startedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'WAITING',
+    ]);
+
+    // signaled
+    const signaledEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+    ];
+    const signaledGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(signaledEvents);
+    expect(signaledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+
+    // faled
+    const failedEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      failSignalExternalWorkflowEvent,
+    ];
+    const failedGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(failedEvents);
+    expect(failedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'FAILED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+    ];
+    const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Initiated at 08 Sep, 04:24:30 GMT+0',
+      'Signaled at 08 Sep, 04:26:10 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -1,0 +1,134 @@
+import {
+  startWorkflowExecutionEvent,
+  signalWorkflowExecutionEvent,
+  recordMarkerExecutionEvent,
+  failWorkflowExecutionEvent,
+  terminateWorkflowExecutionEvent,
+  timeoutWorkflowExecutionEvent,
+  completeWorkflowExecutionEvent,
+  cancelRequestActivityTaskEvent,
+  failCancelTimerEvent,
+  failCancelRequestActivityTaskEvent,
+  continueAsNewWorkflowExecutionEvent,
+  requestCancelWorkflowExecutionEvent,
+  upsertWorkflowSearchAttributesEvent,
+  cancelWorkflowExecutionEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-single-events';
+
+import type {
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  SingleEventHistoryGroup,
+  SingleHistoryEvent,
+} from '../../../workflow-history.types';
+import getSingleEventGroupFromEvents from '../get-single-event-group-from-events';
+
+describe('getSingleEventGroupFromEvents', () => {
+  const events: SingleHistoryEvent[] = [
+    startWorkflowExecutionEvent,
+    signalWorkflowExecutionEvent,
+    recordMarkerExecutionEvent,
+    failWorkflowExecutionEvent,
+    terminateWorkflowExecutionEvent,
+    timeoutWorkflowExecutionEvent,
+    completeWorkflowExecutionEvent,
+    cancelRequestActivityTaskEvent,
+    failCancelTimerEvent,
+    failCancelRequestActivityTaskEvent,
+    continueAsNewWorkflowExecutionEvent,
+    requestCancelWorkflowExecutionEvent,
+    upsertWorkflowSearchAttributesEvent,
+    cancelWorkflowExecutionEvent,
+  ];
+  it('should return a group with a proper label when scheduled event exists', () => {
+    const expectedLabels: Record<SingleHistoryEvent['attributes'], string> = {
+      activityTaskCancelRequestedEventAttributes: `Activity ${cancelRequestActivityTaskEvent.activityTaskCancelRequestedEventAttributes?.activityId}: Cancel Request`,
+      requestCancelActivityTaskFailedEventAttributes: `Activity ${failCancelRequestActivityTaskEvent.requestCancelActivityTaskFailedEventAttributes?.activityId}: Cancel Request Failed`,
+      cancelTimerFailedEventAttributes: `Timer ${failCancelTimerEvent.cancelTimerFailedEventAttributes?.timerId}: Cancellation Failed`,
+      markerRecordedEventAttributes: 'Version Marker',
+      upsertWorkflowSearchAttributesEventAttributes:
+        'Workflow Search Attributes',
+      workflowExecutionStartedEventAttributes: 'Workflow Started',
+      workflowExecutionCompletedEventAttributes: 'Workflow Completed',
+      workflowExecutionFailedEventAttributes: 'Workflow Failed',
+      workflowExecutionTimedOutEventAttributes: 'Workflow Timed out',
+      workflowExecutionSignaledEventAttributes: 'Workflow Signaled',
+      workflowExecutionTerminatedEventAttributes: 'Workflow Terminated',
+      workflowExecutionCancelRequestedEventAttributes:
+        'Workflow Cancel Request',
+      workflowExecutionCanceledEventAttributes: 'Workflow Canceled',
+      workflowExecutionContinuedAsNewEventAttributes:
+        'Workflow Continued As New',
+    };
+    for (const event of events) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.label).toBe(expectedLabels[event.attributes]);
+    }
+  });
+
+  it('should return a group with hasMissingEvents set to false for all event groups', () => {
+    for (const event of events) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.hasMissingEvents).toBe(false);
+    }
+  });
+
+  it('should return a group with groupType equal to Event', () => {
+    for (const event of events) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.groupType).toBe('Event');
+    }
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const eventToLabel: HistoryGroupEventToStringMap<SingleEventHistoryGroup> =
+      {
+        activityTaskCancelRequestedEventAttributes: 'Requested',
+        requestCancelActivityTaskFailedEventAttributes: 'Failed',
+        cancelTimerFailedEventAttributes: 'Failed',
+        markerRecordedEventAttributes: 'Recorded',
+        upsertWorkflowSearchAttributesEventAttributes: 'Upserted',
+        workflowExecutionStartedEventAttributes: 'Started',
+        workflowExecutionCompletedEventAttributes: 'Completed',
+        workflowExecutionFailedEventAttributes: 'Failed',
+        workflowExecutionTimedOutEventAttributes: 'Timed out',
+        workflowExecutionSignaledEventAttributes: 'Signaled',
+        workflowExecutionTerminatedEventAttributes: 'Terminated',
+        workflowExecutionCancelRequestedEventAttributes: 'Requested',
+        workflowExecutionCanceledEventAttributes: 'Canceled',
+        workflowExecutionContinuedAsNewEventAttributes: 'Continued as new',
+      };
+    for (const event of events) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.eventsMetadata[0].label).toBe(
+        eventToLabel[event.attributes]
+      );
+    }
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    const eventToStatus: HistoryGroupEventToStatusMap<SingleEventHistoryGroup> =
+      {
+        activityTaskCancelRequestedEventAttributes: 'COMPLETED',
+        requestCancelActivityTaskFailedEventAttributes: 'FAILED',
+        cancelTimerFailedEventAttributes: 'FAILED',
+        markerRecordedEventAttributes: 'COMPLETED',
+        upsertWorkflowSearchAttributesEventAttributes: 'COMPLETED',
+        workflowExecutionStartedEventAttributes: 'COMPLETED',
+        workflowExecutionCompletedEventAttributes: 'COMPLETED',
+        workflowExecutionFailedEventAttributes: 'FAILED',
+        workflowExecutionTimedOutEventAttributes: 'FAILED',
+        workflowExecutionSignaledEventAttributes: 'COMPLETED',
+        workflowExecutionTerminatedEventAttributes: 'FAILED',
+        workflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
+        workflowExecutionCanceledEventAttributes: 'CANCELED',
+        workflowExecutionContinuedAsNewEventAttributes: 'COMPLETED',
+      };
+    for (const event of events) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.eventsMetadata[0].status).toBe(
+        eventToStatus[event.attributes]
+      );
+    }
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -1,0 +1,96 @@
+import {
+  cancelTimerTaskEvent,
+  startTimerTaskEvent,
+  fireTimerTaskEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-timer-events';
+
+import type { TimerHistoryEvent } from '../../../workflow-history.types';
+import getTimerGroupFromEvents from '../get-timer-group-from-events';
+
+describe('getTimerGroupFromEvents', () => {
+  it('should return a group with a correct label', () => {
+    const events: TimerHistoryEvent[] = [startTimerTaskEvent];
+
+    const expectedLabel = `Timer ${startTimerTaskEvent.timerStartedEventAttributes?.timerId}`;
+
+    const group = getTimerGroupFromEvents(events);
+
+    expect(group.label).toBe(expectedLabel);
+  });
+
+  it('should return a group with hasMissingEvents set to true when start event is missing', () => {
+    const fireEvents: TimerHistoryEvent[] = [fireTimerTaskEvent];
+    const firedTimerGroup = getTimerGroupFromEvents(fireEvents);
+    expect(firedTimerGroup.hasMissingEvents).toBe(true);
+
+    const cancelEvents: TimerHistoryEvent[] = [cancelTimerTaskEvent];
+    const canceledTimerGroup = getTimerGroupFromEvents(cancelEvents);
+    expect(canceledTimerGroup.hasMissingEvents).toBe(true);
+  });
+
+  it('should return a group with groupType equal to Timer', () => {
+    const events: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+    ];
+    const group = getTimerGroupFromEvents(events);
+    expect(group.groupType).toBe('Timer');
+  });
+
+  it('should return group eventsMetadata with correct labels', () => {
+    const events: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+      cancelTimerTaskEvent,
+    ];
+    const group = getTimerGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ label }) => label)).toEqual([
+      'Started',
+      'Fired',
+      'Canceled',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct status', () => {
+    // started
+    const startEvents: TimerHistoryEvent[] = [startTimerTaskEvent];
+    const startedGroup = getTimerGroupFromEvents(startEvents);
+    expect(startedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'ONGOING',
+    ]);
+
+    // Fired
+    const firedEvents: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+    ];
+    const firedGroup = getTimerGroupFromEvents(firedEvents);
+    expect(firedGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'COMPLETED',
+    ]);
+
+    // Canceled
+    const canceledEvents: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      cancelTimerTaskEvent,
+    ];
+    const canceledGroup = getTimerGroupFromEvents(canceledEvents);
+    expect(canceledGroup.eventsMetadata.map(({ status }) => status)).toEqual([
+      'COMPLETED',
+      'CANCELED',
+    ]);
+  });
+
+  it('should return group eventsMetadata with correct timeLabel', () => {
+    const events: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+    ];
+    const group = getTimerGroupFromEvents(events);
+    expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
+      'Started at 07 Sep, 22:32:50 GMT+0',
+      'Fired at 07 Sep, 22:34:30 GMT+0',
+    ]);
+  });
+});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -1,0 +1,61 @@
+import type {
+  ActivityHistoryEvent,
+  ActivityHistoryGroup,
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getActivityGroupFromEvents(
+  events: ActivityHistoryEvent[]
+): ActivityHistoryGroup {
+  let label = '';
+  let hasMissingEvents = false;
+  const groupType = 'Activity';
+
+  const scheduleAttr = 'activityTaskScheduledEventAttributes';
+  const scheduleEvent = events.find(
+    ({ attributes }) => attributes === scheduleAttr
+  );
+  const firstEvent = events[0];
+
+  if (scheduleEvent) {
+    label = `Activity ${scheduleEvent[scheduleAttr]?.activityId}: ${scheduleEvent[scheduleAttr]?.activityType?.name}`;
+  }
+
+  if (firstEvent.attributes !== 'activityTaskScheduledEventAttributes') {
+    hasMissingEvents = true;
+  }
+
+  const eventToLabel: HistoryGroupEventToStringMap<ActivityHistoryGroup> = {
+    activityTaskScheduledEventAttributes: 'Scheduled',
+    activityTaskStartedEventAttributes: 'Started',
+    activityTaskCompletedEventAttributes: 'Completed',
+    activityTaskFailedEventAttributes: 'Failed',
+    activityTaskCanceledEventAttributes: 'Canceled',
+    activityTaskTimedOutEventAttributes: 'Timed out',
+  };
+
+  const eventToStatus: HistoryGroupEventToStatusMap<ActivityHistoryGroup> = {
+    activityTaskScheduledEventAttributes: (_, events, index) =>
+      index < events.length - 1 ? 'COMPLETED' : 'WAITING',
+    activityTaskStartedEventAttributes: (_, events, index) =>
+      index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
+    activityTaskCompletedEventAttributes: 'COMPLETED',
+    activityTaskFailedEventAttributes: 'FAILED',
+    activityTaskCanceledEventAttributes: 'CANCELED',
+    activityTaskTimedOutEventAttributes: 'FAILED',
+  };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<ActivityHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -1,0 +1,67 @@
+import type {
+  ChildWorkflowExecutionHistoryEvent,
+  ChildWorkflowExecutionHistoryGroup,
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getChildWorkflowExecutionGroupFromEvents(
+  events: ChildWorkflowExecutionHistoryEvent[]
+): ChildWorkflowExecutionHistoryGroup {
+  const firstEvent = events[0];
+  const childWorkflowName =
+    firstEvent[firstEvent.attributes]?.workflowType?.name;
+
+  const label = childWorkflowName
+    ? `Child Workflow: ${childWorkflowName}`
+    : 'Child Workflow';
+  let hasMissingEvents = false;
+  const groupType = 'ChildWorkflowExecution';
+
+  if (
+    firstEvent.attributes !==
+    'startChildWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    hasMissingEvents = true;
+  }
+  const eventToLabel: HistoryGroupEventToStringMap<ChildWorkflowExecutionHistoryGroup> =
+    {
+      startChildWorkflowExecutionInitiatedEventAttributes: 'Initiated',
+      startChildWorkflowExecutionFailedEventAttributes: 'Initiation failed',
+      childWorkflowExecutionStartedEventAttributes: 'Started',
+      childWorkflowExecutionCompletedEventAttributes: 'Completed',
+      childWorkflowExecutionFailedEventAttributes: 'Failed',
+      childWorkflowExecutionCanceledEventAttributes: 'Canceled',
+      childWorkflowExecutionTimedOutEventAttributes: 'Timed out',
+      childWorkflowExecutionTerminatedEventAttributes: 'Terminated',
+    };
+  const eventToStatus: HistoryGroupEventToStatusMap<ChildWorkflowExecutionHistoryGroup> =
+    {
+      startChildWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      startChildWorkflowExecutionFailedEventAttributes: 'FAILED',
+      childWorkflowExecutionStartedEventAttributes: (_, events, index) =>
+        index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
+      childWorkflowExecutionCompletedEventAttributes: 'COMPLETED',
+      childWorkflowExecutionFailedEventAttributes: 'FAILED',
+      childWorkflowExecutionCanceledEventAttributes: 'CANCELED',
+      childWorkflowExecutionTimedOutEventAttributes: 'FAILED',
+      childWorkflowExecutionTerminatedEventAttributes: 'FAILED',
+    };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<ChildWorkflowExecutionHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -1,0 +1,49 @@
+import type {
+  DecisionHistoryEvent,
+  DecisionHistoryGroup,
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getDecisionGroupFromEvents(
+  events: DecisionHistoryEvent[]
+): DecisionHistoryGroup {
+  const label = 'Decision Task';
+  let hasMissingEvents = false;
+  const groupType = 'Decision';
+
+  const firstEvent = events[0];
+
+  if (firstEvent.attributes !== 'decisionTaskScheduledEventAttributes') {
+    hasMissingEvents = true;
+  }
+  const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {
+    decisionTaskScheduledEventAttributes: 'Scheduled',
+    decisionTaskStartedEventAttributes: 'Started',
+    decisionTaskCompletedEventAttributes: 'Completed',
+    decisionTaskFailedEventAttributes: 'Failed',
+    decisionTaskTimedOutEventAttributes: 'Timed out',
+  };
+  const eventToStatus: HistoryGroupEventToStatusMap<DecisionHistoryGroup> = {
+    decisionTaskScheduledEventAttributes: (_, events, index) =>
+      index < events.length - 1 ? 'COMPLETED' : 'WAITING',
+    decisionTaskStartedEventAttributes: (_, events, index) =>
+      index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
+    decisionTaskCompletedEventAttributes: 'COMPLETED',
+    decisionTaskFailedEventAttributes: 'FAILED',
+    decisionTaskTimedOutEventAttributes: 'FAILED',
+  };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<DecisionHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
@@ -1,0 +1,55 @@
+import type {
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  RequestCancelExternalWorkflowExecutionHistoryEvent,
+  RequestCancelExternalWorkflowExecutionHistoryGroup,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getRequestCancelExternalWorkflowExecutionGroupFromEvents(
+  events: RequestCancelExternalWorkflowExecutionHistoryEvent[]
+): RequestCancelExternalWorkflowExecutionHistoryGroup {
+  const label = 'Request Cancel External Workflow';
+  let hasMissingEvents = false;
+  const groupType = 'RequestCancelExternalWorkflowExecution';
+
+  const firstEvent = events[0];
+
+  if (
+    firstEvent.attributes !==
+    'requestCancelExternalWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    hasMissingEvents = true;
+  }
+
+  const eventToLabel: HistoryGroupEventToStringMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
+    {
+      requestCancelExternalWorkflowExecutionInitiatedEventAttributes:
+        'Initiated',
+      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+      externalWorkflowExecutionCancelRequestedEventAttributes: 'Requested',
+    };
+
+  const eventToStatus: HistoryGroupEventToStatusMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
+    {
+      requestCancelExternalWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+      externalWorkflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
+    };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<RequestCancelExternalWorkflowExecutionHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
@@ -1,0 +1,61 @@
+import type {
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  SignalExternalWorkflowExecutionHistoryEvent,
+  SignalExternalWorkflowExecutionHistoryGroup,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getSignalExternalWorkflowExecutionGroupFromEvents(
+  events: SignalExternalWorkflowExecutionHistoryEvent[]
+): SignalExternalWorkflowExecutionHistoryGroup {
+  let label = '';
+  let hasMissingEvents = false;
+  const groupType = 'SignalExternalWorkflowExecution';
+
+  const initiationEventAttr =
+    'signalExternalWorkflowExecutionInitiatedEventAttributes';
+  const initiationEvent = events.find(
+    ({ attributes }) => attributes === initiationEventAttr
+  );
+  const firstEvent = events[0];
+
+  if (initiationEvent) {
+    label = `External Workflow Signal: ${initiationEvent[initiationEventAttr]?.signalName}`;
+  }
+
+  if (
+    firstEvent.attributes !==
+    'signalExternalWorkflowExecutionInitiatedEventAttributes'
+  ) {
+    hasMissingEvents = true;
+  }
+  const eventToLabel: HistoryGroupEventToStringMap<SignalExternalWorkflowExecutionHistoryGroup> =
+    {
+      signalExternalWorkflowExecutionInitiatedEventAttributes: 'Initiated',
+      signalExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+      externalWorkflowExecutionSignaledEventAttributes: 'Signaled',
+    };
+  const eventToStatus: HistoryGroupEventToStatusMap<SignalExternalWorkflowExecutionHistoryGroup> =
+    {
+      signalExternalWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      signalExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+      externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
+    };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<SignalExternalWorkflowExecutionHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -1,0 +1,79 @@
+import type {
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  SingleEventHistoryGroup,
+  SingleHistoryEvent,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getSingleEventGroupFromEvents(
+  events: SingleHistoryEvent[]
+): SingleEventHistoryGroup {
+  const event = events[0];
+  const eventToGroupLabel: Record<SingleHistoryEvent['attributes'], string> = {
+    activityTaskCancelRequestedEventAttributes: `Activity ${event.activityTaskCancelRequestedEventAttributes?.activityId}: Cancel Request`,
+    requestCancelActivityTaskFailedEventAttributes: `Activity ${event.requestCancelActivityTaskFailedEventAttributes?.activityId}: Cancel Request Failed`,
+    cancelTimerFailedEventAttributes: `Timer ${event.cancelTimerFailedEventAttributes?.timerId}: Cancellation Failed`,
+    markerRecordedEventAttributes: 'Version Marker',
+    upsertWorkflowSearchAttributesEventAttributes: 'Workflow Search Attributes',
+    workflowExecutionStartedEventAttributes: 'Workflow Started',
+    workflowExecutionCompletedEventAttributes: 'Workflow Completed',
+    workflowExecutionFailedEventAttributes: 'Workflow Failed',
+    workflowExecutionTimedOutEventAttributes: 'Workflow Timed out',
+    workflowExecutionSignaledEventAttributes: 'Workflow Signaled',
+    workflowExecutionTerminatedEventAttributes: 'Workflow Terminated',
+    workflowExecutionCancelRequestedEventAttributes: 'Workflow Cancel Request',
+    workflowExecutionCanceledEventAttributes: 'Workflow Canceled',
+    workflowExecutionContinuedAsNewEventAttributes: 'Workflow Continued As New',
+  };
+
+  const label = eventToGroupLabel[event.attributes];
+  const groupType = 'Event';
+  const hasMissingEvents = false;
+
+  const eventToLabel: HistoryGroupEventToStringMap<SingleEventHistoryGroup> = {
+    activityTaskCancelRequestedEventAttributes: 'Requested',
+    requestCancelActivityTaskFailedEventAttributes: 'Failed',
+    cancelTimerFailedEventAttributes: 'Failed',
+    markerRecordedEventAttributes: 'Recorded',
+    upsertWorkflowSearchAttributesEventAttributes: 'Upserted',
+    workflowExecutionStartedEventAttributes: 'Started',
+    workflowExecutionCompletedEventAttributes: 'Completed',
+    workflowExecutionFailedEventAttributes: 'Failed',
+    workflowExecutionTimedOutEventAttributes: 'Timed out',
+    workflowExecutionSignaledEventAttributes: 'Signaled',
+    workflowExecutionTerminatedEventAttributes: 'Terminated',
+    workflowExecutionCancelRequestedEventAttributes: 'Requested',
+    workflowExecutionCanceledEventAttributes: 'Canceled',
+    workflowExecutionContinuedAsNewEventAttributes: 'Continued as new',
+  };
+
+  const eventToStatus: HistoryGroupEventToStatusMap<SingleEventHistoryGroup> = {
+    activityTaskCancelRequestedEventAttributes: 'COMPLETED',
+    requestCancelActivityTaskFailedEventAttributes: 'FAILED',
+    cancelTimerFailedEventAttributes: 'FAILED',
+    markerRecordedEventAttributes: 'COMPLETED',
+    upsertWorkflowSearchAttributesEventAttributes: 'COMPLETED',
+    workflowExecutionStartedEventAttributes: 'COMPLETED',
+    workflowExecutionCompletedEventAttributes: 'COMPLETED',
+    workflowExecutionFailedEventAttributes: 'FAILED',
+    workflowExecutionTimedOutEventAttributes: 'FAILED',
+    workflowExecutionSignaledEventAttributes: 'COMPLETED',
+    workflowExecutionTerminatedEventAttributes: 'FAILED',
+    workflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
+    workflowExecutionCanceledEventAttributes: 'CANCELED',
+    workflowExecutionContinuedAsNewEventAttributes: 'COMPLETED',
+  };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<SingleEventHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -1,0 +1,44 @@
+import type {
+  HistoryGroupEventToStatusMap,
+  HistoryGroupEventToStringMap,
+  TimerHistoryEvent,
+  TimerHistoryGroup,
+} from '../../workflow-history.types';
+import getCommonHistoryGroupFields from '../get-common-history-group-fields';
+
+export default function getTimerGroupFromEvents(
+  events: TimerHistoryEvent[]
+): TimerHistoryGroup {
+  const firstEvent = events[0];
+
+  const label = `Timer ${firstEvent[firstEvent.attributes]?.timerId}`; // TODO add duration
+  let hasMissingEvents = false;
+  const groupType = 'Timer';
+
+  if (firstEvent.attributes !== 'timerStartedEventAttributes') {
+    hasMissingEvents = true;
+  }
+  const eventToLabel: HistoryGroupEventToStringMap<TimerHistoryGroup> = {
+    timerStartedEventAttributes: 'Started',
+    timerFiredEventAttributes: 'Fired',
+    timerCanceledEventAttributes: 'Canceled',
+  };
+  const eventToStatus: HistoryGroupEventToStatusMap<TimerHistoryGroup> = {
+    timerStartedEventAttributes: (_, events, index) =>
+      index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
+    timerFiredEventAttributes: 'COMPLETED',
+    timerCanceledEventAttributes: 'CANCELED',
+  };
+
+  return {
+    label,
+    hasMissingEvents,
+    groupType,
+    ...getCommonHistoryGroupFields<TimerHistoryGroup>(
+      events,
+      eventToStatus,
+      eventToLabel,
+      {}
+    ),
+  };
+}

--- a/src/views/workflow-history/helpers/group-history-events.ts
+++ b/src/views/workflow-history/helpers/group-history-events.ts
@@ -1,0 +1,95 @@
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import logger from '@/utils/logger';
+
+import type {
+  HistoryEventsGroup,
+  HistoryEventsGroups,
+} from '../workflow-history.types';
+
+import isActivityEvent from './check-history-event-group/is-activity-event';
+import isChildWorkflowExecutionEvent from './check-history-event-group/is-child-workflow-execution-event';
+import isDecisionEvent from './check-history-event-group/is-decision-event';
+import isRequestCancelExternalWorkflowExecutionEvent from './check-history-event-group/is-request-cancel-external-workflow-execution-event';
+import isSignalExternalWorkflowExecutionEvent from './check-history-event-group/is-signal-external-workflow-execution-event';
+import isSingleEvent from './check-history-event-group/is-single-event';
+import isTimerEvent from './check-history-event-group/is-timer-event';
+import getHistoryEventGroupId from './get-history-event-group-id';
+import getActivityGroupFromEvents from './get-history-group-from-events/get-activity-group-from-events';
+import getChildWorkflowExecutionGroupFromEvents from './get-history-group-from-events/get-child-workflow-execution-group-from-events';
+import getDecisionGroupFromEvents from './get-history-group-from-events/get-decision-group-from-events';
+import getRequestCancelExternalWorkflowExecutionGroupFromEvents from './get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events';
+import getSignalExternalWorkflowExecutionGroupFromEvents from './get-history-group-from-events/get-signal-external-workflow-execution-group-from-events';
+import getSingleEventGroupFromEvents from './get-history-group-from-events/get-single-event-group-from-events';
+import getTimerGroupFromEvents from './get-history-group-from-events/get-timer-group-from-events';
+import placeEventInGroupEvents from './place-event-in-group-events';
+
+export function groupHistoryEvents(
+  events: HistoryEvent[],
+  initialGroups: HistoryEventsGroups = {}
+) {
+  const groupByFirstEventId: HistoryEventsGroups = initialGroups;
+  events.forEach((event) => {
+    const groupId = getHistoryEventGroupId(event);
+    if (!groupId) {
+      logger.warn(
+        {
+          eventId: event.eventId,
+          eventTime: event.eventTime,
+        },
+        "Couldn't extract groupId from event, check event payload and extraction logic"
+      );
+    } else {
+      const defaultGroupDetails: Partial<HistoryEventsGroup> = {
+        events: [],
+        hasMissingEvents: false,
+        label: '',
+      };
+      const currentGroup = groupByFirstEventId[groupId] || defaultGroupDetails;
+      const updatedEventsArr = placeEventInGroupEvents(
+        event,
+        currentGroup.events
+      );
+      if (updatedEventsArr.every(isActivityEvent)) {
+        groupByFirstEventId[groupId] =
+          getActivityGroupFromEvents(updatedEventsArr);
+      } else if (updatedEventsArr.every(isDecisionEvent)) {
+        groupByFirstEventId[groupId] =
+          getDecisionGroupFromEvents(updatedEventsArr);
+      } else if (updatedEventsArr.every(isTimerEvent)) {
+        groupByFirstEventId[groupId] =
+          getTimerGroupFromEvents(updatedEventsArr);
+      } else if (updatedEventsArr.every(isChildWorkflowExecutionEvent)) {
+        groupByFirstEventId[groupId] =
+          getChildWorkflowExecutionGroupFromEvents(updatedEventsArr);
+      } else if (
+        updatedEventsArr.every(isSignalExternalWorkflowExecutionEvent)
+      ) {
+        groupByFirstEventId[groupId] =
+          getSignalExternalWorkflowExecutionGroupFromEvents(updatedEventsArr);
+      } else if (
+        updatedEventsArr.every(isRequestCancelExternalWorkflowExecutionEvent)
+      ) {
+        groupByFirstEventId[groupId] =
+          getRequestCancelExternalWorkflowExecutionGroupFromEvents(
+            updatedEventsArr
+          );
+      } else if (updatedEventsArr.every(isSingleEvent)) {
+        groupByFirstEventId[groupId] =
+          getSingleEventGroupFromEvents(updatedEventsArr);
+      } else {
+        logger.warn(
+          {
+            eventId: event.eventId,
+            eventTime: event.eventTime,
+            events: updatedEventsArr.map(({ eventId, eventTime }) => ({
+              eventId,
+              eventTime,
+            })),
+          },
+          'No handler for grouping this event'
+        );
+      }
+    }
+  });
+  return groupByFirstEventId;
+}

--- a/src/views/workflow-history/helpers/place-event-in-group-events.ts
+++ b/src/views/workflow-history/helpers/place-event-in-group-events.ts
@@ -1,0 +1,18 @@
+import sortedIndexBy from 'lodash/sortedIndexBy';
+
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+export default function placeEventInGroupEvents(
+  event: HistoryEvent,
+  events: HistoryEvent[]
+) {
+  const sortedEvents = [...events];
+  sortedEvents.splice(
+    sortedIndexBy(sortedEvents, event, (e) =>
+      e?.eventId ? parseInt(e?.eventId) : 0
+    ),
+    0,
+    event
+  );
+  return sortedEvents;
+}


### PR DESCRIPTION
### Summary
- Create `groupHistoryEvents` utility to group history events
- The utility accepts history events and return an object with `groupId` as a key and a group object which includes metadata extracted from the group events
- There are helper utilities created to be used within `groupHistoryEvents`, each responsible of handling specific group type 