### PR TITLE
Create formatter functions for workflow execution events

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
@@ -1,0 +1,24 @@
+import type { HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+import formatTimestampToDatetime from '../format-timestamp-to-datetime';
+import formatWorkflowHistoryEventType from '../format-workflow-history-event-type';
+
+export default function formatWorkflowCommonEventFields<
+  T extends HistoryEvent['attributes'],
+>({
+  eventId,
+  eventTime,
+  attributes,
+  ...rest
+}: {
+  eventId: HistoryEvent['eventId'];
+  eventTime: HistoryEvent['eventTime'];
+  attributes: T;
+}) {
+  return {
+    ...rest,
+    eventId: parseInt(eventId),
+    timestamp: formatTimestampToDatetime(eventTime),
+    eventType: formatWorkflowHistoryEventType<T>(attributes),
+  };
+}

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
@@ -19,22 +19,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import formatWorkflowEventId from '../format-workflow-event-id';
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCancelRequestedEvent } from './format-workflow-history-event.type';
 
-const formatWorkflowExecutionCancelRequestedEventAttributes = ({
-  externalExecutionInfo,
-  ...eventAttributes
-}: {
-  externalExecutionInfo?:
-    | { initiatedId: string | number; workflowExecution: any }
-    | null
-    | undefined;
-} & Record<string, any>) => ({
-  ...eventAttributes,
-  externalInitiatedEventId: formatWorkflowEventId(
-    externalExecutionInfo?.initiatedId
-  ),
-  externalWorkflowExecution: externalExecutionInfo?.workflowExecution,
-});
+const formatWorkflowExecutionCancelRequestedEvent = ({
+  workflowExecutionCancelRequestedEventAttributes: {
+    externalExecutionInfo,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCancelRequestedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    externalInitiatedEventId: externalExecutionInfo?.initiatedId
+      ? parseInt(externalExecutionInfo.initiatedId)
+      : null,
+    externalWorkflowExecution: externalExecutionInfo?.workflowExecution,
+  };
+};
 
-export default formatWorkflowExecutionCancelRequestedEventAttributes;
+export default formatWorkflowExecutionCancelRequestedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+const formatWorkflowExecutionCancelRequestedEventAttributes = ({
+  externalExecutionInfo,
+  ...eventAttributes
+}: {
+  externalExecutionInfo?:
+    | { initiatedId: string | number; workflowExecution: any }
+    | null
+    | undefined;
+} & Record<string, any>) => ({
+  ...eventAttributes,
+  externalInitiatedEventId: formatWorkflowEventId(
+    externalExecutionInfo?.initiatedId
+  ),
+  externalWorkflowExecution: externalExecutionInfo?.workflowExecution,
+});
+
+export default formatWorkflowExecutionCancelRequestedEventAttributes;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCanceledEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionCanceledEvent = ({
+  workflowExecutionCanceledEventAttributes: {
+    decisionTaskCompletedEventId,
+    details,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCanceledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    details: formatPayload(details),
+  };
+};
+
+export default formatWorkflowExecutionCanceledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCompletedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionCompletedEvent = ({
+  workflowExecutionCompletedEventAttributes: {
+    decisionTaskCompletedEventId,
+    result,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCompletedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    result: formatPayload(result),
+  };
+};
+
+export default formatWorkflowExecutionCompletedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatFailureDetails from '../format-failure-details';
+import formatPayloadMap from '../format-payload-map';
+import formatWorkflowEventId from '../format-workflow-event-id';
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionContinuedAsNewEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionContinuedAsNewEvent = ({
+  workflowExecutionContinuedAsNewEventAttributes: {
+    backoffStartInterval,
+    decisionTaskCompletedEventId,
+    executionStartToCloseTimeout,
+    failure,
+    header,
+    initiator,
+    input,
+    memo,
+    searchAttributes,
+    taskList,
+    taskStartToCloseTimeout,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionContinuedAsNewEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    backoffStartIntervalInSeconds:
+      formatDurationToSeconds(backoffStartInterval),
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      executionStartToCloseTimeout
+    ),
+    failureDetails: formatFailureDetails(failure),
+    failureReason: failure?.reason || '',
+    header: formatPayloadMap(header, 'fields'),
+    initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
+    input: formatWorkflowInputPayload(input),
+    memo: formatPayloadMap(memo, 'fields'),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    taskStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      taskStartToCloseTimeout
+    ),
+  };
+};
+
+export default formatWorkflowExecutionContinuedAsNewEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionFailedEvent = ({
+  workflowExecutionFailedEventAttributes: {
+    decisionTaskCompletedEventId,
+    failure,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    details: formatFailureDetails(failure),
+    reason: failure?.reason || '',
+  };
+};
+
+export default formatWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionSignaledEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionSignaledEvent = ({
+  workflowExecutionSignaledEventAttributes: { input, ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionSignaledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    input: formatWorkflowInputPayload(input),
+  };
+};
+
+export default formatWorkflowExecutionSignaledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatFailureDetails from '../format-failure-details';
+import formatPayloadMap from '../format-payload-map';
+import formatPrevAutoResetPoints from '../format-prev-auto-reset-points';
+import formatRetryPolicy from '../format-retry-policy';
+import formatTimestampToDatetime from '../format-timestamp-to-datetime';
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionStartedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionStartedEvent = ({
+  workflowExecutionStartedEventAttributes: {
+    attempt,
+    continuedExecutionRunId,
+    continuedFailure,
+    cronSchedule,
+    executionStartToCloseTimeout,
+    expirationTime,
+    firstDecisionTaskBackoff,
+    firstExecutionRunId,
+    firstScheduledTime,
+    identity,
+    initiator,
+    input,
+    memo,
+    originalExecutionRunId,
+    parentExecutionInfo,
+    prevAutoResetPoints,
+    retryPolicy,
+    searchAttributes,
+    taskList,
+    taskStartToCloseTimeout,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    input: formatWorkflowInputPayload(input),
+    executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      executionStartToCloseTimeout
+    ),
+    taskStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      taskStartToCloseTimeout
+    ),
+    attempt: attempt || null,
+    continuedExecutionRunId: continuedExecutionRunId || null,
+    continuedFailureDetails: formatFailureDetails(continuedFailure),
+    continuedFailureReason: continuedFailure?.reason || null,
+    cronSchedule: cronSchedule || null,
+    expirationTimestamp: formatTimestampToDatetime(expirationTime),
+    firstDecisionTaskBackoffSeconds: formatDurationToSeconds(
+      firstDecisionTaskBackoff
+    ),
+    firstExecutionRunId: firstExecutionRunId || null,
+    firstScheduledTimeNano: firstScheduledTime
+      ? parseGrpcTimestamp(firstScheduledTime)
+      : null,
+    identity: identity || null,
+    initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
+    memo: formatPayloadMap(memo, 'fields'),
+    originalExecutionRunId: originalExecutionRunId || null,
+    parentInitiatedEventId: parentExecutionInfo?.initiatedId
+      ? parseInt(parentExecutionInfo.initiatedId)
+      : null,
+    parentWorkflowDomain: parentExecutionInfo?.domainName || null,
+    parentWorkflowExecution: parentExecutionInfo?.workflowExecution || null,
+    prevAutoResetPoints: formatPrevAutoResetPoints(prevAutoResetPoints),
+    retryPolicy: formatRetryPolicy(retryPolicy),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+  };
+};
+
+export default formatWorkflowExecutionStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionTerminatedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionTerminatedEvent = ({
+  workflowExecutionTerminatedEventAttributes: { details, ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionTerminatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatPayload(details),
+  };
+};
+
+export default formatWorkflowExecutionTerminatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionTimedOutEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionTimedOutEvent = ({
+  workflowExecutionTimedOutEventAttributes: { ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionTimedOutEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+  };
+};
+
+export default formatWorkflowExecutionTimedOutEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-history-event.type.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-history-event.type.ts
@@ -1,0 +1,254 @@
+import { type ActivityTaskCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCancelRequestedEventAttributes';
+import { type ActivityTaskCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCanceledEventAttributes';
+import { type ActivityTaskCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCompletedEventAttributes';
+import { type ActivityTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskFailedEventAttributes';
+import { type ActivityTaskScheduledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskScheduledEventAttributes';
+import { type ActivityTaskStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskStartedEventAttributes';
+import { type ActivityTaskTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskTimedOutEventAttributes';
+import { type CancelTimerFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/CancelTimerFailedEventAttributes';
+import { type ChildWorkflowExecutionCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionCanceledEventAttributes';
+import { type ChildWorkflowExecutionCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionCompletedEventAttributes';
+import { type ChildWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionFailedEventAttributes';
+import { type ChildWorkflowExecutionStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionStartedEventAttributes';
+import { type ChildWorkflowExecutionTerminatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionTerminatedEventAttributes';
+import { type ChildWorkflowExecutionTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionTimedOutEventAttributes';
+import { type DecisionTaskCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskCompletedEventAttributes';
+import { type DecisionTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskFailedEventAttributes';
+import { type DecisionTaskScheduledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskScheduledEventAttributes';
+import { type DecisionTaskStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskStartedEventAttributes';
+import { type DecisionTaskTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskTimedOutEventAttributes';
+import { type ExternalWorkflowExecutionCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ExternalWorkflowExecutionCancelRequestedEventAttributes';
+import { type ExternalWorkflowExecutionSignaledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ExternalWorkflowExecutionSignaledEventAttributes';
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import { type MarkerRecordedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/MarkerRecordedEventAttributes';
+import { type RequestCancelActivityTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelActivityTaskFailedEventAttributes';
+import { type RequestCancelExternalWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelExternalWorkflowExecutionFailedEventAttributes';
+import { type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+import { type SignalExternalWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalExternalWorkflowExecutionFailedEventAttributes';
+import { type SignalExternalWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalExternalWorkflowExecutionInitiatedEventAttributes';
+import { type StartChildWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/StartChildWorkflowExecutionFailedEventAttributes';
+import { type StartChildWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/StartChildWorkflowExecutionInitiatedEventAttributes';
+import { type TimerCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerCanceledEventAttributes';
+import { type TimerFiredEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerFiredEventAttributes';
+import { type TimerStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerStartedEventAttributes';
+import { type UpsertWorkflowSearchAttributesEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpsertWorkflowSearchAttributesEventAttributes';
+import { type WorkflowExecutionCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCancelRequestedEventAttributes';
+import { type WorkflowExecutionCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCanceledEventAttributes';
+import { type WorkflowExecutionCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCompletedEventAttributes';
+import { type WorkflowExecutionContinuedAsNewEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionContinuedAsNewEventAttributes';
+import { type WorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionFailedEventAttributes';
+import { type WorkflowExecutionSignaledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionSignaledEventAttributes';
+import { type WorkflowExecutionStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionStartedEventAttributes';
+import { type WorkflowExecutionTerminatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionTerminatedEventAttributes';
+import { type WorkflowExecutionTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionTimedOutEventAttributes';
+
+export type WorkflowExecutionStartedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionStartedEventAttributes';
+  workflowExecutionStartedEventAttributes: WorkflowExecutionStartedEventAttributes;
+};
+
+export type WorkflowExecutionCompletedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCompletedEventAttributes';
+  workflowExecutionCompletedEventAttributes: WorkflowExecutionCompletedEventAttributes;
+};
+
+export type WorkflowExecutionCanceledEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCanceledEventAttributes';
+  workflowExecutionCanceledEventAttributes: WorkflowExecutionCanceledEventAttributes;
+};
+
+export type WorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionFailedEventAttributes';
+  workflowExecutionFailedEventAttributes: WorkflowExecutionFailedEventAttributes;
+};
+
+export type WorkflowExecutionTimedOutEvent = HistoryEvent & {
+  attributes: 'workflowExecutionTimedOutEventAttributes';
+  workflowExecutionTimedOutEventAttributes: WorkflowExecutionTimedOutEventAttributes;
+};
+
+export type DecisionTaskScheduledEvent = HistoryEvent & {
+  attributes: 'decisionTaskScheduledEventAttributes';
+  decisionTaskScheduledEventAttributes: DecisionTaskScheduledEventAttributes;
+};
+
+export type DecisionTaskStartedEvent = HistoryEvent & {
+  attributes: 'decisionTaskStartedEventAttributes';
+  decisionTaskStartedEventAttributes: DecisionTaskStartedEventAttributes;
+};
+
+export type DecisionTaskCompletedEvent = HistoryEvent & {
+  attributes: 'decisionTaskCompletedEventAttributes';
+  decisionTaskCompletedEventAttributes: DecisionTaskCompletedEventAttributes;
+};
+
+export type DecisionTaskTimedOutEvent = HistoryEvent & {
+  attributes: 'decisionTaskTimedOutEventAttributes';
+  decisionTaskTimedOutEventAttributes: DecisionTaskTimedOutEventAttributes;
+};
+
+export type DecisionTaskFailedEvent = HistoryEvent & {
+  attributes: 'decisionTaskFailedEventAttributes';
+  decisionTaskFailedEventAttributes: DecisionTaskFailedEventAttributes;
+};
+
+export type ActivityTaskScheduledEvent = HistoryEvent & {
+  attributes: 'activityTaskScheduledEventAttributes';
+  activityTaskScheduledEventAttributes: ActivityTaskScheduledEventAttributes;
+};
+
+export type ActivityTaskStartedEvent = HistoryEvent & {
+  attributes: 'activityTaskStartedEventAttributes';
+  activityTaskStartedEventAttributes: ActivityTaskStartedEventAttributes;
+};
+
+export type ActivityTaskCompletedEvent = HistoryEvent & {
+  attributes: 'activityTaskCompletedEventAttributes';
+  activityTaskCompletedEventAttributes: ActivityTaskCompletedEventAttributes;
+};
+
+export type ActivityTaskFailedEvent = HistoryEvent & {
+  attributes: 'activityTaskFailedEventAttributes';
+  activityTaskFailedEventAttributes: ActivityTaskFailedEventAttributes;
+};
+
+export type ActivityTaskTimedOutEvent = HistoryEvent & {
+  attributes: 'activityTaskTimedOutEventAttributes';
+  activityTaskTimedOutEventAttributes: ActivityTaskTimedOutEventAttributes;
+};
+
+export type TimerStartedEvent = HistoryEvent & {
+  attributes: 'timerStartedEventAttributes';
+  timerStartedEventAttributes: TimerStartedEventAttributes;
+};
+
+export type TimerFiredEvent = HistoryEvent & {
+  attributes: 'timerFiredEventAttributes';
+  timerFiredEventAttributes: TimerFiredEventAttributes;
+};
+
+export type ActivityTaskCancelRequestedEvent = HistoryEvent & {
+  attributes: 'activityTaskCancelRequestedEventAttributes';
+  activityTaskCancelRequestedEventAttributes: ActivityTaskCancelRequestedEventAttributes;
+};
+
+export type RequestCancelActivityTaskFailedEvent = HistoryEvent & {
+  attributes: 'requestCancelActivityTaskFailedEventAttributes';
+  requestCancelActivityTaskFailedEventAttributes: RequestCancelActivityTaskFailedEventAttributes;
+};
+
+export type ActivityTaskCanceledEvent = HistoryEvent & {
+  attributes: 'activityTaskCanceledEventAttributes';
+  activityTaskCanceledEventAttributes: ActivityTaskCanceledEventAttributes;
+};
+
+export type TimerCanceledEvent = HistoryEvent & {
+  attributes: 'timerCanceledEventAttributes';
+  timerCanceledEventAttributes: TimerCanceledEventAttributes;
+};
+
+export type CancelTimerFailedEvent = HistoryEvent & {
+  attributes: 'cancelTimerFailedEventAttributes';
+  cancelTimerFailedEventAttributes: CancelTimerFailedEventAttributes;
+};
+
+export type MarkerRecordedEvent = HistoryEvent & {
+  attributes: 'markerRecordedEventAttributes';
+  markerRecordedEventAttributes: MarkerRecordedEventAttributes;
+};
+
+export type WorkflowExecutionSignaledEvent = HistoryEvent & {
+  attributes: 'workflowExecutionSignaledEventAttributes';
+  workflowExecutionSignaledEventAttributes: WorkflowExecutionSignaledEventAttributes;
+};
+
+export type WorkflowExecutionTerminatedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionTerminatedEventAttributes';
+  workflowExecutionTerminatedEventAttributes: WorkflowExecutionTerminatedEventAttributes;
+};
+
+export type WorkflowExecutionCancelRequestedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCancelRequestedEventAttributes';
+  workflowExecutionCancelRequestedEventAttributes: WorkflowExecutionCancelRequestedEventAttributes;
+};
+
+export type RequestCancelExternalWorkflowExecutionInitiatedEvent =
+  HistoryEvent & {
+    attributes: 'requestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+    requestCancelExternalWorkflowExecutionInitiatedEventAttributes: RequestCancelExternalWorkflowExecutionInitiatedEventAttributes;
+  };
+
+export type RequestCancelExternalWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'requestCancelExternalWorkflowExecutionFailedEventAttributes';
+  requestCancelExternalWorkflowExecutionFailedEventAttributes: RequestCancelExternalWorkflowExecutionFailedEventAttributes;
+};
+
+export type ExternalWorkflowExecutionCancelRequestedEvent = HistoryEvent & {
+  attributes: 'externalWorkflowExecutionCancelRequestedEventAttributes';
+  externalWorkflowExecutionCancelRequestedEventAttributes: ExternalWorkflowExecutionCancelRequestedEventAttributes;
+};
+
+export type WorkflowExecutionContinuedAsNewEvent = HistoryEvent & {
+  attributes: 'workflowExecutionContinuedAsNewEventAttributes';
+  workflowExecutionContinuedAsNewEventAttributes: WorkflowExecutionContinuedAsNewEventAttributes;
+};
+
+export type StartChildWorkflowExecutionInitiatedEvent = HistoryEvent & {
+  attributes: 'startChildWorkflowExecutionInitiatedEventAttributes';
+  startChildWorkflowExecutionInitiatedEventAttributes: StartChildWorkflowExecutionInitiatedEventAttributes;
+};
+
+export type StartChildWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'startChildWorkflowExecutionFailedEventAttributes';
+  startChildWorkflowExecutionFailedEventAttributes: StartChildWorkflowExecutionFailedEventAttributes;
+};
+
+export type ChildWorkflowExecutionStartedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionStartedEventAttributes';
+  childWorkflowExecutionStartedEventAttributes: ChildWorkflowExecutionStartedEventAttributes;
+};
+
+export type ChildWorkflowExecutionCompletedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionCompletedEventAttributes';
+  childWorkflowExecutionCompletedEventAttributes: ChildWorkflowExecutionCompletedEventAttributes;
+};
+
+export type ChildWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionFailedEventAttributes';
+  childWorkflowExecutionFailedEventAttributes: ChildWorkflowExecutionFailedEventAttributes;
+};
+
+export type ChildWorkflowExecutionCanceledEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionCanceledEventAttributes';
+  childWorkflowExecutionCanceledEventAttributes: ChildWorkflowExecutionCanceledEventAttributes;
+};
+
+export type ChildWorkflowExecutionTimedOutEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionTimedOutEventAttributes';
+  childWorkflowExecutionTimedOutEventAttributes: ChildWorkflowExecutionTimedOutEventAttributes;
+};
+
+export type ChildWorkflowExecutionTerminatedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionTerminatedEventAttributes';
+  childWorkflowExecutionTerminatedEventAttributes: ChildWorkflowExecutionTerminatedEventAttributes;
+};
+
+export type SignalExternalWorkflowExecutionInitiatedEvent = HistoryEvent & {
+  attributes: 'signalExternalWorkflowExecutionInitiatedEventAttributes';
+  signalExternalWorkflowExecutionInitiatedEventAttributes: SignalExternalWorkflowExecutionInitiatedEventAttributes;
+};
+
+export type SignalExternalWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'signalExternalWorkflowExecutionFailedEventAttributes';
+  signalExternalWorkflowExecutionFailedEventAttributes: SignalExternalWorkflowExecutionFailedEventAttributes;
+};
+
+export type ExternalWorkflowExecutionSignaledEvent = HistoryEvent & {
+  attributes: 'externalWorkflowExecutionSignaledEventAttributes';
+  externalWorkflowExecutionSignaledEventAttributes: ExternalWorkflowExecutionSignaledEventAttributes;
+};
+
+export type UpsertWorkflowSearchAttributesEvent = HistoryEvent & {
+  attributes: 'upsertWorkflowSearchAttributesEventAttributes';
+  upsertWorkflowSearchAttributesEventAttributes: UpsertWorkflowSearchAttributesEventAttributes;
+};


### PR DESCRIPTION
### Summary
Create formatter function for workflow execution events, following what we have [here](https://github.com/uber/cadence-web/tree/master/server/middleware/grpc-client/format-response/format-history-event-details) using typescript


### Testing
Testing this individual methods would be done from a single format function that would responsible of formatting all event types