### PR TITLE
Workflow timeline virtual lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-icons": "^5.1.0",
         "react-intersection-observer": "^9.8.1",
         "react-json-view-lite": "^1.4.0",
+        "react-virtuoso": "^4.10.4",
         "styletron-engine-monolithic": "^1.0.0",
         "styletron-react": "^6.1.1",
         "use-between": "^1.3.5",
@@ -9289,6 +9290,18 @@
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.10.4.tgz",
+      "integrity": "sha512-G/gprhTbK+lzMxoo/iStcZxVEGph/cIhc3WANEpt92RuMw+LiCZOmBfKoeoZOHlm/iyftTrDJhGaTCpxyucnkQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18",
+        "react-dom": ">=16 || >=17 || >= 18"
       }
     },
     "node_modules/react-window": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-icons": "^5.1.0",
     "react-intersection-observer": "^9.8.1",
     "react-json-view-lite": "^1.4.0",
+    "react-virtuoso": "^4.10.4",
     "styletron-engine-monolithic": "^1.0.0",
     "styletron-react": "^6.1.1",
     "use-between": "^1.3.5",

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 
 import { HttpResponse } from 'msw';
+import { VirtuosoMockContext } from 'react-virtuoso';
 
 import { act, render, screen } from '@/test-utils/rtl';
 
@@ -94,6 +95,15 @@ function setup({ error }: { error?: boolean }) {
               }),
         },
       ],
+    },
+    {
+      wrapper: ({ children }) => (
+        <VirtuosoMockContext.Provider
+          value={{ viewportHeight: 1000, itemHeight: 100 }}
+        >
+          {children}
+        </VirtuosoMockContext.Provider>
+      ),
     }
   );
 }

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
@@ -11,9 +11,10 @@ export const styled = {
     ({ $theme, $hidden }: { $theme: Theme; $hidden?: boolean }) => ({
       ...$theme.borders.border200,
       borderColor: $theme.colors.borderOpaque,
-      height: $hidden ? 0 : '100%',
       marginLeft: $theme.sizing.scale500,
-      transition: `height 0.2s ${$theme.animation.easeOutCurve}`,
+      ...($hidden && {
+        height: 0,
+      }),
     })
   ),
 };

--- a/src/views/workflow-history/workflow-history-timeline-load-more/__tests__/workflow-history-timeline-load-more.test.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-load-more/__tests__/workflow-history-timeline-load-more.test.tsx
@@ -3,7 +3,7 @@ import {
   intersectionMockInstance,
 } from 'react-intersection-observer/test-utils';
 
-import { render, screen, act, fireEvent, waitFor } from '@/test-utils/rtl';
+import { render, screen, act, fireEvent } from '@/test-utils/rtl';
 
 import { RequestError } from '@/utils/request/request-error';
 
@@ -44,12 +44,7 @@ describe('WorkflowHistoryTimelineLoadMore', () => {
     act(() => {
       mockIsIntersecting(spinnerDiv, 1);
     });
-    waitFor(
-      () => {
-        expect(mockFetchNextPage).toHaveBeenCalled();
-      },
-      { timeout: 2000 }
-    ); //TODO @assem.hafez remove the waitFor when removing the setTimeout
+    expect(mockFetchNextPage).toHaveBeenCalled();
   });
 });
 

--- a/src/views/workflow-history/workflow-history-timeline-load-more/workflow-history-timeline-load-more.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-load-more/workflow-history-timeline-load-more.tsx
@@ -37,9 +37,7 @@ export default function WorkflowHistoryTimelineLoadMore(props: Props) {
         data-testid="intersection-observer-container"
         onChange={(inView) => {
           if (inView && !props.isFetchingNextPage) {
-            // For testing purposes
-            // TODO @assem.hafez: Remove setimeout on page finalization
-            setTimeout(() => props.fetchNextPage(), 2000);
+            props.fetchNextPage();
           }
         }}
       >

--- a/src/views/workflow-history/workflow-history.styles.ts
+++ b/src/views/workflow-history/workflow-history.styles.ts
@@ -1,21 +1,7 @@
-import { styled as createStyled, type Theme } from 'baseui';
-
 import type {
   StyletronCSSObject,
   StyletronCSSObjectOf,
 } from '@/hooks/use-styletron-classes';
-
-export const styled = {
-  VerticalDivider: createStyled<'div', { $hidden?: boolean }>(
-    'div',
-    ({ $theme, $hidden }: { $theme: Theme; $hidden?: boolean }) => ({
-      ...$theme.borders.border200,
-      borderColor: $theme.colors.borderOpaque,
-      height: $hidden ? 0 : '100%',
-      marginLeft: $theme.sizing.scale500,
-    })
-  ),
-};
 
 const cssStylesObj = {
   pageContainer: {
@@ -25,22 +11,29 @@ const cssStylesObj = {
   eventsContainer: (theme) => ({
     display: 'flex',
     marginTop: theme.sizing.scale500,
-    gap: theme.sizing.scale400,
-    overflow: 'hidden',
+    // gap: theme.sizing.scale400,
   }),
   compactSection: (theme) => ({
     display: 'flex',
     flexDirection: 'column',
-    width: '370px',
-    gap: theme.sizing.scale400,
+    width: '362px',
+    maxHeight: `calc(100vh - ${theme.sizing.scale900})`, // fill page height excluding page bottom margin
+    overflow: 'auto',
+    position: 'sticky',
+    top: 0,
+    paddingRight: theme.sizing.scale800,
   }),
-  timelineSection: (theme) => ({
+  compactCardContainer: (theme) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    padding: `${theme.sizing.scale200} 0`,
+    marginRight: theme.sizing.scale700,
+  }),
+  timelineSection: {
     display: 'flex',
     flexDirection: 'column',
     flex: 1,
-    paddingLeft: theme.sizing.scale900,
-    overflow: 'hidden',
-  }),
+  },
 } satisfies StyletronCSSObject;
 
 export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-query';
 import { HeadingXSmall } from 'baseui/typography';
 import queryString from 'query-string';
+import { Virtuoso } from 'react-virtuoso';
 
 import PageSection from '@/components/page-section/page-section';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
@@ -30,7 +31,7 @@ export default function WorkflowHistory({
   const { workflowTab, ...historyQueryParams } = params;
   const wfhistoryRequestArgs = {
     ...historyQueryParams,
-    pageSize: 1,
+    pageSize: 200,
     waitForNewEvent: 'true',
   };
 
@@ -83,37 +84,50 @@ export default function WorkflowHistory({
       <div className={cls.pageContainer}>
         <HeadingXSmall>Workflow history</HeadingXSmall>
         <div className={cls.eventsContainer}>
-          <section className={cls.compactSection}>
-            {groupedHistoryEventsEntries.map(
-              ([groupId, { label, status, timeLabel }]) => (
-                <WorkflowHistoryCompactEventCard
-                  key={groupId}
-                  status={status}
-                  label={label}
-                  secondaryLabel={timeLabel}
-                  showLabelPlaceholder={!label}
-                />
-              )
-            )}
-          </section>
+          <div role="list" className={cls.compactSection}>
+            <Virtuoso
+              data={groupedHistoryEventsEntries}
+              itemContent={(_, [groupId, { label, status, timeLabel }]) => (
+                <div role="listitem" className={cls.compactCardContainer}>
+                  <WorkflowHistoryCompactEventCard
+                    key={groupId}
+                    status={status}
+                    label={label}
+                    secondaryLabel={timeLabel}
+                    showLabelPlaceholder={!label}
+                  />
+                </div>
+              )}
+            />
+          </div>
           <section className={cls.timelineSection}>
-            {groupedHistoryEventsEntries.map(([groupId, group], index) => (
-              <WorkflowHistoryTimelineGroup
-                key={groupId}
-                status={group.status}
-                label={group.label}
-                timeLabel={group.timeLabel}
-                events={group.events}
-                eventsMetadata={group.eventsMetadata}
-                hasMissingEvents={group.hasMissingEvents}
-                isLastEvent={index === groupedHistoryEventsEntries.length - 1}
-              />
-            ))}
-            <WorkflowHistoryTimelineLoadMore
-              error={error}
-              fetchNextPage={fetchNextPage}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
+            <Virtuoso
+              useWindowScroll
+              data={groupedHistoryEventsEntries}
+              itemContent={(index, [groupId, group]) => (
+                <WorkflowHistoryTimelineGroup
+                  key={groupId}
+                  status={group.status}
+                  label={
+                    group.label + index + groupedHistoryEventsEntries.length
+                  }
+                  timeLabel={group.timeLabel}
+                  events={group.events}
+                  eventsMetadata={group.eventsMetadata}
+                  hasMissingEvents={group.hasMissingEvents}
+                  isLastEvent={index === groupedHistoryEventsEntries.length - 1}
+                />
+              )}
+              components={{
+                Footer: () => (
+                  <WorkflowHistoryTimelineLoadMore
+                    error={error}
+                    fetchNextPage={fetchNextPage}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                  />
+                ),
+              }}
             />
           </section>
         </div>


### PR DESCRIPTION
### Summary
Handling large lists of workflows using virtual lists. Virtual lists manages large lists by only adding to the DOM rows that are visible in the view port.


### Changes
- Install `react-virtuoso`
- Use `react-virtuoso` in both Timeline and Compact lists
- The Compact list was made sticky while scrolling the main content to remain accessible in long timelines
- History request `pageSize` is now set to 200 instead of 1 (Was set for testing purposes)
- Remove 2 sec delay before loading more history events (Was added for testing purposes )

### Recording
![Screen Recording 2024-09-23 at 13 07 08](https://github.com/user-attachments/assets/5af2f4f1-28d9-4bfc-942b-20a5a18c8485)
