### PR TITLE
fix timeout events status

### DIFF
--- a/src/utils/data-formatters/schema/history-event-schema.ts
+++ b/src/utils/data-formatters/schema/history-event-schema.ts
@@ -184,7 +184,10 @@ const externalExecutionInfoSchema = z.object({
 const historyEventBaseSchema = z.object({
   eventId: z.string(),
   eventTime: timestampSchema.nullable(),
-  version: z.string(),
+  // version is recieved as a numeric value if it is 0
+  // this is unexpected behavior from grpc protoLoader
+  // coerce the value to string to avoid the issue
+  version: z.coerce.string(),
   taskId: z.string(),
 });
 

--- a/src/views/workflow-page/helpers/__tests__/get-workflow-is-completed.test.ts
+++ b/src/views/workflow-page/helpers/__tests__/get-workflow-is-completed.test.ts
@@ -9,6 +9,7 @@ describe('getWorkflowIsCompleted', () => {
     'workflowExecutionContinuedAsNewEventAttributes',
     'workflowExecutionFailedEventAttributes',
     'workflowExecutionTerminatedEventAttributes',
+    'workflowExecutionTimedOutEventAttributes',
   ];
 
   it('should return true for attributes in the workflowCompletedAttributes list', () => {

--- a/src/views/workflow-page/helpers/get-workflow-is-completed.ts
+++ b/src/views/workflow-page/helpers/get-workflow-is-completed.ts
@@ -26,6 +26,7 @@ const workflowCompletedAttributes = [
   'workflowExecutionContinuedAsNewEventAttributes',
   'workflowExecutionFailedEventAttributes',
   'workflowExecutionTerminatedEventAttributes',
+  'workflowExecutionTimedOutEventAttributes',
 ];
 
 const getWorkflowIsCompleted = (lastEventAttributes: string) =>


### PR DESCRIPTION
### Issue Description
- Status of timed out events are showing as `running` instead of `timed out`.
- Also found that details is failing to get parsed correctly.

### Fix
- Added  `workflowExecutionTimedOutEventAttributes ` to the completed events set.
- auto parse version to sting to avoid parsing issues if version is returned as numeric value from API.

### Screenshots
**Before the fix**
<img width="1691" alt="Screenshot 2024-10-15 at 21 04 56" src="https://github.com/user-attachments/assets/ac4725d7-8fec-4753-9bd0-c0a88ed01ce6">

**After the fix**
<img width="1689" alt="Screenshot 2024-10-15 at 21 06 24" src="https://github.com/user-attachments/assets/b603fcdc-4012-4a01-95b4-d1fc5358817c">
