### PR TITLE
Add QueryWorkflow Route Handler

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
@@ -1,0 +1,11 @@
+import { type NextRequest } from 'next/server';
+
+import { queryWorkflow } from '@/route-handlers/query-workflow/query-workflow';
+import { type RouteParams } from '@/route-handlers/query-workflow/query-workflow.types';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: RouteParams }
+) {
+  return queryWorkflow(request, { params });
+}

--- a/src/route-handlers/query-workflow/query-workflow.ts
+++ b/src/route-handlers/query-workflow/query-workflow.ts
@@ -9,13 +9,14 @@ import {
   type QueryWorkflowResponse,
   type RequestParams,
 } from './query-workflow.types';
-import { queryWorkflowResultDataSchema } from './schemas/query-workflow-result-data-schema';
 
 export async function queryWorkflow(
   request: NextRequest,
   requestParams: RequestParams
 ) {
-  const requestBody = await request.json();
+  logger.info({ request }, 'test0');
+  const requestBody = await request.text();
+  logger.info({ requestBody }, 'test1');
 
   const decodedParams = decodeUrlParams(requestParams.params);
 
@@ -31,14 +32,18 @@ export async function queryWorkflow(
       query: {
         queryType: decodedParams.queryName,
         queryArgs: {
-          data: requestBody,
+          data: Buffer.from(requestBody),
         },
       },
     });
 
+    logger.info({ res }, 'test2');
+
     return Response.json({
       result: res.queryResult
-        ? queryWorkflowResultDataSchema.parse(res.queryResult.data)
+        ? JSON.parse(
+            Buffer.from(res.queryResult.data, 'base64').toString('utf-8')
+          )
         : null,
       rejected: res.queryRejected,
     } satisfies QueryWorkflowResponse);

--- a/src/route-handlers/query-workflow/query-workflow.ts
+++ b/src/route-handlers/query-workflow/query-workflow.ts
@@ -1,0 +1,62 @@
+// make this a post endpoint
+
+import { type NextRequest, NextResponse } from 'next/server';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import * as grpcClient from '@/utils/grpc/grpc-client';
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+import { RequestParams } from './query-workflow.types';
+
+export async function queryWorkflow(
+  request: NextRequest,
+  requestParams: RequestParams
+) {
+  const requestBody = await request.json();
+
+  const decodedParams = decodeUrlParams(requestParams.params);
+
+  try {
+    const res = await grpcClient.clusterMethods[
+      decodedParams.cluster
+    ].queryWorkflow({
+      domain: decodedParams.domain,
+      workflowExecution: {
+        workflowId: decodedParams.workflowId,
+        runId: decodedParams.runId,
+      },
+      query: {
+        queryType: '__query_types',
+      },
+    });
+
+    return Response.json({
+      queryTypes: queryTypesDataSchema.parse(res.queryResult?.data),
+    });
+  } catch (e) {
+    // This is a workaround to parse the error message for valid query types if the client
+    // does not have a query handler for __query_types (as is the case with the Java client)
+    if (e instanceof GRPCError) {
+      const parsedQueryTypes = parseErrorMessageForQueryTypes(e.message);
+      if (parsedQueryTypes) {
+        return Response.json({ queryTypes: parsedQueryTypes });
+      }
+    }
+
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, cause: e },
+      'Error querying workflow for query types'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError
+            ? e.message
+            : 'Error querying workflow for query types',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/query-workflow/query-workflow.types.ts
+++ b/src/route-handlers/query-workflow/query-workflow.types.ts
@@ -5,6 +5,7 @@ export type RouteParams = {
   cluster: string;
   workflowId: string;
   runId: string;
+  queryName: string;
 };
 
 export type RequestParams = {
@@ -12,6 +13,6 @@ export type RequestParams = {
 };
 
 export type QueryWorkflowResponse = {
-  result: object;
-  rejected: QueryRejected;
+  result: object | null;
+  rejected: QueryRejected | null;
 };

--- a/src/route-handlers/query-workflow/query-workflow.types.ts
+++ b/src/route-handlers/query-workflow/query-workflow.types.ts
@@ -13,6 +13,6 @@ export type RequestParams = {
 };
 
 export type QueryWorkflowResponse = {
-  result: object | null;
+  result: any;
   rejected: QueryRejected | null;
 };

--- a/src/route-handlers/query-workflow/query-workflow.types.ts
+++ b/src/route-handlers/query-workflow/query-workflow.types.ts
@@ -1,0 +1,17 @@
+import { type QueryRejected } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryRejected';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type QueryWorkflowResponse = {
+  result: object;
+  rejected: QueryRejected;
+};

--- a/src/route-handlers/query-workflow/schemas/query-workflow-result-data-schema.ts
+++ b/src/route-handlers/query-workflow/schemas/query-workflow-result-data-schema.ts
@@ -1,8 +1,0 @@
-import { z } from 'zod';
-
-export const queryWorkflowResultDataSchema = z
-  .string()
-  .transform((d): object => {
-    const parsedJSON = JSON.parse(Buffer.from(d, 'base64').toString('utf-8'));
-    return z.object({}).passthrough().parse(parsedJSON);
-  });

--- a/src/route-handlers/query-workflow/schemas/query-workflow-result-data-schema.ts
+++ b/src/route-handlers/query-workflow/schemas/query-workflow-result-data-schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const queryWorkflowResultDataSchema = z
+  .string()
+  .transform((d): object => {
+    const parsedJSON = JSON.parse(Buffer.from(d, 'base64').toString('utf-8'));
+    return z.object({}).passthrough().parse(parsedJSON);
+  });

--- a/src/route-handlers/query-workflow/schemas/valid-query-input-schema.ts
+++ b/src/route-handlers/query-workflow/schemas/valid-query-input-schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+const validQueryInputSchema = z.string().superRefine((str, ctx) => {
+  if (str === '') return true;
+
+  try {
+    return JSON.parse(str);
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid JSON' });
+    return z.NEVER;
+  }
+});
+
+export default validQueryInputSchema;

--- a/src/views/workflow-queries/helpers/__tests__/get-workflow-query-status.test.ts
+++ b/src/views/workflow-queries/helpers/__tests__/get-workflow-query-status.test.ts
@@ -1,0 +1,49 @@
+import { type QueryStatus } from '@tanstack/react-query';
+
+import { type WorkflowQueryStatus } from '../../workflow-queries-tile/workflow-queries-tile.types';
+import getWorkflowQueryStatus from '../get-workflow-query-status';
+
+describe(getWorkflowQueryStatus.name, () => {
+  const tests: Array<{
+    name: string;
+    status: QueryStatus;
+    isFetching: boolean;
+    expected: WorkflowQueryStatus;
+  }> = [
+    {
+      name: 'returns fetching if isFetching is true',
+      status: 'pending',
+      isFetching: true,
+      expected: 'fetching',
+    },
+    {
+      name: 'returns success if query status is success',
+      status: 'success',
+      isFetching: false,
+      expected: 'success',
+    },
+    {
+      name: 'returns error if query status is error',
+      status: 'error',
+      isFetching: false,
+      expected: 'error',
+    },
+    {
+      name: 'returns pending if query status is pending',
+      status: 'pending',
+      isFetching: false,
+      expected: 'pending',
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(test.name, () => {
+      expect(
+        getWorkflowQueryStatus({
+          queryStatus: test.status,
+          isFetching: test.isFetching,
+        })
+      ).toEqual(test.expected);
+    });
+  });
+});

--- a/src/views/workflow-queries/helpers/get-workflow-query-status.ts
+++ b/src/views/workflow-queries/helpers/get-workflow-query-status.ts
@@ -1,0 +1,24 @@
+import { type QueryStatus } from '@tanstack/react-query';
+
+import { type WorkflowQueryStatus } from '../workflow-queries-tile/workflow-queries-tile.types';
+
+export default function getWorkflowQueryStatus({
+  queryStatus,
+  isFetching,
+}: {
+  queryStatus: QueryStatus;
+  isFetching: boolean;
+}): WorkflowQueryStatus {
+  if (isFetching) {
+    return 'fetching';
+  }
+
+  switch (queryStatus) {
+    case 'error':
+      return 'error';
+    case 'success':
+      return 'success';
+    case 'pending':
+      return 'pending';
+  }
+}

--- a/src/views/workflow-queries/workflow-queries-loader/__tests__/workflow-queries-loader.test.tsx
+++ b/src/views/workflow-queries/workflow-queries-loader/__tests__/workflow-queries-loader.test.tsx
@@ -6,6 +6,7 @@ import { HttpResponse } from 'msw';
 import { render, screen, act } from '@/test-utils/rtl';
 
 import { type FetchWorkflowQueryTypesResponse } from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types';
+import { type QueryWorkflowResponse } from '@/route-handlers/query-workflow/query-workflow.types';
 
 import WorkflowQueriesLoader from '../workflow-queries-loader';
 
@@ -44,9 +45,8 @@ describe(WorkflowQueriesLoader.name, () => {
 
     await user.click(queryRunButtons[1]);
 
-    expect(
-      await screen.findByText(/{"name":"__open_sessions"}/)
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/"test_1"/)).toBeInTheDocument();
+    expect(await screen.findByText(/"test_2"/)).toBeInTheDocument();
   });
 
   it('does not render if the initial call fails', async () => {
@@ -96,6 +96,14 @@ async function setup({ error }: { error?: boolean }) {
                   queryTypes: ['__query_types', '__open_sessions'],
                 } satisfies FetchWorkflowQueryTypesResponse,
               }),
+        },
+        {
+          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/query/:queryName',
+          httpMethod: 'POST',
+          jsonResponse: {
+            result: ['test_1', 'test_2'],
+            rejected: null,
+          } satisfies QueryWorkflowResponse,
         },
       ],
     }

--- a/src/views/workflow-queries/workflow-queries-loader/hooks/use-workflow-queries.ts
+++ b/src/views/workflow-queries/workflow-queries-loader/hooks/use-workflow-queries.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { useQueries, type UseQueryOptions } from '@tanstack/react-query';
+
+import { type QueryWorkflowResponse } from '@/route-handlers/query-workflow/query-workflow.types';
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+export default function useWorkflowQueries({
+  domain,
+  cluster,
+  workflowId,
+  runId,
+  queryTypes,
+}: {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+  queryTypes: Array<string>;
+}) {
+  const [inputs, setInputs] = useState<Record<string, string | undefined>>({});
+
+  const queries = useQueries({
+    queries: queryTypes.map<
+      UseQueryOptions<
+        QueryWorkflowResponse,
+        RequestError,
+        QueryWorkflowResponse,
+        [
+          { workflowId: string; runId: string; name: string },
+          string | undefined,
+        ]
+      >
+    >((name) => ({
+      queryKey: [{ workflowId, runId, name }, inputs[name]] as const,
+      queryFn: ({ queryKey: [{ name }, input] }) =>
+        request(
+          `/api/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}/query/${name}`,
+          {
+            method: 'POST',
+            ...(input && { body: input }),
+          }
+        ).then((res) => res.json()),
+      enabled: false,
+    })),
+  });
+
+  return { queries, inputs, setInputs };
+}

--- a/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.tsx
+++ b/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.tsx
@@ -7,6 +7,7 @@ import { type FetchWorkflowQueryTypesResponse } from '@/route-handlers/fetch-wor
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
 
+import getWorkflowQueryStatus from '../helpers/get-workflow-query-status';
 import WorkflowQueriesResultJson from '../workflow-queries-result-json/workflow-queries-result-json';
 import WorkflowQueriesTile from '../workflow-queries-tile/workflow-queries-tile';
 
@@ -54,9 +55,10 @@ export default function WorkflowQueriesLoader(props: Props) {
             isSelected={index === selectedQueryIndex}
             onClick={() => setSelectedQueryIndex(index)}
             runQuery={queries[index].refetch}
-            queryStatus={
-              queries[index].isFetching ? 'fetching' : queries[index].status
-            }
+            queryStatus={getWorkflowQueryStatus({
+              queryStatus: queries[index].status,
+              isFetching: queries[index].isFetching,
+            })}
           />
         ))}
       </styled.QueriesSidebar>

--- a/src/views/workflow-queries/workflow-queries-result-json/__tests__/workflow-queries-result-json.test.tsx
+++ b/src/views/workflow-queries/workflow-queries-result-json/__tests__/workflow-queries-result-json.test.tsx
@@ -33,12 +33,6 @@ describe(WorkflowQueriesResultJson.name, () => {
     expect(screen.getByText(/dataJson/)).toBeInTheDocument();
   });
 
-  it('renders loading state correctly', () => {
-    setup({ data: undefined, loading: true });
-
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
-  });
-
   it('copies JSON to clipboard', () => {
     const testData = { test: 'dataJson' };
     setup({ data: { result: testData, rejected: null } });

--- a/src/views/workflow-queries/workflow-queries-result-json/__tests__/workflow-queries-result-json.test.tsx
+++ b/src/views/workflow-queries/workflow-queries-result-json/__tests__/workflow-queries-result-json.test.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
 import copy from 'copy-to-clipboard';
+import { act } from 'react-dom/test-utils';
 
-import { render, fireEvent, screen, act } from '@/test-utils/rtl';
+import { render, fireEvent, screen } from '@/test-utils/rtl';
+
+import { type QueryWorkflowResponse } from '@/route-handlers/query-workflow/query-workflow.types';
 
 import WorkflowQueriesResultJson from '../workflow-queries-result-json';
 
 jest.mock('copy-to-clipboard', jest.fn);
+
+jest.mock('../helpers/get-query-json-content', () => ({
+  __esModule: true,
+  default: jest.fn(({ data }) => ({ content: data.result, isError: false })),
+}));
 
 jest.mock('@/components/pretty-json/pretty-json', () =>
   jest.fn(({ json }) => (
@@ -25,14 +33,20 @@ describe(WorkflowQueriesResultJson.name, () => {
     expect(screen.getByText(/dataJson/)).toBeInTheDocument();
   });
 
+  it('renders loading state correctly', () => {
+    setup({ data: undefined, loading: true });
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
   it('copies JSON to clipboard', () => {
-    const inputData = { input: 'dataJson' };
-    setup({ data: inputData });
+    const testData = { test: 'dataJson' };
+    setup({ data: { result: testData, rejected: null } });
 
     const copyButton = screen.getByRole('button');
     fireEvent.click(copyButton);
 
-    expect(copy).toHaveBeenCalledWith(JSON.stringify(inputData, null, '\t'));
+    expect(copy).toHaveBeenCalledWith(JSON.stringify(testData, null, '\t'));
   });
 
   it('show tooltip for 1 second and remove it', () => {
@@ -58,11 +72,11 @@ describe(WorkflowQueriesResultJson.name, () => {
 });
 
 function setup({
-  data = { input: 'dataJson' },
+  data = { result: { test: 'dataJson' }, rejected: null },
   error = undefined,
   loading = false,
 }: {
-  data?: any;
+  data?: QueryWorkflowResponse;
   error?: any;
   loading?: boolean;
 }) {

--- a/src/views/workflow-queries/workflow-queries-result-json/helpers/__tests__/get-query-json-content.test.ts
+++ b/src/views/workflow-queries/workflow-queries-result-json/helpers/__tests__/get-query-json-content.test.ts
@@ -1,0 +1,95 @@
+import { RequestError } from '@/utils/request/request-error';
+
+import {
+  type QueryJsonContent,
+  type Props,
+} from '../../workflow-queries-result-json.types';
+import getQueryJsonContent from '../get-query-json-content';
+
+describe(getQueryJsonContent.name, () => {
+  const tests: Array<{
+    name: string;
+    props: Props;
+    expected: QueryJsonContent;
+  }> = [
+    {
+      name: 'returns undefined/false for the loading state',
+      props: {
+        data: undefined,
+        loading: true,
+        error: undefined,
+      },
+      expected: {
+        content: undefined,
+        isError: false,
+      },
+    },
+    {
+      name: 'returns an error message/true for the error state',
+      props: {
+        data: undefined,
+        loading: false,
+        error: new RequestError('Something went wrong', 500),
+      },
+      expected: {
+        content: { message: 'Something went wrong' },
+        isError: true,
+      },
+    },
+    {
+      name: 'returns workflow close status/true when the query is rejected',
+      props: {
+        data: {
+          result: null,
+          rejected: {
+            closeStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED',
+          },
+        },
+        loading: false,
+        error: undefined,
+      },
+      expected: {
+        content:
+          'Workflow is closed with status WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED',
+        isError: true,
+      },
+    },
+    {
+      name: 'returns data/false for the success state',
+      props: {
+        data: {
+          result: {
+            test: 'test',
+          },
+          rejected: null,
+        },
+        loading: false,
+        error: undefined,
+      },
+      expected: {
+        content: {
+          test: 'test',
+        },
+        isError: false,
+      },
+    },
+    {
+      name: 'returns undefined for the empty state',
+      props: {
+        data: undefined,
+        loading: false,
+        error: undefined,
+      },
+      expected: {
+        content: undefined,
+        isError: false,
+      },
+    },
+  ];
+
+  tests.forEach((test) => {
+    it(test.name, () => {
+      expect(getQueryJsonContent(test.props)).toEqual(test.expected);
+    });
+  });
+});

--- a/src/views/workflow-queries/workflow-queries-result-json/helpers/get-query-json-content.ts
+++ b/src/views/workflow-queries/workflow-queries-result-json/helpers/get-query-json-content.ts
@@ -1,0 +1,33 @@
+import {
+  type QueryJsonContent,
+  type Props,
+} from '../workflow-queries-result-json.types';
+
+export default function getQueryJsonContent(props: Props): QueryJsonContent {
+  if (props.loading) {
+    return { content: undefined, isError: false };
+  }
+
+  if (props.error) {
+    return {
+      content: {
+        message: props.error.message,
+      },
+      isError: true,
+    };
+  }
+
+  if (props.data) {
+    if (props.data.rejected) {
+      return {
+        content:
+          'Workflow is closed with status ' + props.data.rejected.closeStatus,
+        isError: true,
+      };
+    }
+
+    return { content: props.data.result, isError: false };
+  }
+
+  return { content: undefined, isError: false };
+}

--- a/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.styles.ts
+++ b/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.styles.ts
@@ -1,14 +1,27 @@
 import { styled as createStyled } from 'baseui';
 
 export const styled = {
-  ViewContainer: createStyled('div', ({ $theme }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    gap: $theme.sizing.scale600,
-    padding: $theme.sizing.scale600,
-    backgroundColor: $theme.colors.backgroundSecondary,
-    borderRadius: $theme.borders.radius300,
-  })),
+  ViewContainer: createStyled<'div', { $isError: boolean }>(
+    'div',
+    ({ $theme, $isError }) => ({
+      // TODO: revisit this when PageSection is fixed
+      minHeight: '50vh',
+      alignSelf: 'stretch',
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: $theme.sizing.scale600,
+      padding: $theme.sizing.scale600,
+      backgroundColor: $isError
+        ? $theme.colors.backgroundNegativeLight
+        : $theme.colors.backgroundSecondary,
+      borderRadius: $theme.borders.radius300,
+      ...($isError && {
+        borderColor: $theme.colors.contentNegative,
+        borderWidth: '2px',
+        borderStyle: 'solid',
+      }),
+    })
+  ),
 };

--- a/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.tsx
+++ b/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.tsx
@@ -1,13 +1,15 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import { Button, KIND as BUTTON_KIND, SHAPE, SIZE } from 'baseui/button';
+import { Spinner } from 'baseui/spinner';
 import { ACCESSIBILITY_TYPE, Tooltip } from 'baseui/tooltip';
 import copy from 'copy-to-clipboard';
 import { MdCopyAll } from 'react-icons/md';
 
 import PrettyJson from '@/components/pretty-json/pretty-json';
 
+import getQueryJsonContent from './helpers/get-query-json-content';
 import { styled } from './workflow-queries-result-json.styles';
 import { type Props } from './workflow-queries-result-json.types';
 
@@ -23,29 +25,39 @@ export default function WorkflowQueriesResultJson(props: Props) {
     }
   }, [showTooltip]);
 
+  const { content, isError } = useMemo(
+    () => getQueryJsonContent(props),
+    [props]
+  );
+
   return (
-    <styled.ViewContainer>
-      <PrettyJson json={props.data} />
-      <Tooltip
-        animateOutTime={400}
-        isOpen={showTooltip}
-        showArrow
-        placement="bottom"
-        accessibilityType={ACCESSIBILITY_TYPE.tooltip}
-        content={() => <>Copied</>}
-      >
-        <Button
-          onClick={() => {
-            copy(JSON.stringify(props.data, null, '\t'));
-            setShowTooltip(true);
-          }}
-          size={SIZE.compact}
-          shape={SHAPE.pill}
-          kind={BUTTON_KIND.secondary}
-        >
-          <MdCopyAll />
-        </Button>
-      </Tooltip>
+    <styled.ViewContainer $isError={isError}>
+      {props.loading && <Spinner />}
+      {content !== undefined && (
+        <>
+          <PrettyJson json={content} />
+          <Tooltip
+            animateOutTime={400}
+            isOpen={showTooltip}
+            showArrow
+            placement="bottom"
+            accessibilityType={ACCESSIBILITY_TYPE.tooltip}
+            content={() => <>Copied</>}
+          >
+            <Button
+              onClick={() => {
+                copy(JSON.stringify(content, null, '\t'));
+                setShowTooltip(true);
+              }}
+              size={SIZE.compact}
+              shape={SHAPE.pill}
+              kind={BUTTON_KIND.tertiary}
+            >
+              <MdCopyAll />
+            </Button>
+          </Tooltip>
+        </>
+      )}
     </styled.ViewContainer>
   );
 }

--- a/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.tsx
+++ b/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { Button, KIND as BUTTON_KIND, SHAPE, SIZE } from 'baseui/button';
-import { Spinner } from 'baseui/spinner';
 import { ACCESSIBILITY_TYPE, Tooltip } from 'baseui/tooltip';
 import copy from 'copy-to-clipboard';
 import { MdCopyAll } from 'react-icons/md';
@@ -32,7 +31,6 @@ export default function WorkflowQueriesResultJson(props: Props) {
 
   return (
     <styled.ViewContainer $isError={isError}>
-      {props.loading && <Spinner />}
       {content !== undefined && (
         <>
           <PrettyJson json={content} />
@@ -45,6 +43,8 @@ export default function WorkflowQueriesResultJson(props: Props) {
             content={() => <>Copied</>}
           >
             <Button
+              // TODO: Add overrides for the copy button so that
+              // it sticks to the top right when the window is resized
               onClick={() => {
                 copy(JSON.stringify(content, null, '\t'));
                 setShowTooltip(true);

--- a/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.types.ts
+++ b/src/views/workflow-queries/workflow-queries-result-json/workflow-queries-result-json.types.ts
@@ -1,6 +1,14 @@
-// TODO: add proper types here when adding queries
+import { type JsonValue } from '@/components/pretty-json/pretty-json.types';
+import { type QueryWorkflowResponse } from '@/route-handlers/query-workflow/query-workflow.types';
+import { type RequestError } from '@/utils/request/request-error';
+
 export type Props = {
-  data: any;
-  error: any;
-  loading: boolean;
+  data?: QueryWorkflowResponse;
+  error?: RequestError;
+  loading?: boolean;
+};
+
+export type QueryJsonContent = {
+  content: JsonValue | undefined;
+  isError: boolean;
 };

--- a/src/views/workflow-queries/workflow-queries-tile/__tests__/workflow-queries-tile.test.tsx
+++ b/src/views/workflow-queries/workflow-queries-tile/__tests__/workflow-queries-tile.test.tsx
@@ -84,7 +84,7 @@ function setup({
       isSelected={isSelected}
       onClick={mockOnClick}
       runQuery={mockRunQuery}
-      queryStatus="pending"
+      queryStatus="success"
     />
   );
 

--- a/src/views/workflow-queries/workflow-queries-tile/__tests__/workflow-queries-tile.test.tsx
+++ b/src/views/workflow-queries/workflow-queries-tile/__tests__/workflow-queries-tile.test.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import { render, screen } from '@/test-utils/rtl';
 
 import WorkflowQueriesTile from '../workflow-queries-tile';
+import { type WorkflowQueryStatus } from '../workflow-queries-tile.types';
 
 jest.mock('../../workflow-queries-tile-input/workflow-queries-tile-input', () =>
   jest.fn(() => <div>Mock input</div>)
@@ -25,6 +26,12 @@ describe(WorkflowQueriesTile.name, () => {
     setup({ input: 'test input' });
 
     expect(screen.getByText('Mock input')).toBeInTheDocument();
+  });
+
+  it('disables run button when query status is fetching', () => {
+    setup({ status: 'fetching' });
+
+    expect(screen.getByText('Run')).toBeDisabled();
   });
 
   it('calls onSelect when clicked', async () => {
@@ -67,9 +74,11 @@ describe(WorkflowQueriesTile.name, () => {
 function setup({
   input = undefined,
   isSelected = false,
+  status = 'success',
 }: {
   input?: string | undefined;
   isSelected?: boolean;
+  status?: WorkflowQueryStatus;
 }) {
   const user = userEvent.setup();
   const mockOnChangeInput = jest.fn();
@@ -84,7 +93,7 @@ function setup({
       isSelected={isSelected}
       onClick={mockOnClick}
       runQuery={mockRunQuery}
-      queryStatus="success"
+      queryStatus={status}
     />
   );
 

--- a/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.tsx
+++ b/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.tsx
@@ -32,6 +32,7 @@ export default function WorkflowQueriesTile(props: Props) {
             kind={KIND.secondary}
             endEnhancer={MdPlayArrow}
             onClick={props.runQuery}
+            disabled={props.queryStatus === 'fetching'}
           >
             Run
           </Button>

--- a/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.types.ts
+++ b/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.types.ts
@@ -1,5 +1,7 @@
 import { type QueryStatus } from '@tanstack/react-query';
 
+export type WorkflowQueryStatus = QueryStatus | 'fetching';
+
 export type Props = {
   name: string;
   input: string | undefined;
@@ -7,5 +9,5 @@ export type Props = {
   isSelected: boolean;
   onClick: () => void;
   runQuery: () => void;
-  queryStatus?: QueryStatus;
+  queryStatus?: WorkflowQueryStatus;
 };

--- a/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.types.ts
+++ b/src/views/workflow-queries/workflow-queries-tile/workflow-queries-tile.types.ts
@@ -1,6 +1,4 @@
-import { type QueryStatus } from '@tanstack/react-query';
-
-export type WorkflowQueryStatus = QueryStatus | 'fetching';
+export type WorkflowQueryStatus = 'pending' | 'fetching' | 'success' | 'error';
 
 export type Props = {
   name: string;

--- a/src/views/workflow-queries/workflow-queries.tsx
+++ b/src/views/workflow-queries/workflow-queries.tsx
@@ -1,14 +1,9 @@
 'use client';
-import React, { Suspense } from 'react';
 
 import { type WorkflowPageTabContentProps } from '@/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types';
 
 import WorkflowQueriesLoader from './workflow-queries-loader/workflow-queries-loader';
 
 export default function WorkflowQueries(props: WorkflowPageTabContentProps) {
-  return (
-    <Suspense>
-      <WorkflowQueriesLoader {...props.params} />
-    </Suspense>
-  );
+  return <WorkflowQueriesLoader {...props.params} />;
 }


### PR DESCRIPTION
## Summary

### API changes
- Add route handler for QueryWorkflow

### Queries loader changes
- Remove suspense boundary from queries page, since the tabs already have it
- Move useQueries logic + inputs state to a separate hook file for readability
- Add generic types to useQueries

### Queries tile changes
- Create custom WorkflowQueryStatus, which adds the type 'fetching' to the regular QueryStatus
- Disable run button when query status is 'fetching'

### JSON viewer changes
- Add useQueryJsonContent which looks at query state to decide what to show, and if it should be rendered as an error
- Show spinner for loading state

## Test plan
Unit tests + ran cadence-web locally.

![Screenshot 2024-09-19 at 5 57 38 PM](https://github.com/user-attachments/assets/ad84d3e5-b03f-48ec-9bfa-250be9b0a95c)
![Screenshot 2024-09-19 at 5 33 24 PM](https://github.com/user-attachments/assets/5f5d29ce-31cb-4583-9348-8507cdf32d44)
![Screenshot 2024-09-19 at 5 36 58 PM](https://github.com/user-attachments/assets/637b147c-e265-4f35-b556-3d6416f605e3)
