### PR TITLE
Fix inconsistent time filteration

### DIFF
--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -197,9 +197,9 @@ export default {
 
       return query.startTime && query.endTime
         ? {
-          startTime: moment(query.startTime),
-          endTime: moment(query.endTime),
-        }
+            startTime: moment(query.startTime),
+            endTime: moment(query.endTime),
+          }
         : query.range;
     },
     startTime() {
@@ -346,12 +346,16 @@ export default {
       }
 
       let workflows = [];
-      
+
       if (
         this.state !== STATE_ALL ||
         this.filterMode === FILTER_MODE_ADVANCED
       ) {
-        const query = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.npt };
+        const query = {
+          ...this.criteria,
+          filterBy: this.filterBy,
+          nextPageToken: this.npt,
+        };
 
         if (query.queryString) {
           query.queryString = decodeURI(query.queryString);
@@ -370,8 +374,16 @@ export default {
         this.npt = nextPageToken;
       } else {
         const { domain } = this;
-        const queryOpen = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.npt };
-        const queryClosed = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.nptAlt };
+        const queryOpen = {
+          ...this.criteria,
+          filterBy: this.filterBy,
+          nextPageToken: this.npt,
+        };
+        const queryClosed = {
+          ...this.criteria,
+          filterBy: this.filterBy,
+          nextPageToken: this.nptAlt,
+        };
 
         const {
           status: openStatus,

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -197,9 +197,9 @@ export default {
 
       return query.startTime && query.endTime
         ? {
-            startTime: moment(query.startTime),
-            endTime: moment(query.endTime),
-          }
+          startTime: moment(query.startTime),
+          endTime: moment(query.endTime),
+        }
         : query.range;
     },
     startTime() {
@@ -346,12 +346,12 @@ export default {
       }
 
       let workflows = [];
-
+      
       if (
         this.state !== STATE_ALL ||
         this.filterMode === FILTER_MODE_ADVANCED
       ) {
-        const query = { ...this.criteria, nextPageToken: this.npt };
+        const query = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.npt };
 
         if (query.queryString) {
           query.queryString = decodeURI(query.queryString);
@@ -370,8 +370,8 @@ export default {
         this.npt = nextPageToken;
       } else {
         const { domain } = this;
-        const queryOpen = { ...this.criteria, nextPageToken: this.npt };
-        const queryClosed = { ...this.criteria, nextPageToken: this.nptAlt };
+        const queryOpen = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.npt };
+        const queryClosed = { ...this.criteria, filterBy: this.filterBy, nextPageToken: this.nptAlt };
 
         const {
           status: openStatus,

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -353,12 +353,13 @@ export default {
       ) {
         const query = {
           ...this.criteria,
-          filterBy: this.filterBy,
           nextPageToken: this.npt,
         };
 
         if (query.queryString) {
           query.queryString = decodeURI(query.queryString);
+        } else {
+          query.filterBy = this.filterBy;
         }
 
         const { status, workflows: wfs, nextPageToken } = await this.fetch(

--- a/client/services/http-service.js
+++ b/client/services/http-service.js
@@ -19,8 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { getQueryStringFromObject } from '~helpers';
-
+import qs from 'query-string';
 const DEFAULT_FETCH_OPTIONS = {
   credentials: 'same-origin',
   headers: {
@@ -45,8 +44,8 @@ class HttpService {
   async request(baseUrl, { query, ...options } = {}) {
     const { origin } = this;
     const fetch = this.fetchOverride ? this.fetchOverride : window.fetch;
-    const queryString = getQueryStringFromObject(query);
-    const path = queryString ? `${baseUrl}${queryString}` : baseUrl;
+    const queryString = qs.stringify(query, { skipNull: true });
+    const path = queryString ? `${baseUrl}?${queryString}` : baseUrl;
     const hasOrigin = baseUrl.startsWith('http');
     const url = hasOrigin ? path : `${origin}${path}`;
     const isCrossOrigin = !url.startsWith(window.location.origin);

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -23,7 +23,7 @@ import Router from 'vue-router';
 import Vue from 'vue';
 import moment from 'moment';
 import fetchMock from 'fetch-mock';
-import qs from 'friendly-querystring';
+import qs from 'query-string';
 import vueModal from 'vue-js-modal';
 import deepmerge from 'deepmerge';
 
@@ -271,9 +271,12 @@ Scenario.prototype.withWorkflows = function withWorkflows({
           endTime: moment()
             .endOf('day')
             .toISOString(),
+          filterBy: 'StartTime',
           ...query,
-        }
+        },
+    { skipNull: true }
   );
+
   const url = `${baseUrl}?${queryString}`;
   const response = Array.isArray(workflows)
     ? { executions: workflows, nextPageToken: '' }

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -154,6 +154,7 @@ describe('Workflow list', () => {
         status: 'open',
         query: {
           workflowId: '1234',
+          filterBy: 'StartTime',
         },
         workflows: [
           {
@@ -204,6 +205,7 @@ describe('Workflow list', () => {
             .endOf('hour')
             .toISOString(),
           status: 'FAILED',
+          filterBy: 'CloseTime',
         },
       })
       .go();
@@ -266,7 +268,7 @@ describe('Workflow list', () => {
 
     scenario.withWorkflows({
       status: 'closed',
-      query: { status: 'FAILED' },
+      query: { status: 'FAILED', filterBy: 'CloseTime' },
       workflows: demoWf,
     });
     await statusEl.selectItem('Failed');
@@ -365,6 +367,7 @@ describe('Workflow list', () => {
         query: {
           status: 'FAILED',
           workflowName: 'demo',
+          filterBy: 'CloseTime',
         },
       })
       .go();

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "openid-client": "^5.6.5",
     "prismjs": "^1.14.0",
     "promise.prototype.finally": "^3.1.0",
+    "query-string": "^4.3.4",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     "tchannel": "3.10.1",

--- a/server/router/helpers/build-query-string.js
+++ b/server/router/helpers/build-query-string.js
@@ -35,14 +35,14 @@ const getStatusQueryValue = status => {
 const buildQueryString = (
   startTime,
   endTime,
-  { isCron, state = 'closed', status, workflowId, workflowName } = {}
+  { isCron, state = 'closed', status, workflowId, workflowName, filterBy } = {}
 ) => {
-  const filterBy = STATE_TO_FILTER_BY_MAP[state];
+  const filterByField = filterBy || STATE_TO_FILTER_BY_MAP[state];
   const statusQueryValue = getStatusQueryValue(status);
 
   return [
-    `${filterBy} >= "${startTime.toISOString()}"`,
-    `${filterBy} <= "${endTime.toISOString()}"`,
+    `${filterByField} >= "${startTime.toISOString()}"`,
+    `${filterByField} <= "${endTime.toISOString()}"`,
     state === 'open' && `CloseTime = missing`,
     statusQueryValue && `CloseStatus = ${statusQueryValue}`,
     isCron !== undefined && `IsCron = "${isCron}"`,


### PR DESCRIPTION
### Issue
- When start/end dates in `domain workflows page` are selected they behave differently on closed/opened workflows
- `Closed` workflows are filtered using `End time` while `Opened` workflows are filtered based on `Start time`
- This caused confusion as the UI at the top says that `Filter By: StartTime` while this is not the case

### Solution
- Pass the `Filter By` value that shows on UI to both api calls for fetch opened/closed workflows