### PR TITLE
Add export as json button to history page

### DIFF
--- a/src/views/workflow-history/workflow-history-export-json-button/__tests__/workflow-history-export-json-button.test.tsx
+++ b/src/views/workflow-history/workflow-history-export-json-button/__tests__/workflow-history-export-json-button.test.tsx
@@ -36,7 +36,6 @@ describe('WorkflowHistoryExportJsonButton', () => {
     const { getRequestResolver } = setup({ wait: true });
     fireEvent.click(screen.getByText('Export JSON'));
 
-    // Check if spinner shows when loading
     expect(screen.queryByRole('progressbar')).toBeInTheDocument();
     await act(() => {
       const resolver = getRequestResolver();
@@ -51,7 +50,6 @@ describe('WorkflowHistoryExportJsonButton', () => {
 
     setup({});
 
-    // Simulate button click
     fireEvent.click(screen.getByText('Export JSON'));
 
     await waitFor(() => {

--- a/src/views/workflow-history/workflow-history-export-json-button/__tests__/workflow-history-export-json-button.test.tsx
+++ b/src/views/workflow-history/workflow-history-export-json-button/__tests__/workflow-history-export-json-button.test.tsx
@@ -1,0 +1,129 @@
+import { toaster } from 'baseui/toast';
+import { HttpResponse } from 'msw';
+
+import { render, fireEvent, screen, act, waitFor } from '@/test-utils/rtl';
+
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
+
+import type { Props as MSWMocksHandlersProps } from '../../../../test-utils/msw-mock-handlers/msw-mock-handlers.types';
+import { completedActivityTaskEvents } from '../../__fixtures__/workflow-history-activity-events';
+import WorkflowHistoryExportJsonButton from '../workflow-history-export-json-button';
+import { type Props } from '../workflow-history-export-json-button.types';
+
+jest.mock('@/utils/logger');
+jest.mock('baseui/toast', () => ({
+  ...jest.requireActual('baseui/toast'),
+  toaster: {
+    negative: jest.fn(),
+  },
+}));
+
+describe('WorkflowHistoryExportJsonButton', () => {
+  const originalCreateObjectURL = window.URL.createObjectURL;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    window.URL.createObjectURL = originalCreateObjectURL;
+  });
+
+  it('should render the button with "Export JSON"', () => {
+    setup({});
+    expect(screen.getByText('Export JSON')).toBeInTheDocument();
+  });
+
+  it('should show spinner when loading', async () => {
+    const { getRequestResolver } = setup({ wait: true });
+    fireEvent.click(screen.getByText('Export JSON'));
+
+    // Check if spinner shows when loading
+    expect(screen.queryByRole('progressbar')).toBeInTheDocument();
+    await act(() => {
+      const resolver = getRequestResolver();
+      resolver();
+    });
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('should call request API and download JSON file', async () => {
+    const createObjectURLMock: jest.Mock = jest.fn();
+    window.URL.createObjectURL = createObjectURLMock;
+
+    setup({});
+
+    // Simulate button click
+    fireEvent.click(screen.getByText('Export JSON'));
+
+    await waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledWith(expect.any(Blob));
+    });
+  });
+
+  it('should handle error and show toast', async () => {
+    setup({ error: true });
+    fireEvent.click(screen.getByText('Export JSON'));
+
+    await waitFor(() => {
+      expect(toaster.negative).toHaveBeenCalledWith(
+        'Failed to export workflow history'
+      );
+    });
+  });
+});
+
+function setup({
+  error,
+  wait,
+  ...overrides
+}: Partial<Props> & { error?: boolean; loading?: boolean; wait?: boolean }) {
+  const defaultProps: Props = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    workflowId: 'test-workflowId',
+    runId: 'test-runId',
+  };
+  const mockEvents: HistoryEvent[] = completedActivityTaskEvents;
+  const totalEventsCount = mockEvents.length;
+  let currentEventIndex = 0;
+  let requestResolver = () => {};
+  const getRequestResolver = () => requestResolver;
+
+  render(<WorkflowHistoryExportJsonButton {...defaultProps} {...overrides} />, {
+    endpointsMocks: [
+      {
+        path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/history',
+        httpMethod: 'GET',
+        httpResolver: async () => {
+          const index = currentEventIndex;
+          currentEventIndex = currentEventIndex + 1;
+          if (wait && currentEventIndex === 0) {
+            await new Promise<void>((resolve) => {
+              requestResolver = () => {
+                resolve();
+              };
+            });
+          }
+          if (error)
+            return HttpResponse.json(
+              { message: 'Failed to fetch workflow history' },
+              { status: 500 }
+            );
+
+          return HttpResponse.json(
+            {
+              history: {
+                events: [mockEvents[index]],
+              },
+              archived: false,
+              nextPageToken: index < totalEventsCount - 1 ? '' : `${index + 1}`,
+              rawHistory: [],
+            } satisfies GetWorkflowHistoryResponse,
+            { status: 200 }
+          );
+        },
+      },
+    ] as MSWMocksHandlersProps['endpointsMocks'],
+  });
+
+  return { getRequestResolver };
+}

--- a/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.tsx
+++ b/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useRef, useState } from 'react';
+
+import { Button } from 'baseui/button';
+import { Spinner } from 'baseui/spinner';
+import { ToasterContainer, toaster } from 'baseui/toast';
+import queryString from 'query-string';
+import { MdOutlineCloudDownload } from 'react-icons/md';
+
+import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
+import logger from '@/utils/logger';
+import request from '@/utils/request';
+import { RequestError } from '@/utils/request/request-error';
+
+import { type Props } from './workflow-history-export-json-button.types';
+
+export default function WorkflowHistoryExportJsonButton(props: Props) {
+  const nextPage = useRef<string>();
+  const [loadingState, setLoadingState] = useState<
+    'loading' | 'error' | 'idle'
+  >('idle');
+
+  const downloadJSON = (jsonData: any) => {
+    const blob = new Blob([JSON.stringify(jsonData, null, '\t')], {
+      type: 'application/json',
+    });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `history-${props.workflowId}-${props.runId}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const handleExport = async () => {
+    try {
+      const events = [];
+      setLoadingState('loading');
+      do {
+        const res = await request(
+          `/api/domains/${props.domain}/${props.cluster}/workflows/${props.workflowId}/${props.runId}/history?${queryString.stringify({ pageSize: 500, nextPage: nextPage.current })}`
+        );
+        const data: GetWorkflowHistoryResponse = await res.json();
+        nextPage.current = data.nextPageToken;
+        events.push(...(data.history?.events || []));
+      } while (nextPage.current);
+
+      setLoadingState('idle');
+      downloadJSON(events);
+    } catch (e) {
+      if (!(e instanceof RequestError)) {
+        logger.error(e, 'Failed to export workflow');
+      }
+      toaster.negative('Failed to export workflow history');
+      setLoadingState('error');
+    }
+  };
+
+  return (
+    <>
+      <ToasterContainer autoHideDuration={2000} placement="bottom" />
+      <Button
+        $size="mini"
+        kind="secondary"
+        startEnhancer={<MdOutlineCloudDownload size={16} />}
+        onClick={handleExport}
+        endEnhancer={loadingState === 'loading' && <Spinner $size={16} />}
+      >
+        Export JSON
+      </Button>
+    </>
+  );
+}

--- a/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.types.ts
+++ b/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.types.ts
@@ -1,0 +1,6 @@
+export type Props = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+};

--- a/src/views/workflow-history/workflow-history.styles.ts
+++ b/src/views/workflow-history/workflow-history.styles.ts
@@ -8,6 +8,12 @@ const cssStylesObj = {
     display: 'flex',
     flexDirection: 'column',
   },
+  pageHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+  },
   eventsContainer: (theme) => ({
     display: 'flex',
     marginTop: theme.sizing.scale500,

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -19,6 +19,7 @@ import type { WorkflowPageTabContentProps } from '@/views/workflow-page/workflow
 
 import { groupHistoryEvents } from './helpers/group-history-events';
 import WorkflowHistoryCompactEventCard from './workflow-history-compact-event-card/workflow-history-compact-event-card';
+import WorkflowHistoryExportJsonButton from './workflow-history-export-json-button/workflow-history-export-json-button';
 import WorkflowHistoryTimelineGroup from './workflow-history-timeline-group/workflow-history-timeline-group';
 import WorkflowHistoryTimelineLoadMore from './workflow-history-timeline-load-more/workflow-history-timeline-load-more';
 import { cssStyles } from './workflow-history.styles';
@@ -82,7 +83,10 @@ export default function WorkflowHistory({
   return (
     <PageSection>
       <div className={cls.pageContainer}>
-        <HeadingXSmall>Workflow history</HeadingXSmall>
+        <div className={cls.pageHeader}>
+          <HeadingXSmall>Workflow history</HeadingXSmall>
+          <WorkflowHistoryExportJsonButton {...wfhistoryRequestArgs} />
+        </div>
         <div className={cls.eventsContainer}>
           <div role="list" className={cls.compactSection}>
             <Virtuoso


### PR DESCRIPTION
### Summary
Add Export Button that exports the complete workflow history.

### Changes
- create export button component that requests all pages of workflow history and shows loading and disables the button until all history is fetched.
- Fetched data is then aggregated into single array of events and downloaded as JSON file.

### Screenshots
![Gif 2024-09-30 at 08 34 12](https://github.com/user-attachments/assets/c84fcc81-45ea-4949-9ed8-a7d2903818fd)
