### PR TITLE
Add types to existing common values formatter

### DIFF
--- a/src/utils/data-formatters/__tests__/format-duration-to-seconds.test.ts
+++ b/src/utils/data-formatters/__tests__/format-duration-to-seconds.test.ts
@@ -10,7 +10,7 @@ describe('formatDurationToSeconds', () => {
   });
 
   test('should return seconds as number for valid input', () => {
-    const duration = { seconds: 60 };
+    const duration = { seconds: '60' };
     expect(formatDurationToSeconds(duration)).toBe(60);
   });
 
@@ -20,7 +20,7 @@ describe('formatDurationToSeconds', () => {
   });
 
   test('should handle zero seconds', () => {
-    const duration = { seconds: 0 };
+    const duration = { seconds: '0' };
     expect(formatDurationToSeconds(duration)).toBe(0);
   });
 

--- a/src/utils/data-formatters/__tests__/format-failure-details.test.ts
+++ b/src/utils/data-formatters/__tests__/format-failure-details.test.ts
@@ -3,11 +3,13 @@ import formatFailureDetails from '../format-failure-details';
 describe('formatFailureDetails', () => {
   test('should return null if failure details are not provided', () => {
     const failure = {};
+    // @ts-expect-error Testing with wrong type `{}`
     expect(formatFailureDetails(failure)).toBeNull();
   });
 
   test('should return null if failure details are null', () => {
     const failure = { details: null };
+    // @ts-expect-error Testing with wrong type `{ details: null}`
     expect(formatFailureDetails(failure)).toBeNull();
   });
 

--- a/src/utils/data-formatters/__tests__/format-payload-map.test.ts
+++ b/src/utils/data-formatters/__tests__/format-payload-map.test.ts
@@ -20,6 +20,7 @@ describe('formatPayloadMap', () => {
 
   test('should return null if fieldKey is not present in map', () => {
     const map = { otherKey: { subkey: { value: 'test' } } };
+    // @ts-expect-error Testing without passing `someKey` property
     expect(formatPayloadMap(map, 'someKey')).toBeNull();
   });
 

--- a/src/utils/data-formatters/__tests__/format-prev-auto-reset-points.test.ts
+++ b/src/utils/data-formatters/__tests__/format-prev-auto-reset-points.test.ts
@@ -1,3 +1,5 @@
+import { type ResetPoints } from '@/__generated__/proto-ts/uber/cadence/api/v1/ResetPoints';
+
 import formatPrevAutoResetPoints from '../format-prev-auto-reset-points';
 import formatTimestampToDatetime from '../format-timestamp-to-datetime';
 
@@ -13,6 +15,7 @@ describe('formatPrevAutoResetPoints', () => {
   });
 
   test('should return null if prevAutoResetPoints is not provided', () => {
+    // @ts-expect-error Testing with `undefined`
     expect(formatPrevAutoResetPoints(undefined)).toBeNull();
   });
 
@@ -28,12 +31,15 @@ describe('formatPrevAutoResetPoints', () => {
   });
 
   test('should format prevAutoResetPoints correctly for valid input', () => {
-    const prevAutoResetPoints = {
+    const prevAutoResetPoints: ResetPoints = {
       points: [
         {
-          createdTime: { seconds: 1623153200, nanos: 0 },
-          expiringTime: { seconds: 1623239600, nanos: 0 },
-          otherProperty: 'some value',
+          createdTime: { seconds: '1623153200', nanos: 0 },
+          expiringTime: { seconds: '1623239600', nanos: 0 },
+          binaryChecksum: '122434',
+          firstDecisionCompletedId: '123',
+          resettable: true,
+          runId: '2348yjk',
         },
       ],
     };
@@ -43,7 +49,10 @@ describe('formatPrevAutoResetPoints', () => {
     const expectedFormattedPoints = {
       points: [
         {
-          otherProperty: 'some value',
+          binaryChecksum: '122434',
+          firstDecisionCompletedId: '123',
+          resettable: true,
+          runId: '2348yjk',
           createdTimeNano: formattedCreatedTime1,
           expiringTimeNano: formattedCreatedTime2,
         },
@@ -57,23 +66,39 @@ describe('formatPrevAutoResetPoints', () => {
       expectedFormattedPoints
     );
     expect(formatTimestampToDatetime).toHaveBeenCalledWith({
-      seconds: 1623153200,
+      seconds: '1623153200',
       nanos: 0,
     });
     expect(formatTimestampToDatetime).toHaveBeenCalledWith({
-      seconds: 1623239600,
+      seconds: '1623239600',
       nanos: 0,
     });
   });
 
   test('should format prevAutoResetPoints correctly when createdTime or expiringTime is missing', () => {
-    const prevAutoResetPoints = {
-      points: [{ createdTime: { seconds: 1623153200, nanos: 0 } }],
+    const prevAutoResetPoints: ResetPoints = {
+      points: [
+        {
+          createdTime: { seconds: '1623153200', nanos: 0 },
+          expiringTime: { seconds: '1623239600', nanos: 0 },
+          binaryChecksum: '122434',
+          firstDecisionCompletedId: '123',
+          resettable: true,
+          runId: '2348yjk',
+        },
+      ],
     };
     const formattedCreatedTime1 = new Date(1623153200000);
     const expectedFormattedPoints = {
       points: [
-        { createdTimeNano: formattedCreatedTime1, expiringTimeNano: null },
+        {
+          createdTimeNano: formattedCreatedTime1,
+          expiringTimeNano: null,
+          binaryChecksum: '122434',
+          firstDecisionCompletedId: '123',
+          resettable: true,
+          runId: '2348yjk',
+        },
       ],
     };
     mockedFormatTimestampToDatetime
@@ -84,7 +109,7 @@ describe('formatPrevAutoResetPoints', () => {
       expectedFormattedPoints
     );
     expect(formatTimestampToDatetime).toHaveBeenCalledWith({
-      seconds: 1623153200,
+      seconds: '1623153200',
       nanos: 0,
     });
   });

--- a/src/utils/data-formatters/__tests__/format-retry-policy.test.ts
+++ b/src/utils/data-formatters/__tests__/format-retry-policy.test.ts
@@ -1,3 +1,5 @@
+import { type RetryPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/RetryPolicy';
+
 import formatDurationToSeconds from '../format-duration-to-seconds';
 import formatRetryPolicy from '../format-retry-policy';
 
@@ -21,10 +23,13 @@ describe('formatRetryPolicy', () => {
   });
 
   test('should return formatted retry policy with valid input', () => {
-    const retryPolicy = {
-      expirationInterval: { seconds: 60 },
-      initialInterval: { seconds: '30' },
-      maximumInterval: { seconds: 300 },
+    const retryPolicy: RetryPolicy = {
+      expirationInterval: { seconds: '60', nanos: 0 },
+      initialInterval: { seconds: '30', nanos: 0 },
+      maximumInterval: { seconds: '300', nanos: 0 },
+      backoffCoefficient: 10,
+      maximumAttempts: 10,
+      nonRetryableErrorReasons: [],
     };
     const formattedExpirationInterval = 60;
     const formattedInitialInterval = 30;
@@ -39,6 +44,9 @@ describe('formatRetryPolicy', () => {
       expirationIntervalInSeconds: formattedExpirationInterval,
       initialIntervalInSeconds: formattedInitialInterval,
       maximumIntervalInSeconds: formattedMaximumInterval,
+      backoffCoefficient: 10,
+      maximumAttempts: 10,
+      nonRetryableErrorReasons: [],
     };
 
     expect(formatRetryPolicy(retryPolicy)).toEqual(

--- a/src/utils/data-formatters/__tests__/format-workflow-history-event-type.test.ts
+++ b/src/utils/data-formatters/__tests__/format-workflow-history-event-type.test.ts
@@ -10,19 +10,20 @@ describe('formatWorkflowHistoryEventType', () => {
   it('should handle strings without "EventAttributes" correctly', () => {
     const input = 'workflowExecutionStarted';
     const expectedOutput = 'WorkflowExecutionStarted';
+    // @ts-expect-error Testing with wrong attribute `workflowExecutionStarted`
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
 
   it('should handle empty strings correctly', () => {
     const input = '';
     const expectedOutput = '';
+    // @ts-expect-error Testing with wrong attribute ``
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
 
   it('should handle null input correctly', () => {
     const input = null;
     const expectedOutput = null;
-    // @ts-expect-error Testing null
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
 
@@ -36,11 +37,12 @@ describe('formatWorkflowHistoryEventType', () => {
   it('should handle single-character input correctly', () => {
     const input = 'a';
     const expectedOutput = 'A';
+    // @ts-expect-error Testing with wrong attribute `a`
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
 
   it('should handle strings that start with a capital letter correctly', () => {
-    const input = 'WorkflowExecutionStartedEventAttributes';
+    const input = 'workflowExecutionStartedEventAttributes';
     const expectedOutput = 'WorkflowExecutionStarted';
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
@@ -48,6 +50,7 @@ describe('formatWorkflowHistoryEventType', () => {
   it('should handle strings that are already in the correct format', () => {
     const input = 'WorkflowExecutionStarted';
     const expectedOutput = 'WorkflowExecutionStarted';
+    // @ts-expect-error Testing with wrong attribute `WorkflowExecutionStarted`
     expect(formatWorkflowHistoryEventType(input)).toEqual(expectedOutput);
   });
 });

--- a/src/utils/data-formatters/__tests__/format-workflow-history.test.ts
+++ b/src/utils/data-formatters/__tests__/format-workflow-history.test.ts
@@ -30,7 +30,9 @@ describe('formatWorkflowHistory', () => {
     const expectedTimestamp = new Date('2023-06-18T12:34:56.Z');
     mockedFormatTimestampToDatetime.mockReturnValue(expectedTimestamp);
     mockedFormatWorkflowHistoryEvent.mockReturnValue({ formattedEvent: true });
-    mockedFormatWorkflowHistoryEventType.mockReturnValue('FormattedEventType');
+    mockedFormatWorkflowHistoryEventType.mockReturnValue(
+      'ActivityTaskCanceled'
+    );
 
     const input = {
       archived: true,
@@ -54,7 +56,7 @@ describe('formatWorkflowHistory', () => {
           {
             eventId: 1,
             timestamp: expectedTimestamp,
-            eventType: 'FormattedEventType',
+            eventType: 'ActivityTaskCanceled',
             attributes: 'workflowExecutionStartedEventAttributes',
             formattedEvent: true,
           },

--- a/src/utils/data-formatters/format-duration-to-seconds.ts
+++ b/src/utils/data-formatters/format-duration-to-seconds.ts
@@ -19,8 +19,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import { type Duration } from '@/__generated__/proto-ts/google/protobuf/Duration';
+
 const formatDurationToSeconds = (
-  duration?: { seconds: number | string } | null
+  duration?: Pick<Duration, 'seconds'> | null
 ) => (duration ? parseInt(String(duration.seconds)) : null);
 
 export default formatDurationToSeconds;

--- a/src/utils/data-formatters/format-enum.ts
+++ b/src/utils/data-formatters/format-enum.ts
@@ -24,33 +24,81 @@ import lowerCase from 'lodash/lowerCase';
 import snakeCase from 'lodash/snakeCase';
 import startCase from 'lodash/startCase';
 
-const convertToUpper = (value: string) => value.toUpperCase();
+type Formatter = (value: string) => string;
 
-const upperSnakeCase = flowRight([snakeCase, convertToUpper]);
+const convertToUpper: Formatter = (value: string) => value.toUpperCase();
 
-const removeWhiteSpace = (value: string) => value.replace(/\s/g, '');
+const upperSnakeCase: Formatter = flowRight([snakeCase, convertToUpper]);
 
-const pascalCase = flowRight([lowerCase, startCase, removeWhiteSpace]);
+const removeWhiteSpace: Formatter = (value: string) => value.replace(/\s/g, '');
 
+const pascalCase: Formatter = flowRight([
+  lowerCase,
+  startCase,
+  removeWhiteSpace,
+]);
+
+// Case formatter map with strict typing
 const caseFormatterMap = {
   snake: upperSnakeCase,
   pascal: pascalCase,
 } as const;
 
-const formatEnum = (
-  value: string,
-  prefix?: string,
-  caseFormat: keyof typeof caseFormatterMap = 'snake'
-) => {
+// Case format types
+type CaseFormat = keyof typeof caseFormatterMap;
+
+// Utility type to remove a given prefix from a string
+type RemovePrefix<
+  T extends string,
+  Prefix extends string,
+> = T extends `${Prefix}_${infer Rest}` ? Rest : T;
+
+// Template literal types for string transformation
+type ToUpperSnakeCase<T extends string> = T extends `${infer Head}${infer Tail}`
+  ? `${Uppercase<Head>}${ToUpperSnakeCase<Tail>}`
+  : T;
+
+type ToPascalCase<T extends string> = T extends `${infer First}_${infer Rest}`
+  ? `${Capitalize<Lowercase<First>>}${ToPascalCase<Capitalize<Rest>>}`
+  : Capitalize<Lowercase<T>>;
+
+// Utility type to check if a string contains "INVALID" and exclude it from the type
+type ExcludeInvalid<T extends string> = T extends `${infer _}INVALID${infer _}`
+  ? never
+  : T;
+
+type FormattedEnumValue<
+  T extends string,
+  P extends string,
+  F extends CaseFormat,
+> =
+  ExcludeInvalid<T> extends never
+    ? null
+    : F extends 'snake'
+      ? ToUpperSnakeCase<RemovePrefix<ExcludeInvalid<T>, P>> | null
+      : ToPascalCase<RemovePrefix<ExcludeInvalid<T>, P>> | null;
+
+const formatEnum = <
+  T extends string,
+  P extends string = '',
+  F extends CaseFormat = 'snake',
+>(
+  value: T | null | undefined,
+  prefix?: P,
+  caseFormat: F = 'snake' as F
+): FormattedEnumValue<T, P, F> => {
   if (!value || value.includes('INVALID')) {
     return null;
   }
+
+  // Remove prefix from the value if provided
   const valueRemovedPrefix = prefix
     ? value.replace(new RegExp(`^${prefix}_`), '')
     : value;
+
   const caseFormatter = caseFormatterMap[caseFormat];
 
-  return caseFormatter(valueRemovedPrefix);
+  return caseFormatter(valueRemovedPrefix) as FormattedEnumValue<T, P, F>;
 };
 
 export default formatEnum;

--- a/src/utils/data-formatters/format-failure-details.ts
+++ b/src/utils/data-formatters/format-failure-details.ts
@@ -19,7 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const formatFailureDetails = (failure: { details?: string | null }) => {
+import { type Failure } from '@/__generated__/proto-ts/uber/cadence/api/v1/Failure';
+
+const formatFailureDetails = (failure: Pick<Failure, 'details'> | null) => {
   if (!failure?.details) {
     return null;
   }

--- a/src/utils/data-formatters/format-payload-map.ts
+++ b/src/utils/data-formatters/format-payload-map.ts
@@ -21,9 +21,9 @@
 
 import formatPayload from './format-payload';
 
-const formatPayloadMap = (
-  map: { [k: string]: any } | null | undefined,
-  fieldKey: string
+const formatPayloadMap = <K extends string>(
+  map: { [key in K]: any } | null | undefined,
+  fieldKey: K
 ) => {
   if (!map?.[fieldKey]) {
     return null;
@@ -41,7 +41,7 @@ const formatPayloadMap = (
         }),
         {}
       ),
-  };
+  } as { [key in K]: any };
 };
 
 export default formatPayloadMap;

--- a/src/utils/data-formatters/format-prev-auto-reset-points.ts
+++ b/src/utils/data-formatters/format-prev-auto-reset-points.ts
@@ -19,28 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import { type ResetPoints } from '@/__generated__/proto-ts/uber/cadence/api/v1/ResetPoints';
+
 import formatTimestampToDatetime from './format-timestamp-to-datetime';
 
-const formatPrevAutoResetPoints = (
-  prevAutoResetPoints:
-    | {
-        points?:
-          | Array<{
-              createdTime?: {
-                seconds: number | string;
-                nanos: number | string;
-              };
-              expiringTime?: {
-                seconds: number | string;
-                nanos: number | string;
-              };
-            }>
-          | null
-          | undefined;
-      }
-    | null
-    | undefined
-) => {
+const formatPrevAutoResetPoints = (prevAutoResetPoints: ResetPoints | null) => {
   const points = prevAutoResetPoints?.points;
 
   if (!points) {

--- a/src/utils/data-formatters/format-retry-policy.ts
+++ b/src/utils/data-formatters/format-retry-policy.ts
@@ -19,20 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import type { RetryPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/RetryPolicy';
+
 import formatDurationToSeconds from './format-duration-to-seconds';
 
-type RetryPolicyInterval = { seconds: number | string } | null;
-
-const formatRetryPolicy = (
-  retryPolicy:
-    | {
-        expirationInterval?: RetryPolicyInterval;
-        initialInterval?: RetryPolicyInterval;
-        maximumInterval?: RetryPolicyInterval;
-      }
-    | null
-    | undefined
-) => {
+const formatRetryPolicy = (retryPolicy: RetryPolicy | null | undefined) => {
   if (!retryPolicy) {
     return null;
   }

--- a/src/utils/data-formatters/format-workflow-history-event-type.ts
+++ b/src/utils/data-formatters/format-workflow-history-event-type.ts
@@ -19,12 +19,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const formatWorkflowHistoryEventType = (attributes: string) =>
-  attributes
-    ? `${attributes[0].toUpperCase()}${attributes.slice(1)}`.replace(
-        'EventAttributes',
-        ''
-      )
-    : attributes;
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+// Utility type to capitalize the first letter
+type CapitalizeFirstLetter<T extends string> =
+  T extends `${infer First}${infer Rest}` ? `${Uppercase<First>}${Rest}` : T;
+
+// Utility type to remove 'EventAttributes' suffix
+type RemoveEventAttributes<T extends string> =
+  T extends `${infer Prefix}EventAttributes` ? Prefix : T;
+
+// Combine both transformations: capitalize and remove 'EventAttributes'
+type TransformEventType<T extends string> = CapitalizeFirstLetter<
+  RemoveEventAttributes<T>
+>;
+
+const formatWorkflowHistoryEventType = <T extends HistoryEvent['attributes']>(
+  attributes: T | null
+) => {
+  if (!attributes) return null;
+
+  return `${attributes[0].toUpperCase()}${attributes.slice(1)}`.replace(
+    'EventAttributes',
+    ''
+  ) as TransformEventType<T>;
+};
 
 export default formatWorkflowHistoryEventType;

--- a/src/utils/data-formatters/format-workflow-history-event-type.ts
+++ b/src/utils/data-formatters/format-workflow-history-event-type.ts
@@ -37,7 +37,7 @@ type TransformEventType<T extends string> = CapitalizeFirstLetter<
 const formatWorkflowHistoryEventType = <T extends HistoryEvent['attributes']>(
   attributes: T | null
 ) => {
-  if (!attributes) return null;
+  if (!attributes) return attributes;
 
   return `${attributes[0].toUpperCase()}${attributes.slice(1)}`.replace(
     'EventAttributes',

--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/format-workflow-execution-started-event-attributes.test.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/format-workflow-execution-started-event-attributes.test.ts
@@ -107,12 +107,19 @@ describe('formatWorkflowExecutionStartedEventAttributes', () => {
       expirationIntervalInSeconds: 600,
       initialIntervalInSeconds: 30,
       maximumIntervalInSeconds: 300,
+      backoffCoefficient: 100,
+      maximumAttempts: 1,
+      nonRetryableErrorReasons: [],
     });
     mockedFormatPrevAutoResetPoints.mockReturnValueOnce({
       points: [
         {
           createdTimeNano: new Date(123456000),
           expiringTimeNano: new Date(789000101),
+          binaryChecksum: '122434',
+          firstDecisionCompletedId: '123',
+          resettable: true,
+          runId: '2348yjk',
         },
       ],
     });
@@ -176,14 +183,20 @@ describe('formatWorkflowExecutionStartedEventAttributes', () => {
           {
             createdTimeNano: new Date(123456000),
             expiringTimeNano: new Date(789000101),
+            binaryChecksum: '122434',
+            firstDecisionCompletedId: '123',
+            resettable: true,
+            runId: '2348yjk',
           },
         ],
       },
       retryPolicy: {
         expirationIntervalInSeconds: 600,
-
         initialIntervalInSeconds: 30,
         maximumIntervalInSeconds: 300,
+        backoffCoefficient: 100,
+        maximumAttempts: 1,
+        nonRetryableErrorReasons: [],
       },
       searchAttributes: eventAttributes.searchAttributes,
     });


### PR DESCRIPTION
### Summary 
Add types to existing common event value formatters. Previously we didn't have types generated for history events so typing was hard.


### Changes
- Fix formatter argument and return types
- updating test cases to include missing values, add correct types of values and ignore typescript issues when it we send wrong type values on purpose to simulate bad input.

