### PR TITLE
Workflow history filters

### DIFF
--- a/src/components/page-filters/__fixtures__/page-filters.fixtures.ts
+++ b/src/components/page-filters/__fixtures__/page-filters.fixtures.ts
@@ -1,5 +1,7 @@
 import type { PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
 
+import { type PageFilterConfig } from '../page-filters.types';
+
 const defaultParamA = 'valueA1';
 const defaultParamB = 'valueB1';
 
@@ -21,3 +23,21 @@ export const mockQueryParamsValues = {
   paramA: defaultParamA,
   paramB: defaultParamB,
 };
+
+export const mockFiltersConfig: [
+  PageFilterConfig<typeof mockPageQueryParamConfig, { paramA: string }>,
+  PageFilterConfig<typeof mockPageQueryParamConfig, { paramB: string }>,
+] = [
+  {
+    id: 'filterA',
+    getValue: (v) => ({ paramA: v.paramA }),
+    formatValue: (v) => v,
+    component: () => 'FilterA',
+  },
+  {
+    id: 'filterB',
+    getValue: (v) => ({ paramB: v.paramB }),
+    formatValue: (v) => v,
+    component: () => 'FilterB',
+  },
+];

--- a/src/components/page-filters/__tests__/page-filters.test.tsx
+++ b/src/components/page-filters/__tests__/page-filters.test.tsx
@@ -8,65 +8,25 @@ import { type PageQueryParamValues } from '@/hooks/use-page-query-params/use-pag
 import {
   mockQueryParamsValues,
   mockPageQueryParamConfig,
+  mockFiltersConfig,
 } from '../__fixtures__/page-filters.fixtures';
 import PageFilters from '../page-filters';
-import {
-  type PageFilterComponentProps,
-  type PageFilterConfig,
-} from '../page-filters.types';
+import { type Props as PageFiltersToggleProps } from '../page-filters-toggle/page-filters-toggle.types';
 
 const mockSetQueryParams = jest.fn();
 jest.mock('../../../hooks/use-page-query-params/use-page-query-params', () =>
   jest.fn(() => [mockQueryParamsValues, mockSetQueryParams])
 );
 
-const MockFilterA = ({
-  value,
-  setValue,
-}: PageFilterComponentProps<{ paramA: string }>) => {
-  return (
-    <div>
-      <div>Value 1: {value.paramA}</div>
-      <div
-        data-testid="change-filters"
-        onClick={() => setValue({ paramA: 'valueA2' })}
-      />
-    </div>
-  );
-};
+jest.mock('../page-filters-fields/page-filters-fields', () =>
+  jest.fn(() => <div data-testid="filter-fields">Filter Fields</div>)
+);
 
-const MockFilterB = ({
-  value,
-  setValue,
-}: PageFilterComponentProps<{ paramB: string }>) => {
-  return (
-    <div>
-      <div>Value 2: {value.paramB}</div>
-      <div
-        data-testid="change-filters"
-        onClick={() => setValue({ paramB: 'valueB2' })}
-      />
-    </div>
-  );
-};
-
-const MOCK_FILTERS_CONFIG: [
-  PageFilterConfig<typeof mockPageQueryParamConfig, { paramA: string }>,
-  PageFilterConfig<typeof mockPageQueryParamConfig, { paramB: string }>,
-] = [
-  {
-    id: 'filterA',
-    getValue: (v) => ({ paramA: v.paramA }),
-    formatValue: (v) => v,
-    component: MockFilterA,
-  },
-  {
-    id: 'filterB',
-    getValue: (v) => ({ paramB: v.paramB }),
-    formatValue: (v) => v,
-    component: MockFilterB,
-  },
-];
+jest.mock('../page-filters-toggle/page-filters-toggle', () =>
+  jest.fn((props: PageFiltersToggleProps) => (
+    <button onClick={props.onClick}>Filters Button</button>
+  ))
+);
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -88,43 +48,15 @@ describe('PageFilters', () => {
   it('should show filters when Filters button is clicked, and modify additional filters', async () => {
     setup({});
 
-    const filtersButton = await screen.findByText('Filters');
+    const filtersButton = await screen.findByRole('button', {
+      name: 'Filters Button',
+    });
 
     act(() => {
       fireEvent.click(filtersButton);
     });
 
-    const filtersButtons = await screen.findAllByTestId('change-filters');
-    expect(filtersButtons).toHaveLength(2);
-
-    act(() => {
-      fireEvent.click(filtersButtons[0]);
-    });
-
-    expect(mockSetQueryParams).toHaveBeenCalledWith({ paramA: 'valueA2' });
-  });
-
-  it('should reset filters when clear filters button is pressed', async () => {
-    setup({
-      valuesOverrides: { paramA: 'valueA2', paramB: 'valueB2' },
-    });
-
-    const filtersButton = await screen.findByText('Filters (2)');
-
-    act(() => {
-      fireEvent.click(filtersButton);
-    });
-
-    const clearFiltersButton = await screen.findByText('Clear filters');
-
-    act(() => {
-      fireEvent.click(clearFiltersButton);
-    });
-
-    expect(mockSetQueryParams).toHaveBeenCalledWith({
-      paramA: undefined,
-      paramB: undefined,
-    });
+    expect(screen.getByTestId('filter-fields')).toBeInTheDocument();
   });
 });
 
@@ -148,7 +80,7 @@ function setup({
     <PageFilters
       searchQueryParamKey="search"
       searchPlaceholder="placeholder"
-      pageFiltersConfig={MOCK_FILTERS_CONFIG}
+      pageFiltersConfig={mockFiltersConfig}
       pageQueryParamsConfig={mockPageQueryParamConfig}
     />
   );

--- a/src/components/page-filters/hooks/use-page-filters.ts
+++ b/src/components/page-filters/hooks/use-page-filters.ts
@@ -1,0 +1,58 @@
+import { useMemo, useCallback } from 'react';
+
+import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
+import {
+  type PageQueryParams,
+  type PageQueryParamKeys,
+  type PageQueryParamValues,
+} from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+import { type PageFilterConfig } from '../page-filters.types';
+
+export default function usePageFilters<P extends PageQueryParams>({
+  pageFiltersConfig,
+  pageQueryParamsConfig,
+}: {
+  pageFiltersConfig: Array<PageFilterConfig<P, any>>;
+  pageQueryParamsConfig: P;
+}) {
+  const [queryParams, setQueryParams] = usePageQueryParams(
+    pageQueryParamsConfig,
+    { pageRerender: false }
+  );
+
+  const activeFiltersCount = useMemo(() => {
+    const configsByKey = Object.fromEntries(
+      pageQueryParamsConfig.map((c) => [c.key, c])
+    );
+    return pageFiltersConfig.filter((pageFilter) =>
+      Object.keys(pageFilter.getValue(queryParams)).every(
+        (queryParamKey: PageQueryParamKeys<P>) =>
+          queryParams[queryParamKey] &&
+          queryParams[queryParamKey] !==
+            configsByKey[queryParamKey].defaultValue
+      )
+    ).length;
+  }, [pageFiltersConfig, pageQueryParamsConfig, queryParams]);
+
+  const resetAllFilters = useCallback(() => {
+    const emptyQueryParamsObject = pageQueryParamsConfig.reduce(
+      (acc, config) => ({
+        ...acc,
+        [config.key]: undefined,
+      }),
+      {}
+    ) as PageQueryParamValues<P>;
+
+    setQueryParams(
+      pageFiltersConfig.reduce((acc, pageFilter) => {
+        return {
+          ...acc,
+          ...pageFilter.getValue(emptyQueryParamsObject),
+        };
+      }, {})
+    );
+  }, [pageFiltersConfig, pageQueryParamsConfig, setQueryParams]);
+
+  return { resetAllFilters, activeFiltersCount, queryParams, setQueryParams };
+}

--- a/src/components/page-filters/page-filters-fields/__tests__/page-filters-fields.test.tsx
+++ b/src/components/page-filters/page-filters-fields/__tests__/page-filters-fields.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { render, screen, act, fireEvent } from '@/test-utils/rtl';
+
+import { type PageQueryParamValues } from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+import {
+  type mockPageQueryParamConfig,
+  mockQueryParamsValues,
+} from '../../__fixtures__/page-filters.fixtures';
+import {
+  type PageFilterComponentProps,
+  type PageFilterConfig,
+} from '../../page-filters.types';
+import PageFiltersFields from '../page-filters-fields';
+
+const MockFilterA = ({
+  value,
+  setValue,
+}: PageFilterComponentProps<{ paramA: string }>) => {
+  return (
+    <div>
+      <div>Value 1: {value.paramA}</div>
+      <div
+        data-testid="change-filters"
+        onClick={() => setValue({ paramA: 'valueA2' })}
+      />
+    </div>
+  );
+};
+
+const MockFilterB = ({
+  value,
+  setValue,
+}: PageFilterComponentProps<{ paramB: string }>) => {
+  return (
+    <div>
+      <div>Value 2: {value.paramB}</div>
+      <div
+        data-testid="change-filters"
+        onClick={() => setValue({ paramB: 'valueB2' })}
+      />
+    </div>
+  );
+};
+
+export const mockFiltersConfig: [
+  PageFilterConfig<typeof mockPageQueryParamConfig, { paramA: string }>,
+  PageFilterConfig<typeof mockPageQueryParamConfig, { paramB: string }>,
+] = [
+  {
+    id: 'filterA',
+    getValue: (v) => ({ paramA: v.paramA }),
+    formatValue: (v) => v,
+    component: MockFilterA,
+  },
+  {
+    id: 'filterB',
+    getValue: (v) => ({ paramB: v.paramB }),
+    formatValue: (v) => v,
+    component: MockFilterB,
+  },
+];
+
+describe('PageFiltersFields', () => {
+  it('should reset filters when clear filters button is pressed', async () => {
+    const { mockedResetAllFilters } = setup({
+      valuesOverrides: { paramA: 'valueA2', paramB: 'valueB2' },
+    });
+
+    const clearFiltersButton = await screen.findByText('Clear filters');
+
+    act(() => {
+      fireEvent.click(clearFiltersButton);
+    });
+
+    expect(mockedResetAllFilters).toHaveBeenCalled();
+  });
+
+  it('should call setQueryParams when filter setValue is called', async () => {
+    const { mockedSetQueryParams } = setup({});
+
+    const filtersButtons = await screen.findAllByTestId('change-filters');
+    expect(filtersButtons).toHaveLength(2);
+
+    act(() => {
+      fireEvent.click(filtersButtons[0]);
+    });
+
+    expect(mockedSetQueryParams).toHaveBeenCalledWith({ paramA: 'valueA2' });
+  });
+});
+
+function setup({
+  valuesOverrides,
+}: {
+  valuesOverrides?: Partial<
+    PageQueryParamValues<typeof mockPageQueryParamConfig>
+  >;
+}) {
+  const mockedResetAllFilters = jest.fn();
+  const mockedSetQueryParams = jest.fn();
+
+  render(
+    <PageFiltersFields
+      pageFiltersConfig={mockFiltersConfig}
+      resetAllFilters={mockedResetAllFilters}
+      setQueryParams={mockedSetQueryParams}
+      queryParams={{ ...mockQueryParamsValues, ...valuesOverrides }}
+    />
+  );
+  return { mockedResetAllFilters, mockedSetQueryParams };
+}

--- a/src/components/page-filters/page-filters-fields/page-filters-fields.styles.ts
+++ b/src/components/page-filters/page-filters-fields/page-filters-fields.styles.ts
@@ -1,0 +1,41 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import type { ButtonOverrides } from 'baseui/button';
+import { type InputOverrides } from 'baseui/input';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  SearchFiltersContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }) => ({
+      display: 'flex',
+      flexDirection: 'column',
+      flexWrap: 'wrap',
+      gap: $theme.sizing.scale500,
+      marginBottom: $theme.sizing.scale700,
+      [$theme.mediaQuery.medium]: {
+        flexDirection: 'row',
+      },
+    })
+  ),
+  SearchFilterContainer: createStyled('div', {
+    flexGrow: 2,
+    flexBasis: 0,
+  }),
+};
+
+export const overrides = {
+  clearFiltersButton: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        whiteSpace: 'nowrap',
+        flexGrow: 2,
+        height: $theme.sizing.scale950,
+        [$theme.mediaQuery.medium]: {
+          flexGrow: 0,
+          alignSelf: 'flex-end',
+          marginTop: $theme.sizing.scale700,
+        },
+      }),
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/components/page-filters/page-filters-fields/page-filters-fields.styles.ts
+++ b/src/components/page-filters/page-filters-fields/page-filters-fields.styles.ts
@@ -1,6 +1,5 @@
 import { styled as createStyled, type Theme } from 'baseui';
 import type { ButtonOverrides } from 'baseui/button';
-import { type InputOverrides } from 'baseui/input';
 import { type StyleObject } from 'styletron-react';
 
 export const styled = {

--- a/src/components/page-filters/page-filters-fields/page-filters-fields.tsx
+++ b/src/components/page-filters/page-filters-fields/page-filters-fields.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { Button, KIND, SIZE } from 'baseui/button';
+import { Delete } from 'baseui/icon';
+
+import { type PageQueryParams } from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+import { styled, overrides } from './page-filters-fields.styles';
+import { type Props } from './page-filters-fields.types';
+
+export default function PageFiltersFields<P extends PageQueryParams>({
+  pageFiltersConfig,
+  resetAllFilters,
+  queryParams,
+  setQueryParams,
+}: Props<P>) {
+  return (
+    <styled.SearchFiltersContainer>
+      {pageFiltersConfig?.map((filter) => {
+        return (
+          <styled.SearchFilterContainer key={filter.id}>
+            <filter.component
+              value={filter.getValue(queryParams)}
+              setValue={(newValue) =>
+                setQueryParams(filter.formatValue(newValue))
+              }
+            />
+          </styled.SearchFilterContainer>
+        );
+      })}
+      <Button
+        size={SIZE.compact}
+        kind={KIND.tertiary}
+        onClick={resetAllFilters}
+        startEnhancer={Delete}
+        overrides={overrides.clearFiltersButton}
+      >
+        Clear filters
+      </Button>
+    </styled.SearchFiltersContainer>
+  );
+}

--- a/src/components/page-filters/page-filters-fields/page-filters-fields.types.ts
+++ b/src/components/page-filters/page-filters-fields/page-filters-fields.types.ts
@@ -1,0 +1,14 @@
+import {
+  type PageQueryParamSetter,
+  type PageQueryParamValues,
+  type PageQueryParams,
+} from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+import { type PageFilterConfig } from '../page-filters.types';
+
+export type Props<P extends PageQueryParams> = {
+  pageFiltersConfig: Array<PageFilterConfig<P, any>>;
+  resetAllFilters: () => void;
+  queryParams: PageQueryParamValues<P>;
+  setQueryParams: PageQueryParamSetter<P>;
+};

--- a/src/components/page-filters/page-filters-toggle/__tests__/page-filters-toggle.test.tsx
+++ b/src/components/page-filters/page-filters-toggle/__tests__/page-filters-toggle.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { render, screen, act, fireEvent } from '@/test-utils/rtl';
+
+import PageFiltersToggle from '../page-filters-toggle';
+import { type Props } from '../page-filters-toggle.types';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PageFiltersToggle', () => {
+  it('should call onClick prop on clicking the button', async () => {
+    const { mockedOnClick } = setup({});
+
+    const filtersButton = await screen.findByText('Filters');
+
+    act(() => {
+      fireEvent.click(filtersButton);
+    });
+
+    expect(mockedOnClick).toHaveBeenCalled();
+  });
+  it('should show filters count', async () => {
+    setup({ activeFiltersCount: 2 });
+    expect(screen.getByText('Filters (2)')).toBeInTheDocument();
+  });
+});
+
+function setup(props: Partial<Props>) {
+  const mockedOnClick = jest.fn();
+  render(
+    <PageFiltersToggle
+      activeFiltersCount={0}
+      isActive={true}
+      onClick={mockedOnClick}
+      {...props}
+    />
+  );
+  return { mockedOnClick };
+}

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.styles.ts
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.styles.ts
@@ -1,15 +1,11 @@
-import { type Theme } from 'baseui';
 import type { ButtonOverrides } from 'baseui/button';
-import { type StyleObject } from 'styletron-react';
 
 export const overrides = {
   filtersButton: {
     Root: {
-      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+      style: {
         whiteSpace: 'nowrap',
-        height: $theme.sizing.scale950,
-        ...$theme.typography.LabelSmall,
-      }),
+      },
     },
   } satisfies ButtonOverrides,
 };

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.styles.ts
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.styles.ts
@@ -1,0 +1,15 @@
+import { type Theme } from 'baseui';
+import type { ButtonOverrides } from 'baseui/button';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  filtersButton: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        whiteSpace: 'nowrap',
+        height: $theme.sizing.scale950,
+        ...$theme.typography.LabelSmall,
+      }),
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
@@ -16,7 +16,7 @@ export default function PageFiltersToggle({
       $size="compact"
       kind={isActive ? KIND.primary : KIND.secondary}
       onClick={onClick}
-      startEnhancer={Filter}
+      startEnhancer={<Filter size={16} />}
       overrides={overrides.filtersButton}
     >
       {activeFiltersCount === 0 ? 'Filters' : `Filters (${activeFiltersCount})`}

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Button, KIND } from 'baseui/button';
+import { Filter } from 'baseui/icon';
+
+import { overrides } from './page-filters-toggle.styles';
+import { type Props } from './page-filters-toggle.types';
+
+export default function PageFiltersToggle({
+  activeFiltersCount,
+  onClick,
+  isActive,
+}: Props) {
+  return (
+    <Button
+      kind={isActive ? KIND.primary : KIND.secondary}
+      onClick={onClick}
+      startEnhancer={Filter}
+      overrides={overrides.filtersButton}
+    >
+      {activeFiltersCount === 0 ? 'Filters' : `Filters (${activeFiltersCount})`}
+    </Button>
+  );
+}

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.tsx
@@ -13,6 +13,7 @@ export default function PageFiltersToggle({
 }: Props) {
   return (
     <Button
+      $size="compact"
       kind={isActive ? KIND.primary : KIND.secondary}
       onClick={onClick}
       startEnhancer={Filter}

--- a/src/components/page-filters/page-filters-toggle/page-filters-toggle.types.ts
+++ b/src/components/page-filters/page-filters-toggle/page-filters-toggle.types.ts
@@ -1,0 +1,7 @@
+import { type ButtonProps } from 'baseui/button';
+
+export type Props = {
+  onClick: ButtonProps['onClick'];
+  activeFiltersCount: number;
+  isActive: boolean;
+};

--- a/src/components/page-filters/page-filters.tsx
+++ b/src/components/page-filters/page-filters.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState } from 'react';
 
-import { Button, KIND, SIZE } from 'baseui/button';
-import { Search, Filter, Delete } from 'baseui/icon';
+import { Search } from 'baseui/icon';
 import { Input } from 'baseui/input';
 
-import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import {
   type PageQueryParams,
   type PageQueryParamKeys,
   type PageQueryParamSetterValues,
-  type PageQueryParamValues,
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
 
+import usePageFilters from './hooks/use-page-filters';
+import PageFiltersFields from './page-filters-fields/page-filters-fields';
+import PageFiltersToggle from './page-filters-toggle/page-filters-toggle';
 import { styled, overrides } from './page-filters.styles';
 import { type Props } from './page-filters.types';
 
@@ -25,43 +25,9 @@ export default function PageFilters<
   pageQueryParamsConfig,
 }: Props<P, K>) {
   const [areFiltersShown, setAreFiltersShown] = useState(false);
-  const [queryParams, setQueryParams] = usePageQueryParams(
-    pageQueryParamsConfig,
-    { pageRerender: false }
-  );
 
-  const activeFiltersCount = useMemo(() => {
-    const configsByKey = Object.fromEntries(
-      pageQueryParamsConfig.map((c) => [c.key, c])
-    );
-    return pageFiltersConfig.filter((pageFilter) =>
-      Object.keys(pageFilter.getValue(queryParams)).every(
-        (queryParamKey: PageQueryParamKeys<P>) =>
-          queryParams[queryParamKey] &&
-          queryParams[queryParamKey] !==
-            configsByKey[queryParamKey].defaultValue
-      )
-    ).length;
-  }, [pageFiltersConfig, pageQueryParamsConfig, queryParams]);
-
-  const resetAllFilters = useCallback(() => {
-    const emptyQueryParamsObject = pageQueryParamsConfig.reduce(
-      (acc, config) => ({
-        ...acc,
-        [config.key]: undefined,
-      }),
-      {}
-    ) as PageQueryParamValues<P>;
-
-    setQueryParams(
-      pageFiltersConfig.reduce((acc, pageFilter) => {
-        return {
-          ...acc,
-          ...pageFilter.getValue(emptyQueryParamsObject),
-        };
-      }, {})
-    );
-  }, [pageFiltersConfig, pageQueryParamsConfig, setQueryParams]);
+  const { resetAllFilters, activeFiltersCount, queryParams, setQueryParams } =
+    usePageFilters<P>({ pageFiltersConfig, pageQueryParamsConfig });
 
   return (
     <>
@@ -78,43 +44,21 @@ export default function PageFilters<
           clearOnEscape
           overrides={overrides.searchInput}
         />
-        <Button
-          kind={areFiltersShown ? KIND.primary : KIND.secondary}
+        <PageFiltersToggle
+          isActive={areFiltersShown}
           onClick={() => {
             setAreFiltersShown((value) => !value);
           }}
-          startEnhancer={Filter}
-          overrides={overrides.filtersButton}
-        >
-          {activeFiltersCount === 0
-            ? 'Filters'
-            : `Filters (${activeFiltersCount})`}
-        </Button>
+          activeFiltersCount={activeFiltersCount}
+        />
       </styled.SearchInputContainer>
       {areFiltersShown && (
-        <styled.SearchFiltersContainer>
-          {pageFiltersConfig?.map((filter) => {
-            return (
-              <styled.SearchFilterContainer key={filter.id}>
-                <filter.component
-                  value={filter.getValue(queryParams)}
-                  setValue={(newValue) =>
-                    setQueryParams(filter.formatValue(newValue))
-                  }
-                />
-              </styled.SearchFilterContainer>
-            );
-          })}
-          <Button
-            size={SIZE.compact}
-            kind={KIND.tertiary}
-            onClick={resetAllFilters}
-            startEnhancer={Delete}
-            overrides={overrides.clearFiltersButton}
-          >
-            Clear filters
-          </Button>
-        </styled.SearchFiltersContainer>
+        <PageFiltersFields
+          pageFiltersConfig={pageFiltersConfig}
+          resetAllFilters={resetAllFilters}
+          queryParams={queryParams}
+          setQueryParams={setQueryParams}
+        />
       )}
     </>
   );

--- a/src/utils/data-formatters/format-enum.ts
+++ b/src/utils/data-formatters/format-enum.ts
@@ -63,6 +63,7 @@ type ToPascalCase<T extends string> = T extends `${infer First}_${infer Rest}`
   : Capitalize<Lowercase<T>>;
 
 // Utility type to check if a string contains "INVALID" and exclude it from the type
+// eslint-disable-next-line no-unused-vars
 type ExcludeInvalid<T extends string> = T extends `${infer _}INVALID${infer _}`
   ? never
   : T;

--- a/src/utils/data-formatters/format-enum.ts
+++ b/src/utils/data-formatters/format-enum.ts
@@ -63,7 +63,7 @@ type ToPascalCase<T extends string> = T extends `${infer First}_${infer Rest}`
   : Capitalize<Lowercase<T>>;
 
 // Utility type to check if a string contains "INVALID" and exclude it from the type
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ExcludeInvalid<T extends string> = T extends `${infer _}INVALID${infer _}`
   ? never
   : T;

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -3,8 +3,9 @@ import { Suspense } from 'react';
 import { HttpResponse } from 'msw';
 import { VirtuosoMockContext } from 'react-virtuoso';
 
-import { act, render, screen } from '@/test-utils/rtl';
+import { act, render, screen, userEvent } from '@/test-utils/rtl';
 
+import { type Props as PageFiltersToggleProps } from '@/components/page-filters/page-filters-toggle/page-filters-toggle.types';
 import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
 
 import { completedActivityTaskEvents } from '../__fixtures__/workflow-history-activity-events';
@@ -23,6 +24,25 @@ jest.mock(
   '../workflow-history-timeline-load-more/workflow-history-timeline-load-more',
   () => jest.fn(() => <div>Load more</div>)
 );
+
+jest.mock(
+  '@/components/page-filters/page-filters-toggle/page-filters-toggle',
+  () =>
+    jest.fn((props: PageFiltersToggleProps) => (
+      <button onClick={props.onClick}>Filter Toggle</button>
+    ))
+);
+
+jest.mock(
+  '@/components/page-filters/page-filters-fields/page-filters-fields',
+  () => jest.fn(() => <div>Filter Fields</div>)
+);
+
+jest.mock('@/components/page-filters/hooks/use-page-filters', () =>
+  jest.fn().mockReturnValue({})
+);
+
+jest.mock('../config/workflow-history-filters.config', () => []);
 
 describe('WorkflowHistory', () => {
   it('renders page correctly', async () => {
@@ -53,6 +73,21 @@ describe('WorkflowHistory', () => {
         'Failed to fetch workflow history'
       );
     }
+  });
+  it('should render the page initially with filters hidden', async () => {
+    setup({});
+    expect(screen.queryByText('Filter Fields')).not.toBeInTheDocument();
+  });
+
+  it('should show filters on executing toggle button onClick', async () => {
+    setup({});
+    const toggleButton = await screen.findByText('Filter Toggle');
+
+    await act(() => {
+      userEvent.click(toggleButton);
+    });
+
+    expect(await screen.findByText('Filter Fields')).toBeInTheDocument();
   });
 });
 

--- a/src/views/workflow-history/config/workflow-history-filters.config.ts
+++ b/src/views/workflow-history/config/workflow-history-filters.config.ts
@@ -1,0 +1,31 @@
+import filterEventsByEventStatus from '../workflow-history-filters-status/helpers/filter-events-by-event-status';
+import WorkflowHistoryFiltersStatus from '../workflow-history-filters-status/workflow-history-filters-status';
+import { type WorkflowHistoryFiltersStatusValue } from '../workflow-history-filters-status/workflow-history-filters-status.types';
+import filterEventsByEventType from '../workflow-history-filters-type/helpers/filter-events-by-event-type';
+import WorkflowHistoryFiltersType from '../workflow-history-filters-type/workflow-history-filters-type';
+import { type WorkflowHistoryFiltersTypeValue } from '../workflow-history-filters-type/workflow-history-filters-type.types';
+import { type WorkflowHistoryFilterConfig } from '../workflow-history.types';
+
+const workflowHistoryFiltersConfig: [
+  WorkflowHistoryFilterConfig<WorkflowHistoryFiltersTypeValue>,
+  WorkflowHistoryFilterConfig<WorkflowHistoryFiltersStatusValue>,
+] = [
+  {
+    id: 'historyEventType',
+    getValue: (v) => ({ historyEventType: v.historyEventType }),
+    formatValue: (v) => v,
+    component: WorkflowHistoryFiltersType,
+    filterFunc: filterEventsByEventType,
+    filterTarget: 'event',
+  },
+  {
+    id: 'historyEventStatus',
+    getValue: (v) => ({ historyEventStatus: v.historyEventStatus }),
+    formatValue: (v) => v,
+    component: WorkflowHistoryFiltersStatus,
+    filterFunc: filterEventsByEventStatus,
+    filterTarget: 'group',
+  },
+] as const;
+
+export default workflowHistoryFiltersConfig;

--- a/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.tsx
+++ b/src/views/workflow-history/workflow-history-export-json-button/workflow-history-export-json-button.tsx
@@ -61,7 +61,7 @@ export default function WorkflowHistoryExportJsonButton(props: Props) {
     <>
       <ToasterContainer autoHideDuration={2000} placement="bottom" />
       <Button
-        $size="mini"
+        $size="compact"
         kind="secondary"
         startEnhancer={<MdOutlineCloudDownload size={16} />}
         onClick={handleExport}

--- a/src/views/workflow-history/workflow-history-filters-status/__tests__/workflow-history-filters-status.test.tsx
+++ b/src/views/workflow-history/workflow-history-filters-status/__tests__/workflow-history-filters-status.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { render, screen, fireEvent, act } from '@/test-utils/rtl';
+
+import WorkflowHistoryFiltersType from '../workflow-history-filters-status';
+import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS } from '../workflow-history-filters-status.constants';
+import { type WorkflowHistoryFiltersStatusValue } from '../workflow-history-filters-status.types';
+
+describe('WorkflowHistoryFiltersStatus', () => {
+  it('renders without errors', () => {
+    setup({});
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('displays all the options in the select component', () => {
+    setup({});
+    const selectFilter = screen.getByRole('combobox');
+    act(() => {
+      fireEvent.click(selectFilter);
+    });
+    WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS.forEach(({ label }) =>
+      expect(screen.getByText(label)).toBeInTheDocument()
+    );
+  });
+
+  it('calls the setQueryParams function when an option is selected', () => {
+    const { mockSetValue } = setup({});
+    const selectFilter = screen.getByRole('combobox');
+    act(() => {
+      fireEvent.click(selectFilter);
+    });
+    const completedOption = screen.getByText('Completed');
+    act(() => {
+      fireEvent.click(completedOption);
+    });
+    expect(mockSetValue).toHaveBeenCalledWith({
+      historyEventStatus: 'COMPLETED',
+    } as WorkflowHistoryFiltersStatusValue);
+  });
+
+  it('calls the setQueryParams function when the filter is cleared', () => {
+    const { mockSetValue } = setup({
+      overrides: {
+        historyEventStatus: 'COMPLETED',
+      },
+    });
+    const clearButton = screen.getByLabelText('Clear value');
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+    expect(mockSetValue).toHaveBeenCalledWith({ historyEventType: undefined });
+  });
+});
+
+function setup({
+  overrides,
+}: {
+  overrides?: WorkflowHistoryFiltersStatusValue;
+}) {
+  const mockSetValue = jest.fn();
+  render(
+    <WorkflowHistoryFiltersType
+      value={{
+        historyEventStatus: undefined,
+        ...overrides,
+      }}
+      setValue={mockSetValue}
+    />
+  );
+
+  return { mockSetValue };
+}

--- a/src/views/workflow-history/workflow-history-filters-status/helpers/filter-events-by-event-status.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/helpers/filter-events-by-event-status.ts
@@ -1,0 +1,14 @@
+import { type HistoryEventsGroup } from '../../workflow-history.types';
+import { type WorkflowHistoryFiltersStatusValue } from '../workflow-history-filters-status.types';
+
+export default function filterEventsByEventStatus(
+  group: HistoryEventsGroup,
+  value: WorkflowHistoryFiltersStatusValue
+) {
+  const selectedGroupStatus = value.historyEventStatus;
+  if (!selectedGroupStatus) return true;
+
+  if (group.status === selectedGroupStatus) return true;
+
+  return false;
+}

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants.ts
@@ -1,0 +1,29 @@
+import { WORKFLOW_EVENT_STATUS } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.constants';
+import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+
+export const WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS = [
+  {
+    label: 'On Going',
+    id: WORKFLOW_EVENT_STATUS.ONGOING,
+  },
+
+  {
+    label: 'Waiting',
+    id: WORKFLOW_EVENT_STATUS.WAITING,
+  },
+  {
+    label: 'Canceled',
+    id: WORKFLOW_EVENT_STATUS.CANCELED,
+  },
+  {
+    label: 'Failed',
+    id: WORKFLOW_EVENT_STATUS.FAILED,
+  },
+  {
+    label: 'Completed',
+    id: WORKFLOW_EVENT_STATUS.COMPLETED,
+  },
+] as const satisfies {
+  id: WorkflowEventStatus;
+  label: string;
+}[];

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.styles.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.styles.ts
@@ -1,0 +1,18 @@
+import { type Theme } from 'baseui';
+import type { FormControlOverrides } from 'baseui/form-control/types';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  selectFormControl: {
+    Label: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        ...$theme.typography.LabelXSmall,
+      }),
+    },
+    ControlContainer: {
+      style: (): StyleObject => ({
+        margin: '0px',
+      }),
+    },
+  } satisfies FormControlOverrides,
+};

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.tsx
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.tsx
@@ -1,0 +1,44 @@
+'use client';
+import React from 'react';
+
+import { FormControl } from 'baseui/form-control';
+import { Select, SIZE } from 'baseui/select';
+
+import { type PageFilterComponentProps } from '@/components/page-filters/page-filters.types';
+
+import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+
+import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS } from './workflow-history-filters-status.constants';
+import { overrides } from './workflow-history-filters-status.styles';
+import { type WorkflowHistoryFiltersStatusValue } from './workflow-history-filters-status.types';
+
+export default function WorkflowHistoryFiltersStatus({
+  value,
+  setValue,
+}: PageFilterComponentProps<WorkflowHistoryFiltersStatusValue>) {
+  const statusOptionValue =
+    WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS.filter(
+      (option) => option.id === value.historyEventStatus
+    );
+
+  return (
+    <FormControl label="Status" overrides={overrides.selectFormControl}>
+      <Select
+        size={SIZE.compact}
+        value={statusOptionValue}
+        options={WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS}
+        onChange={(params) =>
+          setValue({
+            historyEventStatus:
+              WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS.find(
+                (opt) => opt.id === params.value[0]?.id
+              )
+                ? (String(params.value[0]?.id) as WorkflowEventStatus)
+                : undefined,
+          })
+        }
+        placeholder="All"
+      />
+    </FormControl>
+  );
+}

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types.ts
@@ -1,0 +1,5 @@
+import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+
+export type WorkflowHistoryFiltersStatusValue = {
+  historyEventStatus: WorkflowEventStatus | undefined;
+};

--- a/src/views/workflow-history/workflow-history-filters-type/__tests__/workflow-history-filters-type.test.tsx
+++ b/src/views/workflow-history/workflow-history-filters-type/__tests__/workflow-history-filters-type.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { render, screen, fireEvent, act } from '@/test-utils/rtl';
+
+import WorkflowHistoryFiltersType from '../workflow-history-filters-type';
+import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS } from '../workflow-history-filters-type.constants';
+import { type WorkflowHistoryFiltersTypeValue } from '../workflow-history-filters-type.types';
+
+describe('WorkflowHistoryFiltersType', () => {
+  it('renders without errors', () => {
+    setup({});
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('displays all the options in the select component', () => {
+    setup({});
+    const selectFilter = screen.getByRole('combobox');
+    act(() => {
+      fireEvent.click(selectFilter);
+    });
+    WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS.forEach(({ label }) =>
+      expect(screen.getByText(label)).toBeInTheDocument()
+    );
+  });
+
+  it('calls the setQueryParams function when an option is selected', () => {
+    const { mockSetValue } = setup({});
+    const selectFilter = screen.getByRole('combobox');
+    act(() => {
+      fireEvent.click(selectFilter);
+    });
+    const decisionOption = screen.getByText('Decision');
+    act(() => {
+      fireEvent.click(decisionOption);
+    });
+    expect(mockSetValue).toHaveBeenCalledWith({
+      historyEventType: 'DECISION',
+    });
+  });
+
+  it('calls the setQueryParams function when the filter is cleared', () => {
+    const { mockSetValue } = setup({
+      overrides: {
+        historyEventType: 'ACTIVITY',
+      },
+    });
+    const clearButton = screen.getByLabelText('Clear value');
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+    expect(mockSetValue).toHaveBeenCalledWith({ historyEventType: undefined });
+  });
+});
+
+function setup({ overrides }: { overrides?: WorkflowHistoryFiltersTypeValue }) {
+  const mockSetValue = jest.fn();
+  render(
+    <WorkflowHistoryFiltersType
+      value={{
+        historyEventType: undefined,
+        ...overrides,
+      }}
+      setValue={mockSetValue}
+    />
+  );
+
+  return { mockSetValue };
+}

--- a/src/views/workflow-history/workflow-history-filters-type/helpers/filter-events-by-event-type.ts
+++ b/src/views/workflow-history/workflow-history-filters-type/helpers/filter-events-by-event-type.ts
@@ -1,0 +1,20 @@
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPE_TO_ATTRS_MAP } from '../workflow-history-filters-type.constants';
+import { type WorkflowHistoryFiltersTypeValue } from '../workflow-history-filters-type.types';
+
+const filterEventsByEventType = function (
+  event: HistoryEvent,
+  value: WorkflowHistoryFiltersTypeValue
+) {
+  const attr = event.attributes;
+  if (value.historyEventType === undefined) return true;
+  const selectedAttributes =
+    WORKFLOW_HISTORY_EVENT_FILTERING_TYPE_TO_ATTRS_MAP[
+      value.historyEventType
+    ] || [];
+  if (selectedAttributes.includes(attr)) return true;
+  return false;
+};
+
+export default filterEventsByEventType;

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants.ts
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants.ts
@@ -1,0 +1,96 @@
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+import { type WokflowHistoryEventFilteringType } from './workflow-history-filters-type.types';
+
+export const WORKFLOW_HISTORY_EVENT_FILTERING_TYPES: WokflowHistoryEventFilteringType[] =
+  ['ACTIVITY', 'CHILDWORKFLOW', 'DECISION', 'SIGNAL', 'TIMER', 'WORKFLOW'];
+
+export const WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS = [
+  {
+    label: 'Decision',
+    id: 'DECISION',
+  },
+  {
+    label: 'Activity',
+    id: 'ACTIVITY',
+  },
+  {
+    label: 'Signal',
+    id: 'SIGNAL',
+  },
+  {
+    label: 'Timer',
+    id: 'TIMER',
+  },
+  {
+    label: 'Child Workflow',
+    id: 'CHILDWORKFLOW',
+  },
+  {
+    label: 'Workflow',
+    id: 'WORKFLOW',
+  },
+] as const satisfies {
+  id: WokflowHistoryEventFilteringType;
+  label: string;
+}[];
+
+export const WORKFLOW_HISTORY_EVENT_FILTERING_TYPE_TO_ATTRS_MAP: Record<
+  WokflowHistoryEventFilteringType,
+  HistoryEvent['attributes'][]
+> = {
+  ACTIVITY: [
+    'activityTaskScheduledEventAttributes',
+    'activityTaskStartedEventAttributes',
+    'activityTaskCompletedEventAttributes',
+    'activityTaskFailedEventAttributes',
+    'activityTaskTimedOutEventAttributes',
+    'activityTaskCanceledEventAttributes',
+    'activityTaskCancelRequestedEventAttributes',
+    'requestCancelActivityTaskFailedEventAttributes',
+  ],
+  DECISION: [
+    'decisionTaskScheduledEventAttributes',
+    'decisionTaskStartedEventAttributes',
+    'decisionTaskCompletedEventAttributes',
+    'decisionTaskFailedEventAttributes',
+    'decisionTaskTimedOutEventAttributes',
+  ],
+  TIMER: [
+    'timerStartedEventAttributes',
+    'timerFiredEventAttributes',
+    'timerCanceledEventAttributes',
+    'cancelTimerFailedEventAttributes',
+  ],
+  CHILDWORKFLOW: [
+    'startChildWorkflowExecutionInitiatedEventAttributes',
+    'startChildWorkflowExecutionFailedEventAttributes',
+    'childWorkflowExecutionStartedEventAttributes',
+    'childWorkflowExecutionCompletedEventAttributes',
+    'childWorkflowExecutionFailedEventAttributes',
+    'childWorkflowExecutionCanceledEventAttributes',
+    'childWorkflowExecutionTimedOutEventAttributes',
+    'childWorkflowExecutionTerminatedEventAttributes',
+  ],
+  SIGNAL: [
+    'signalExternalWorkflowExecutionInitiatedEventAttributes',
+    'signalExternalWorkflowExecutionFailedEventAttributes',
+    'externalWorkflowExecutionSignaledEventAttributes',
+    'workflowExecutionSignaledEventAttributes',
+  ],
+  WORKFLOW: [
+    'requestCancelExternalWorkflowExecutionInitiatedEventAttributes',
+    'requestCancelExternalWorkflowExecutionFailedEventAttributes',
+    'externalWorkflowExecutionCancelRequestedEventAttributes',
+    'workflowExecutionStartedEventAttributes',
+    'workflowExecutionCompletedEventAttributes',
+    'workflowExecutionFailedEventAttributes',
+    'workflowExecutionTimedOutEventAttributes',
+    'markerRecordedEventAttributes',
+    'workflowExecutionTerminatedEventAttributes',
+    'workflowExecutionCancelRequestedEventAttributes',
+    'workflowExecutionCanceledEventAttributes',
+    'workflowExecutionContinuedAsNewEventAttributes',
+    'upsertWorkflowSearchAttributesEventAttributes',
+  ],
+};

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.styles.ts
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.styles.ts
@@ -1,0 +1,18 @@
+import { type Theme } from 'baseui';
+import type { FormControlOverrides } from 'baseui/form-control/types';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  selectFormControl: {
+    Label: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        ...$theme.typography.LabelXSmall,
+      }),
+    },
+    ControlContainer: {
+      style: (): StyleObject => ({
+        margin: '0px',
+      }),
+    },
+  } satisfies FormControlOverrides,
+};

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.tsx
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React from 'react';
+
+import { FormControl } from 'baseui/form-control';
+import { Select, SIZE } from 'baseui/select';
+
+import { type PageFilterComponentProps } from '@/components/page-filters/page-filters.types';
+
+import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS } from './workflow-history-filters-type.constants';
+import { overrides } from './workflow-history-filters-type.styles';
+import {
+  type WokflowHistoryEventFilteringType,
+  type WorkflowHistoryFiltersTypeValue,
+} from './workflow-history-filters-type.types';
+
+export default function WorkflowHistoryFiltersType({
+  value,
+  setValue,
+}: PageFilterComponentProps<WorkflowHistoryFiltersTypeValue>) {
+  const statusOptionValue =
+    WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS.filter(
+      (option) => option.id === value.historyEventType
+    );
+
+  return (
+    <FormControl label="Type" overrides={overrides.selectFormControl}>
+      <Select
+        size={SIZE.compact}
+        value={statusOptionValue}
+        options={WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS}
+        onChange={(params) =>
+          setValue({
+            historyEventType:
+              WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_OPTIONS.find(
+                (opt) => opt.id === params.value[0]?.id
+              )
+                ? (String(
+                    params.value[0]?.id
+                  ) as WokflowHistoryEventFilteringType)
+                : undefined,
+          })
+        }
+        placeholder="All"
+      />
+    </FormControl>
+  );
+}

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.types.ts
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.types.ts
@@ -1,0 +1,12 @@
+export type WokflowHistoryEventFilteringType =
+  | 'DECISION'
+  | 'ACTIVITY'
+  | 'SIGNAL'
+  | 'TIMER'
+  | 'DECISION'
+  | 'CHILDWORKFLOW'
+  | 'WORKFLOW';
+
+export type WorkflowHistoryFiltersTypeValue = {
+  historyEventType: WokflowHistoryEventFilteringType | undefined;
+};

--- a/src/views/workflow-history/workflow-history.styles.ts
+++ b/src/views/workflow-history/workflow-history.styles.ts
@@ -7,6 +7,7 @@ const cssStylesObj = {
   pageContainer: {
     display: 'flex',
     flexDirection: 'column',
+    flex: 1,
   },
   pageHeader: {
     display: 'flex',
@@ -14,6 +15,10 @@ const cssStylesObj = {
     justifyContent: 'space-between',
     flexWrap: 'wrap',
   },
+  headerActions: (theme) => ({
+    display: 'flex',
+    gap: theme.sizing.scale500,
+  }),
   eventsContainer: (theme) => ({
     display: 'flex',
     marginTop: theme.sizing.scale500,
@@ -40,6 +45,11 @@ const cssStylesObj = {
     flexDirection: 'column',
     flex: 1,
   },
+  noResultsContainer: (theme) => ({
+    textAlign: 'center',
+    padding: `${theme.sizing.scale900} 0`,
+    ...theme.typography.LabelSmall,
+  }),
 } satisfies StyletronCSSObject;
 
 export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -1,4 +1,8 @@
 import type { HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
+import { type PageQueryParamValues } from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+import type workflowPageQueryParamsConfig from '../workflow-page/config/workflow-page-query-params.config';
 
 import type { WorkflowEventStatus } from './workflow-history-event-status-badge/workflow-history-event-status-badge.types';
 
@@ -158,3 +162,19 @@ export type SingleHistoryEvent = HistoryEvent & {
     | 'workflowExecutionContinuedAsNewEventAttributes'
     | 'upsertWorkflowSearchAttributesEventAttributes';
 };
+
+export type WorkflowHistoryFilterTarget = 'group' | 'event';
+export type WorkflowHistoryFilterConfig<
+  V extends Partial<PageQueryParamValues<typeof workflowPageQueryParamsConfig>>,
+> = PageFilterConfig<typeof workflowPageQueryParamsConfig, V> & {
+  filterTarget: WorkflowHistoryFilterTarget;
+} & (
+    | {
+        filterFunc: (d: HistoryEvent, value: V) => boolean;
+        filterTarget: 'event';
+      }
+    | {
+        filterFunc: (d: HistoryEventsGroup, value: V) => boolean;
+        filterTarget: 'group';
+      }
+  );

--- a/src/views/workflow-page/config/workflow-page-query-params.config.ts
+++ b/src/views/workflow-page/config/workflow-page-query-params.config.ts
@@ -1,0 +1,41 @@
+import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import { WORKFLOW_EVENT_STATUS } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.constants';
+import { type WorkflowEventStatus } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants';
+import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants';
+import { type WokflowHistoryEventFilteringType } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.types';
+
+const workflowPageQueryParamsConfig: [
+  PageQueryParam<
+    'historyEventType',
+    WokflowHistoryEventFilteringType | undefined
+  >,
+  PageQueryParam<'historyEventStatus', WorkflowEventStatus | undefined>,
+] = [
+  {
+    key: 'historyEventType',
+    queryParamKey: 'ht',
+    parseValue: (v) => {
+      if (
+        WORKFLOW_HISTORY_EVENT_FILTERING_TYPES.includes(
+          v as WokflowHistoryEventFilteringType
+        )
+      ) {
+        return v as WokflowHistoryEventFilteringType;
+      }
+      return undefined;
+    },
+  },
+  {
+    key: 'historyEventStatus',
+    queryParamKey: 'hs',
+    parseValue: (v) => {
+      if (v in WORKFLOW_EVENT_STATUS) {
+        return v as WorkflowEventStatus;
+      }
+      return undefined;
+    },
+  },
+] as const;
+
+export default workflowPageQueryParamsConfig;

--- a/src/views/workflow-page/config/workflow-page-query-params.config.ts
+++ b/src/views/workflow-page/config/workflow-page-query-params.config.ts
@@ -1,7 +1,6 @@
 import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
 import { WORKFLOW_EVENT_STATUS } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.constants';
 import { type WorkflowEventStatus } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.types';
-import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_OPTIONS } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants';
 import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants';
 import { type WokflowHistoryEventFilteringType } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.types';
 


### PR DESCRIPTION
### Summary
- Add filtering functionality to the workflow history page
- Allow filtering events by their type `'ACTIVITY', 'CHILDWORKFLOW', 'DECISION', 'SIGNAL', 'TIMER', 'WORKFLOW'`
- Allow filtering event groups by their status `'ONGOING','WAITING', 'COMPLETED',  'FAILED', 'CANCELED'`


### Changes
- Existing filters component didn't support removing ,search input and rendering filters button next to another buttons. To support this some refactoring was made to the component to expose individual sub components for external usage.
- added type and status filter components
- added filters config and page params to the workflow history page
- use the refactored component in the workflow history page

### Screenshots
![Gif 2024-10-01 at 10 53 56](https://github.com/user-attachments/assets/83ae39af-7c82-48d5-8958-216061fe723b)


