### PR TITLE
Create formatters for timers, external workflows & childworkflows 

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskCancelRequestedEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskCancelRequestedEvent = ({
+  activityTaskCancelRequestedEventAttributes: {
+    decisionTaskCompletedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskCancelRequestedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+  };
+};
+
+export default formatActivityTaskCancelRequestedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskCanceledEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskCanceledEvent = ({
+  activityTaskCanceledEventAttributes: {
+    details,
+    latestCancelRequestedEventId,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskCanceledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatPayload(details),
+    latestCancelRequestedEventId: parseInt(latestCancelRequestedEventId),
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatActivityTaskCanceledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskCompletedEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskCompletedEvent = ({
+  activityTaskCompletedEventAttributes: {
+    result,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskCompletedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    result: formatPayload(result),
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatActivityTaskCompletedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskFailedEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskFailedEvent = ({
+  activityTaskFailedEventAttributes: {
+    failure,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatFailureDetails(failure),
+    reason: failure?.reason || '',
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatActivityTaskFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatPayload from '../format-payload';
+import formatPayloadMap from '../format-payload-map';
+import formatRetryPolicy from '../format-retry-policy';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskScheduledEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskScheduledEvent = ({
+  activityTaskScheduledEventAttributes: {
+    decisionTaskCompletedEventId,
+    domain,
+    header,
+    heartbeatTimeout,
+    input,
+    retryPolicy,
+    scheduleToCloseTimeout,
+    scheduleToStartTimeout,
+    startToCloseTimeout,
+    taskList,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskScheduledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    domain: domain || null,
+    header: formatPayloadMap(header, 'fields'),
+    heartbeatTimeoutSeconds: formatDurationToSeconds(heartbeatTimeout),
+    input: formatPayload(input),
+    retryPolicy: formatRetryPolicy(retryPolicy),
+    scheduleToCloseTimeoutSeconds: formatDurationToSeconds(
+      scheduleToCloseTimeout
+    ),
+    scheduleToStartTimeoutSeconds: formatDurationToSeconds(
+      scheduleToStartTimeout
+    ),
+    startToCloseTimeoutSeconds: formatDurationToSeconds(startToCloseTimeout),
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+  };
+};
+
+export default formatActivityTaskScheduledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskStartedEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskStartedEvent = ({
+  activityTaskStartedEventAttributes: {
+    lastFailure,
+    scheduledEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    lastFailureDetails: formatFailureDetails(lastFailure),
+    lastFailureReason: lastFailure?.reason || '',
+    scheduledEventId: parseInt(scheduledEventId),
+  };
+};
+
+export default formatActivityTaskStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ActivityTaskTimedOutEvent } from './format-workflow-history-event.type';
+
+const formatActivityTaskTimedOutEvent = ({
+  activityTaskTimedOutEventAttributes: {
+    details,
+    lastFailure,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ActivityTaskTimedOutEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatPayload(details),
+    lastFailureDetails: formatFailureDetails(lastFailure),
+    lastFailureReason: lastFailure?.reason || '',
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatActivityTaskTimedOutEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type CancelTimerFailedEvent } from './format-workflow-history-event.type';
+
+const formatCancelTimerFailedEvent = ({
+  cancelTimerFailedEventAttributes: {
+    decisionTaskCompletedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: CancelTimerFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+  };
+};
+
+export default formatCancelTimerFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionCanceledEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionCanceledEvent = ({
+  childWorkflowExecutionCanceledEventAttributes: {
+    details,
+    initiatedEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionCanceledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatPayload(details),
+    initiatedEventId: parseInt(initiatedEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionCanceledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionTerminatedEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionTerminatedEvent = ({
+  childWorkflowExecutionTerminatedEventAttributes: {
+    initiatedEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionTerminatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    initiatedEventId: parseInt(initiatedEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionTerminatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionCompletedEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionCompletedEvent = ({
+  childWorkflowExecutionCompletedEventAttributes: {
+    initiatedEventId,
+    result,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionCompletedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    initiatedEventId: parseInt(initiatedEventId),
+    result: formatPayload(result),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionCompletedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionFailedEvent = ({
+  childWorkflowExecutionFailedEventAttributes: {
+    failure,
+    initiatedEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatFailureDetails(failure),
+    initiatedEventId: parseInt(initiatedEventId),
+    reason: failure?.reason || '',
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayloadMap from '../format-payload-map';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionStartedEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionStartedEvent = ({
+  childWorkflowExecutionStartedEventAttributes: {
+    header,
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    header: formatPayloadMap(header, 'fields'),
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ChildWorkflowExecutionTimedOutEvent } from './format-workflow-history-event.type';
+
+const formatChildWorkflowExecutionTimedOutEvent = ({
+  childWorkflowExecutionTimedOutEventAttributes: {
+    initiatedEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ChildWorkflowExecutionTimedOutEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    initiatedEventId: parseInt(initiatedEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatChildWorkflowExecutionTimedOutEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskCompletedEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskCompletedEvent = ({
+  decisionTaskCompletedEventAttributes: { ...eventAttributes },
+  ...eventFields
+}: DecisionTaskCompletedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+  };
+};
+
+export default formatDecisionTaskCompletedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskFailedEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskFailedEvent = ({
+  decisionTaskFailedEventAttributes: {
+    failure,
+    forkEventVersion,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: DecisionTaskFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatFailureDetails(failure),
+    forkEventVersion: parseInt(forkEventVersion),
+    reason: failure?.reason || '',
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatDecisionTaskFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskStartedEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskStartedEvent = ({
+  decisionTaskStartedEventAttributes: { scheduledEventId, ...eventAttributes },
+  ...eventFields
+}: DecisionTaskStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    scheduledEventId: parseInt(scheduledEventId),
+  };
+};
+
+export default formatDecisionTaskStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskScheduledEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskScheduledEvent = ({
+  decisionTaskScheduledEventAttributes: {
+    startToCloseTimeout,
+    taskList,
+    ...eventAttributes
+  },
+  ...eventFields
+}: DecisionTaskScheduledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    startToCloseTimeoutSeconds: formatDurationToSeconds(startToCloseTimeout),
+  };
+};
+
+export default formatDecisionTaskScheduledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskTimedOutEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskTimedOutEvent = ({
+  decisionTaskTimedOutEventAttributes: {
+    forkEventVersion,
+    scheduledEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: DecisionTaskTimedOutEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    forkEventVersion: parseInt(forkEventVersion),
+    scheduledEventId: parseInt(scheduledEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatDecisionTaskTimedOutEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ExternalWorkflowExecutionCancelRequestedEvent } from './format-workflow-history-event.type';
+
+const formatExternalWorkflowExecutionCancelRequestedEvent = ({
+  externalWorkflowExecutionCancelRequestedEventAttributes: {
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ExternalWorkflowExecutionCancelRequestedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatExternalWorkflowExecutionCancelRequestedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type ExternalWorkflowExecutionSignaledEvent } from './format-workflow-history-event.type';
+
+const formatExternalWorkflowExecutionSignaledEvent = ({
+  externalWorkflowExecutionSignaledEventAttributes: {
+    control,
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: ExternalWorkflowExecutionSignaledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatExternalWorkflowExecutionSignaledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+import formatPayloadMap from '../format-payload-map';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type MarkerRecordedEvent } from './format-workflow-history-event.type';
+
+const formatMarkerRecordedEvent = ({
+  markerRecordedEventAttributes: {
+    decisionTaskCompletedEventId,
+    details,
+    header,
+    ...eventAttributes
+  },
+  ...eventFields
+}: MarkerRecordedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    details: formatPayload(details),
+    header: formatPayloadMap(header, 'fields'),
+  };
+};
+
+export default formatMarkerRecordedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type RequestCancelActivityTaskFailedEvent } from './format-workflow-history-event.type';
+
+const formatRequestCancelActivityTaskFailedEvent = ({
+  requestCancelActivityTaskFailedEventAttributes: {
+    decisionTaskCompletedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: RequestCancelActivityTaskFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+  };
+};
+
+export default formatRequestCancelActivityTaskFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type RequestCancelExternalWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatRequestCancelExternalWorkflowExecutionFailedEvent = ({
+  requestCancelExternalWorkflowExecutionFailedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: RequestCancelExternalWorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatRequestCancelExternalWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type RequestCancelExternalWorkflowExecutionInitiatedEvent } from './format-workflow-history-event.type';
+
+const formatRequestCancelExternalWorkflowExecutionInitiatedEvent = ({
+  requestCancelExternalWorkflowExecutionInitiatedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: RequestCancelExternalWorkflowExecutionInitiatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+  };
+};
+
+export default formatRequestCancelExternalWorkflowExecutionInitiatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type SignalExternalWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatSignalExternalWorkflowExecutionFailedEvent = ({
+  signalExternalWorkflowExecutionFailedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: SignalExternalWorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatSignalExternalWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type SignalExternalWorkflowExecutionInitiatedEvent } from './format-workflow-history-event.type';
+
+const formatSignalExternalWorkflowExecutionInitiatedEvent = ({
+  signalExternalWorkflowExecutionInitiatedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    input,
+    ...eventAttributes
+  },
+  ...eventFields
+}: SignalExternalWorkflowExecutionInitiatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    input: formatWorkflowInputPayload(input),
+  };
+};
+
+export default formatSignalExternalWorkflowExecutionInitiatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type StartChildWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatStartChildWorkflowExecutionFailedEvent = ({
+  startChildWorkflowExecutionFailedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    initiatedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: StartChildWorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    initiatedEventId: parseInt(initiatedEventId),
+  };
+};
+
+export default formatStartChildWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatPayloadMap from '../format-payload-map';
+import formatRetryPolicy from '../format-retry-policy';
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type StartChildWorkflowExecutionInitiatedEvent } from './format-workflow-history-event.type';
+
+const formatStartChildWorkflowExecutionInitiatedEvent = ({
+  startChildWorkflowExecutionInitiatedEventAttributes: {
+    control,
+    decisionTaskCompletedEventId,
+    delayStart,
+    executionStartToCloseTimeout,
+    header,
+    input,
+    memo,
+    parentClosePolicy,
+    retryPolicy,
+    searchAttributes,
+    taskList,
+    taskStartToCloseTimeout,
+    workflowIdReusePolicy,
+    ...eventAttributes
+  },
+  ...eventFields
+}: StartChildWorkflowExecutionInitiatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    control: control ? parseInt(atob(control)) : null,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    delayStartSeconds: formatDurationToSeconds(delayStart),
+    executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      executionStartToCloseTimeout
+    ),
+    header: formatPayloadMap(header, 'fields'),
+    input: formatWorkflowInputPayload(input),
+    memo: formatPayloadMap(memo, 'fields'),
+    parentClosePolicy: formatEnum(parentClosePolicy, 'PARENT_CLOSE_POLICY'),
+    retryPolicy: formatRetryPolicy(retryPolicy),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    taskStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      taskStartToCloseTimeout
+    ),
+    workflowIdReusePolicy: formatEnum(
+      workflowIdReusePolicy,
+      'WORKFLOW_ID_REUSE_POLICY',
+      'pascal'
+    ),
+  };
+};
+
+export default formatStartChildWorkflowExecutionInitiatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type TimerCanceledEvent } from './format-workflow-history-event.type';
+
+const formatTimerCanceledEvent = ({
+  timerCanceledEventAttributes: {
+    decisionTaskCompletedEventId,
+    startedEventId,
+    ...eventAttributes
+  },
+  ...eventFields
+}: TimerCanceledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatTimerCanceledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type TimerFiredEvent } from './format-workflow-history-event.type';
+
+const formatTimerFiredEvent = ({
+  timerFiredEventAttributes: { startedEventId, ...eventAttributes },
+  ...eventFields
+}: TimerFiredEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    startedEventId: parseInt(startedEventId),
+  };
+};
+
+export default formatTimerFiredEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-started-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type TimerStartedEvent } from './format-workflow-history-event.type';
+
+const formatTimerStartedEvent = ({
+  timerStartedEventAttributes: {
+    decisionTaskCompletedEventId,
+    startToFireTimeout,
+    ...eventAttributes
+  },
+  ...eventFields
+}: TimerStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    startToFireTimeoutSeconds: formatDurationToSeconds(startToFireTimeout),
+  };
+};
+
+export default formatTimerStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-upsert-workflow-search-attributes-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-upsert-workflow-search-attributes-event.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayloadMap from '../format-payload-map';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type UpsertWorkflowSearchAttributesEvent } from './format-workflow-history-event.type';
+
+const formatUpsertWorkflowSearchAttributesEvent = ({
+  upsertWorkflowSearchAttributesEventAttributes: {
+    decisionTaskCompletedEventId,
+    searchAttributes,
+    ...eventAttributes
+  },
+  ...eventFields
+}: UpsertWorkflowSearchAttributesEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+  };
+};
+
+export default formatUpsertWorkflowSearchAttributesEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
@@ -1,0 +1,24 @@
+import type { HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+import formatTimestampToDatetime from '../format-timestamp-to-datetime';
+import formatWorkflowHistoryEventType from '../format-workflow-history-event-type';
+
+export default function formatWorkflowCommonEventFields<
+  T extends HistoryEvent['attributes'],
+>({
+  eventId,
+  eventTime,
+  attributes,
+  ...rest
+}: {
+  eventId: HistoryEvent['eventId'];
+  eventTime: HistoryEvent['eventTime'];
+  attributes: T;
+}) {
+  return {
+    ...rest,
+    eventId: parseInt(eventId),
+    timestamp: formatTimestampToDatetime(eventTime),
+    eventType: formatWorkflowHistoryEventType<T>(attributes),
+  };
+}

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCancelRequestedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionCancelRequestedEvent = ({
+  workflowExecutionCancelRequestedEventAttributes: {
+    externalExecutionInfo,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCancelRequestedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    externalInitiatedEventId: externalExecutionInfo?.initiatedId
+      ? parseInt(externalExecutionInfo.initiatedId)
+      : null,
+    externalWorkflowExecution: externalExecutionInfo?.workflowExecution,
+  };
+};
+
+export default formatWorkflowExecutionCancelRequestedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCanceledEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionCanceledEvent = ({
+  workflowExecutionCanceledEventAttributes: {
+    decisionTaskCompletedEventId,
+    details,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCanceledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    details: formatPayload(details),
+  };
+};
+
+export default formatWorkflowExecutionCanceledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionCompletedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionCompletedEvent = ({
+  workflowExecutionCompletedEventAttributes: {
+    decisionTaskCompletedEventId,
+    result,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionCompletedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    result: formatPayload(result),
+  };
+};
+
+export default formatWorkflowExecutionCompletedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatFailureDetails from '../format-failure-details';
+import formatPayloadMap from '../format-payload-map';
+import formatWorkflowEventId from '../format-workflow-event-id';
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionContinuedAsNewEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionContinuedAsNewEvent = ({
+  workflowExecutionContinuedAsNewEventAttributes: {
+    backoffStartInterval,
+    decisionTaskCompletedEventId,
+    executionStartToCloseTimeout,
+    failure,
+    header,
+    initiator,
+    input,
+    memo,
+    searchAttributes,
+    taskList,
+    taskStartToCloseTimeout,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionContinuedAsNewEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    backoffStartIntervalInSeconds:
+      formatDurationToSeconds(backoffStartInterval),
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      executionStartToCloseTimeout
+    ),
+    failureDetails: formatFailureDetails(failure),
+    failureReason: failure?.reason || '',
+    header: formatPayloadMap(header, 'fields'),
+    initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
+    input: formatWorkflowInputPayload(input),
+    memo: formatPayloadMap(memo, 'fields'),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    taskStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      taskStartToCloseTimeout
+    ),
+  };
+};
+
+export default formatWorkflowExecutionContinuedAsNewEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatFailureDetails from '../format-failure-details';
+import formatWorkflowEventId from '../format-workflow-event-id';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionFailedEvent = ({
+  workflowExecutionFailedEventAttributes: {
+    decisionTaskCompletedEventId,
+    failure,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionFailedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    decisionTaskCompletedEventId: formatWorkflowEventId(
+      decisionTaskCompletedEventId
+    ),
+    details: formatFailureDetails(failure),
+    reason: failure?.reason || '',
+  };
+};
+
+export default formatWorkflowExecutionFailedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionSignaledEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionSignaledEvent = ({
+  workflowExecutionSignaledEventAttributes: { input, ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionSignaledEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    input: formatWorkflowInputPayload(input),
+  };
+};
+
+export default formatWorkflowExecutionSignaledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
+import formatFailureDetails from '../format-failure-details';
+import formatPayloadMap from '../format-payload-map';
+import formatPrevAutoResetPoints from '../format-prev-auto-reset-points';
+import formatRetryPolicy from '../format-retry-policy';
+import formatTimestampToDatetime from '../format-timestamp-to-datetime';
+import formatWorkflowInputPayload from '../format-workflow-input-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionStartedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionStartedEvent = ({
+  workflowExecutionStartedEventAttributes: {
+    attempt,
+    continuedExecutionRunId,
+    continuedFailure,
+    cronSchedule,
+    executionStartToCloseTimeout,
+    expirationTime,
+    firstDecisionTaskBackoff,
+    firstExecutionRunId,
+    firstScheduledTime,
+    identity,
+    initiator,
+    input,
+    memo,
+    originalExecutionRunId,
+    parentExecutionInfo,
+    prevAutoResetPoints,
+    retryPolicy,
+    searchAttributes,
+    taskList,
+    taskStartToCloseTimeout,
+    ...eventAttributes
+  },
+  ...eventFields
+}: WorkflowExecutionStartedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    input: formatWorkflowInputPayload(input),
+    executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      executionStartToCloseTimeout
+    ),
+    taskStartToCloseTimeoutSeconds: formatDurationToSeconds(
+      taskStartToCloseTimeout
+    ),
+    attempt: attempt || null,
+    continuedExecutionRunId: continuedExecutionRunId || null,
+    continuedFailureDetails: formatFailureDetails(continuedFailure),
+    continuedFailureReason: continuedFailure?.reason || null,
+    cronSchedule: cronSchedule || null,
+    expirationTimestamp: formatTimestampToDatetime(expirationTime),
+    firstDecisionTaskBackoffSeconds: formatDurationToSeconds(
+      firstDecisionTaskBackoff
+    ),
+    firstExecutionRunId: firstExecutionRunId || null,
+    firstScheduledTimeNano: firstScheduledTime
+      ? parseGrpcTimestamp(firstScheduledTime)
+      : null,
+    identity: identity || null,
+    initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
+    memo: formatPayloadMap(memo, 'fields'),
+    originalExecutionRunId: originalExecutionRunId || null,
+    parentInitiatedEventId: parentExecutionInfo?.initiatedId
+      ? parseInt(parentExecutionInfo.initiatedId)
+      : null,
+    parentWorkflowDomain: parentExecutionInfo?.domainName || null,
+    parentWorkflowExecution: parentExecutionInfo?.workflowExecution || null,
+    prevAutoResetPoints: formatPrevAutoResetPoints(prevAutoResetPoints),
+    retryPolicy: formatRetryPolicy(retryPolicy),
+    searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+  };
+};
+
+export default formatWorkflowExecutionStartedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatPayload from '../format-payload';
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionTerminatedEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionTerminatedEvent = ({
+  workflowExecutionTerminatedEventAttributes: { details, ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionTerminatedEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+    details: formatPayload(details),
+  };
+};
+
+export default formatWorkflowExecutionTerminatedEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2022-2024 Uber Technologies Inc.
+//
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type WorkflowExecutionTimedOutEvent } from './format-workflow-history-event.type';
+
+const formatWorkflowExecutionTimedOutEvent = ({
+  workflowExecutionTimedOutEventAttributes: { ...eventAttributes },
+  ...eventFields
+}: WorkflowExecutionTimedOutEvent) => {
+  return {
+    ...formatWorkflowCommonEventFields(eventFields),
+    ...eventAttributes,
+  };
+};
+
+export default formatWorkflowExecutionTimedOutEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-history-event.type.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-history-event.type.ts
@@ -1,0 +1,254 @@
+import { type ActivityTaskCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCancelRequestedEventAttributes';
+import { type ActivityTaskCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCanceledEventAttributes';
+import { type ActivityTaskCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskCompletedEventAttributes';
+import { type ActivityTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskFailedEventAttributes';
+import { type ActivityTaskScheduledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskScheduledEventAttributes';
+import { type ActivityTaskStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskStartedEventAttributes';
+import { type ActivityTaskTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActivityTaskTimedOutEventAttributes';
+import { type CancelTimerFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/CancelTimerFailedEventAttributes';
+import { type ChildWorkflowExecutionCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionCanceledEventAttributes';
+import { type ChildWorkflowExecutionCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionCompletedEventAttributes';
+import { type ChildWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionFailedEventAttributes';
+import { type ChildWorkflowExecutionStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionStartedEventAttributes';
+import { type ChildWorkflowExecutionTerminatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionTerminatedEventAttributes';
+import { type ChildWorkflowExecutionTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ChildWorkflowExecutionTimedOutEventAttributes';
+import { type DecisionTaskCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskCompletedEventAttributes';
+import { type DecisionTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskFailedEventAttributes';
+import { type DecisionTaskScheduledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskScheduledEventAttributes';
+import { type DecisionTaskStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskStartedEventAttributes';
+import { type DecisionTaskTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/DecisionTaskTimedOutEventAttributes';
+import { type ExternalWorkflowExecutionCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ExternalWorkflowExecutionCancelRequestedEventAttributes';
+import { type ExternalWorkflowExecutionSignaledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/ExternalWorkflowExecutionSignaledEventAttributes';
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import { type MarkerRecordedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/MarkerRecordedEventAttributes';
+import { type RequestCancelActivityTaskFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelActivityTaskFailedEventAttributes';
+import { type RequestCancelExternalWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelExternalWorkflowExecutionFailedEventAttributes';
+import { type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+import { type SignalExternalWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalExternalWorkflowExecutionFailedEventAttributes';
+import { type SignalExternalWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/SignalExternalWorkflowExecutionInitiatedEventAttributes';
+import { type StartChildWorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/StartChildWorkflowExecutionFailedEventAttributes';
+import { type StartChildWorkflowExecutionInitiatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/StartChildWorkflowExecutionInitiatedEventAttributes';
+import { type TimerCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerCanceledEventAttributes';
+import { type TimerFiredEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerFiredEventAttributes';
+import { type TimerStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/TimerStartedEventAttributes';
+import { type UpsertWorkflowSearchAttributesEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpsertWorkflowSearchAttributesEventAttributes';
+import { type WorkflowExecutionCancelRequestedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCancelRequestedEventAttributes';
+import { type WorkflowExecutionCanceledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCanceledEventAttributes';
+import { type WorkflowExecutionCompletedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionCompletedEventAttributes';
+import { type WorkflowExecutionContinuedAsNewEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionContinuedAsNewEventAttributes';
+import { type WorkflowExecutionFailedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionFailedEventAttributes';
+import { type WorkflowExecutionSignaledEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionSignaledEventAttributes';
+import { type WorkflowExecutionStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionStartedEventAttributes';
+import { type WorkflowExecutionTerminatedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionTerminatedEventAttributes';
+import { type WorkflowExecutionTimedOutEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionTimedOutEventAttributes';
+
+export type WorkflowExecutionStartedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionStartedEventAttributes';
+  workflowExecutionStartedEventAttributes: WorkflowExecutionStartedEventAttributes;
+};
+
+export type WorkflowExecutionCompletedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCompletedEventAttributes';
+  workflowExecutionCompletedEventAttributes: WorkflowExecutionCompletedEventAttributes;
+};
+
+export type WorkflowExecutionCanceledEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCanceledEventAttributes';
+  workflowExecutionCanceledEventAttributes: WorkflowExecutionCanceledEventAttributes;
+};
+
+export type WorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionFailedEventAttributes';
+  workflowExecutionFailedEventAttributes: WorkflowExecutionFailedEventAttributes;
+};
+
+export type WorkflowExecutionTimedOutEvent = HistoryEvent & {
+  attributes: 'workflowExecutionTimedOutEventAttributes';
+  workflowExecutionTimedOutEventAttributes: WorkflowExecutionTimedOutEventAttributes;
+};
+
+export type DecisionTaskScheduledEvent = HistoryEvent & {
+  attributes: 'decisionTaskScheduledEventAttributes';
+  decisionTaskScheduledEventAttributes: DecisionTaskScheduledEventAttributes;
+};
+
+export type DecisionTaskStartedEvent = HistoryEvent & {
+  attributes: 'decisionTaskStartedEventAttributes';
+  decisionTaskStartedEventAttributes: DecisionTaskStartedEventAttributes;
+};
+
+export type DecisionTaskCompletedEvent = HistoryEvent & {
+  attributes: 'decisionTaskCompletedEventAttributes';
+  decisionTaskCompletedEventAttributes: DecisionTaskCompletedEventAttributes;
+};
+
+export type DecisionTaskTimedOutEvent = HistoryEvent & {
+  attributes: 'decisionTaskTimedOutEventAttributes';
+  decisionTaskTimedOutEventAttributes: DecisionTaskTimedOutEventAttributes;
+};
+
+export type DecisionTaskFailedEvent = HistoryEvent & {
+  attributes: 'decisionTaskFailedEventAttributes';
+  decisionTaskFailedEventAttributes: DecisionTaskFailedEventAttributes;
+};
+
+export type ActivityTaskScheduledEvent = HistoryEvent & {
+  attributes: 'activityTaskScheduledEventAttributes';
+  activityTaskScheduledEventAttributes: ActivityTaskScheduledEventAttributes;
+};
+
+export type ActivityTaskStartedEvent = HistoryEvent & {
+  attributes: 'activityTaskStartedEventAttributes';
+  activityTaskStartedEventAttributes: ActivityTaskStartedEventAttributes;
+};
+
+export type ActivityTaskCompletedEvent = HistoryEvent & {
+  attributes: 'activityTaskCompletedEventAttributes';
+  activityTaskCompletedEventAttributes: ActivityTaskCompletedEventAttributes;
+};
+
+export type ActivityTaskFailedEvent = HistoryEvent & {
+  attributes: 'activityTaskFailedEventAttributes';
+  activityTaskFailedEventAttributes: ActivityTaskFailedEventAttributes;
+};
+
+export type ActivityTaskTimedOutEvent = HistoryEvent & {
+  attributes: 'activityTaskTimedOutEventAttributes';
+  activityTaskTimedOutEventAttributes: ActivityTaskTimedOutEventAttributes;
+};
+
+export type TimerStartedEvent = HistoryEvent & {
+  attributes: 'timerStartedEventAttributes';
+  timerStartedEventAttributes: TimerStartedEventAttributes;
+};
+
+export type TimerFiredEvent = HistoryEvent & {
+  attributes: 'timerFiredEventAttributes';
+  timerFiredEventAttributes: TimerFiredEventAttributes;
+};
+
+export type ActivityTaskCancelRequestedEvent = HistoryEvent & {
+  attributes: 'activityTaskCancelRequestedEventAttributes';
+  activityTaskCancelRequestedEventAttributes: ActivityTaskCancelRequestedEventAttributes;
+};
+
+export type RequestCancelActivityTaskFailedEvent = HistoryEvent & {
+  attributes: 'requestCancelActivityTaskFailedEventAttributes';
+  requestCancelActivityTaskFailedEventAttributes: RequestCancelActivityTaskFailedEventAttributes;
+};
+
+export type ActivityTaskCanceledEvent = HistoryEvent & {
+  attributes: 'activityTaskCanceledEventAttributes';
+  activityTaskCanceledEventAttributes: ActivityTaskCanceledEventAttributes;
+};
+
+export type TimerCanceledEvent = HistoryEvent & {
+  attributes: 'timerCanceledEventAttributes';
+  timerCanceledEventAttributes: TimerCanceledEventAttributes;
+};
+
+export type CancelTimerFailedEvent = HistoryEvent & {
+  attributes: 'cancelTimerFailedEventAttributes';
+  cancelTimerFailedEventAttributes: CancelTimerFailedEventAttributes;
+};
+
+export type MarkerRecordedEvent = HistoryEvent & {
+  attributes: 'markerRecordedEventAttributes';
+  markerRecordedEventAttributes: MarkerRecordedEventAttributes;
+};
+
+export type WorkflowExecutionSignaledEvent = HistoryEvent & {
+  attributes: 'workflowExecutionSignaledEventAttributes';
+  workflowExecutionSignaledEventAttributes: WorkflowExecutionSignaledEventAttributes;
+};
+
+export type WorkflowExecutionTerminatedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionTerminatedEventAttributes';
+  workflowExecutionTerminatedEventAttributes: WorkflowExecutionTerminatedEventAttributes;
+};
+
+export type WorkflowExecutionCancelRequestedEvent = HistoryEvent & {
+  attributes: 'workflowExecutionCancelRequestedEventAttributes';
+  workflowExecutionCancelRequestedEventAttributes: WorkflowExecutionCancelRequestedEventAttributes;
+};
+
+export type RequestCancelExternalWorkflowExecutionInitiatedEvent =
+  HistoryEvent & {
+    attributes: 'requestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+    requestCancelExternalWorkflowExecutionInitiatedEventAttributes: RequestCancelExternalWorkflowExecutionInitiatedEventAttributes;
+  };
+
+export type RequestCancelExternalWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'requestCancelExternalWorkflowExecutionFailedEventAttributes';
+  requestCancelExternalWorkflowExecutionFailedEventAttributes: RequestCancelExternalWorkflowExecutionFailedEventAttributes;
+};
+
+export type ExternalWorkflowExecutionCancelRequestedEvent = HistoryEvent & {
+  attributes: 'externalWorkflowExecutionCancelRequestedEventAttributes';
+  externalWorkflowExecutionCancelRequestedEventAttributes: ExternalWorkflowExecutionCancelRequestedEventAttributes;
+};
+
+export type WorkflowExecutionContinuedAsNewEvent = HistoryEvent & {
+  attributes: 'workflowExecutionContinuedAsNewEventAttributes';
+  workflowExecutionContinuedAsNewEventAttributes: WorkflowExecutionContinuedAsNewEventAttributes;
+};
+
+export type StartChildWorkflowExecutionInitiatedEvent = HistoryEvent & {
+  attributes: 'startChildWorkflowExecutionInitiatedEventAttributes';
+  startChildWorkflowExecutionInitiatedEventAttributes: StartChildWorkflowExecutionInitiatedEventAttributes;
+};
+
+export type StartChildWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'startChildWorkflowExecutionFailedEventAttributes';
+  startChildWorkflowExecutionFailedEventAttributes: StartChildWorkflowExecutionFailedEventAttributes;
+};
+
+export type ChildWorkflowExecutionStartedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionStartedEventAttributes';
+  childWorkflowExecutionStartedEventAttributes: ChildWorkflowExecutionStartedEventAttributes;
+};
+
+export type ChildWorkflowExecutionCompletedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionCompletedEventAttributes';
+  childWorkflowExecutionCompletedEventAttributes: ChildWorkflowExecutionCompletedEventAttributes;
+};
+
+export type ChildWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionFailedEventAttributes';
+  childWorkflowExecutionFailedEventAttributes: ChildWorkflowExecutionFailedEventAttributes;
+};
+
+export type ChildWorkflowExecutionCanceledEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionCanceledEventAttributes';
+  childWorkflowExecutionCanceledEventAttributes: ChildWorkflowExecutionCanceledEventAttributes;
+};
+
+export type ChildWorkflowExecutionTimedOutEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionTimedOutEventAttributes';
+  childWorkflowExecutionTimedOutEventAttributes: ChildWorkflowExecutionTimedOutEventAttributes;
+};
+
+export type ChildWorkflowExecutionTerminatedEvent = HistoryEvent & {
+  attributes: 'childWorkflowExecutionTerminatedEventAttributes';
+  childWorkflowExecutionTerminatedEventAttributes: ChildWorkflowExecutionTerminatedEventAttributes;
+};
+
+export type SignalExternalWorkflowExecutionInitiatedEvent = HistoryEvent & {
+  attributes: 'signalExternalWorkflowExecutionInitiatedEventAttributes';
+  signalExternalWorkflowExecutionInitiatedEventAttributes: SignalExternalWorkflowExecutionInitiatedEventAttributes;
+};
+
+export type SignalExternalWorkflowExecutionFailedEvent = HistoryEvent & {
+  attributes: 'signalExternalWorkflowExecutionFailedEventAttributes';
+  signalExternalWorkflowExecutionFailedEventAttributes: SignalExternalWorkflowExecutionFailedEventAttributes;
+};
+
+export type ExternalWorkflowExecutionSignaledEvent = HistoryEvent & {
+  attributes: 'externalWorkflowExecutionSignaledEventAttributes';
+  externalWorkflowExecutionSignaledEventAttributes: ExternalWorkflowExecutionSignaledEventAttributes;
+};
+
+export type UpsertWorkflowSearchAttributesEvent = HistoryEvent & {
+  attributes: 'upsertWorkflowSearchAttributesEventAttributes';
+  upsertWorkflowSearchAttributesEventAttributes: UpsertWorkflowSearchAttributesEventAttributes;
+};


### PR DESCRIPTION
### Summary
Create formatter function for timers, external workflows & child workflows , following what we have [here](https://github.com/uber/cadence-web/tree/master/server/middleware/grpc-client/format-response/format-history-event-details) using typescript

### Testing
Testing this individual methods would be done from a single format function that would responsible of formatting all event types