### PR TITLE
Flexible page layouts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,12 +9,9 @@ body {
   display: flex;
   flex-direction: column;
   max-width: 100vw;
-  overflow-x: hidden;
   height: 100%;
 }
 
 body main {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+  display: contents;
 }

--- a/src/components/page-section/__test__/page-section.test.tsx
+++ b/src/components/page-section/__test__/page-section.test.tsx
@@ -15,7 +15,7 @@ describe('PageSection', () => {
   });
   it('renders with custom element', () => {
     const { getByRole } = render(
-      <PageSection as="nav">Test Content</PageSection>
+      <PageSection $as="nav">Test Content</PageSection>
     );
     const sectionElement = getByRole('navigation', { name: '' });
     expect(sectionElement).toBeInTheDocument();
@@ -23,7 +23,7 @@ describe('PageSection', () => {
   });
   it('renders provided children', () => {
     const { getByText } = render(
-      <PageSection as="menu">Test menu</PageSection>
+      <PageSection $as="menu">Test menu</PageSection>
     );
     const sectionElement = getByText('Test menu');
     expect(sectionElement).toBeInTheDocument();

--- a/src/components/page-section/page-section.styles.ts
+++ b/src/components/page-section/page-section.styles.ts
@@ -1,0 +1,13 @@
+import { type Theme, styled as createStyled } from 'baseui';
+
+import { getMediaQueryMargins } from '@/utils/media-query/get-media-queries-margins';
+
+export const styled = {
+  PageSection: createStyled('section', ({ $theme }: { $theme: Theme }) => ({
+    ...getMediaQueryMargins($theme, (margin) => ({
+      maxWidth: `${$theme.grid.maxWidth + 2 * margin}px`,
+      paddingRight: `${margin}px`,
+      paddingLeft: `${margin}px`,
+    })),
+  })),
+};

--- a/src/components/page-section/page-section.tsx
+++ b/src/components/page-section/page-section.tsx
@@ -1,19 +1,6 @@
 'use client';
-import React from 'react';
+import { styled } from './page-section.styles';
 
-import { Cell, Grid } from 'baseui/layout-grid';
+const PageSection = styled.PageSection;
 
-import type { Props } from './page-section.types';
-
-export default function PageSection<
-  T extends React.ComponentType<any> | keyof JSX.IntrinsicElements = 'section',
->({ children, as, ...rest }: Props<T>) {
-  const Component = as || 'section';
-  return (
-    <Component {...rest}>
-      <Grid>
-        <Cell span={12}>{children}</Cell>
-      </Grid>
-    </Component>
-  );
-}
+export default PageSection;

--- a/src/components/page-section/page-section.types.tsx
+++ b/src/components/page-section/page-section.types.tsx
@@ -1,8 +1,0 @@
-import type React from 'react';
-
-export type Props<
-  T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
-> = {
-  children: React.ReactNode;
-  as?: T;
-} & Omit<React.ComponentPropsWithoutRef<T>, 'as'>;

--- a/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.styles.ts
+++ b/src/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.styles.ts
@@ -9,6 +9,7 @@ const cssStylesObj = {
     flexDirection: 'column',
     marginTop: theme.sizing.scale900,
     marginBottom: theme.sizing.scale900,
+    flex: 1,
   }),
 } satisfies StyletronCSSObject;
 

--- a/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.styles.ts
+++ b/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.styles.ts
@@ -1,6 +1,13 @@
-import { styled as createStyled } from 'baseui';
+import { styled as createStyled, withStyle } from 'baseui';
+
+import PageSection from '@/components/page-section/page-section';
 
 export const styled = {
+  PageSection: withStyle(PageSection, () => ({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+  })),
   PageContainer: createStyled('div', ({ $theme }) => ({
     display: 'flex',
     flexDirection: 'column',

--- a/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.tsx
+++ b/src/views/workflow-queries/workflow-queries-loader/workflow-queries-loader.tsx
@@ -42,33 +42,35 @@ export default function WorkflowQueriesLoader(props: Props) {
   });
 
   return (
-    <styled.PageContainer>
-      <styled.QueriesSidebar>
-        {queryTypes.map((name, index) => (
-          <WorkflowQueriesTile
-            key={name}
-            name={name}
-            input={inputs[name]}
-            onChangeInput={(v) =>
-              setInputs((oldInputs) => ({ ...oldInputs, [name]: v }))
-            }
-            isSelected={index === selectedQueryIndex}
-            onClick={() => setSelectedQueryIndex(index)}
-            runQuery={queries[index].refetch}
-            queryStatus={getWorkflowQueryStatus({
-              queryStatus: queries[index].status,
-              isFetching: queries[index].isFetching,
-            })}
+    <styled.PageSection>
+      <styled.PageContainer>
+        <styled.QueriesSidebar>
+          {queryTypes.map((name, index) => (
+            <WorkflowQueriesTile
+              key={name}
+              name={name}
+              input={inputs[name]}
+              onChangeInput={(v) =>
+                setInputs((oldInputs) => ({ ...oldInputs, [name]: v }))
+              }
+              isSelected={index === selectedQueryIndex}
+              onClick={() => setSelectedQueryIndex(index)}
+              runQuery={queries[index].refetch}
+              queryStatus={getWorkflowQueryStatus({
+                queryStatus: queries[index].status,
+                isFetching: queries[index].isFetching,
+              })}
+            />
+          ))}
+        </styled.QueriesSidebar>
+        <styled.QueryResultView>
+          <WorkflowQueriesResultJson
+            data={queries[selectedQueryIndex]?.data}
+            error={queries[selectedQueryIndex]?.error ?? undefined}
+            loading={queries[selectedQueryIndex]?.isFetching}
           />
-        ))}
-      </styled.QueriesSidebar>
-      <styled.QueryResultView>
-        <WorkflowQueriesResultJson
-          data={queries[selectedQueryIndex]?.data}
-          error={queries[selectedQueryIndex]?.error ?? undefined}
-          loading={queries[selectedQueryIndex]?.isFetching}
-        />
-      </styled.QueryResultView>
-    </styled.PageContainer>
+        </styled.QueryResultView>
+      </styled.PageContainer>
+    </styled.PageSection>
   );
 }


### PR DESCRIPTION
### Summary
Due to some limitation with the current layout some page layouts were hard to implement. Pages were not able to easily fill the view and it was impossible to add scrollbar to the page body (only to its child elements) which made dealing with scroll bars programatically harder.

### Solution
- Simplified `PageSection` component to do the same functionality with less internal elements by removing (Container/Grid/Cell). This helps minimising the parent elements which requires to have `flex:1` in order to for the child to fill the page.
- Changed `main` element to `display: contents` which keeps its accessibility benefits but remove it from the styles tree.
- Removed the `overflow: hidden` from the body to allow showing scroll bars on the body instead of its children

### Testing
- Tested the changes on the `Queries Page` and added styles for it to fill the page.
<img width="1107" alt="Screenshot 2024-09-23 at 08 31 18" src="https://github.com/user-attachments/assets/d3425521-42a9-4b64-868a-bbd713b63f78">

- Manual testing for existing pages