### PR TITLE
Create and use middlewares

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { describeDomain } from '@/route-handlers/describe-domain/describe-domain';
 import type { RouteParams } from '@/route-handlers/describe-domain/describe-domain.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return describeDomain(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    describeDomain,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { describeDomain } from '@/route-handlers/describe-domain/describe-domain';
 import type { RouteParams } from '@/route-handlers/describe-domain/describe-domain.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    describeDomain,
     request,
     options,
-    describeDomain,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/task-list/[taskListName]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/task-list/[taskListName]/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { describeTaskList } from '@/route-handlers/describe-task-list/describe-task-list';
 import { type RouteParams } from '@/route-handlers/describe-task-list/describe-task-list.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    describeTaskList,
     request,
     options,
-    describeTaskList,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/task-list/[taskListName]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/task-list/[taskListName]/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { describeTaskList } from '@/route-handlers/describe-task-list/describe-task-list';
 import { type RouteParams } from '@/route-handlers/describe-task-list/describe-task-list.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return describeTaskList(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    describeTaskList,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import getWorkflowHistory from '@/route-handlers/get-workflow-history/get-workflow-history';
 import { type RouteParams } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    getWorkflowHistory,
     request,
     options,
-    getWorkflowHistory,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/history/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import getWorkflowHistory from '@/route-handlers/get-workflow-history/get-workflow-history';
 import { type RouteParams } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return getWorkflowHistory(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    getWorkflowHistory,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { queryWorkflow } from '@/route-handlers/query-workflow/query-workflow';
 import { type RouteParams } from '@/route-handlers/query-workflow/query-workflow.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return queryWorkflow(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    queryWorkflow,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/[queryName]/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { queryWorkflow } from '@/route-handlers/query-workflow/query-workflow';
 import { type RouteParams } from '@/route-handlers/query-workflow/query-workflow.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function POST(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    queryWorkflow,
     request,
     options,
-    queryWorkflow,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
@@ -2,14 +2,14 @@ import { type NextRequest } from 'next/server';
 
 import fetchWorkflowQueryTypes from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types';
 import { type RouteParams } from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
     request,
     options,
     fetchWorkflowQueryTypes,

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
@@ -10,9 +10,9 @@ export async function GET(
   options: { params: RouteParams }
 ) {
   return routeHandlerWithMiddlewares(
+    fetchWorkflowQueryTypes,
     request,
     options,
-    fetchWorkflowQueryTypes,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/query/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import fetchWorkflowQueryTypes from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types';
 import { type RouteParams } from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return fetchWorkflowQueryTypes(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    fetchWorkflowQueryTypes,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import describeWorkflow from '@/route-handlers/describe-workflow/describe-workflow';
 import { type RouteParams } from '@/route-handlers/describe-workflow/describe-workflow.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    describeWorkflow,
     request,
     options,
-    describeWorkflow,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import describeWorkflow from '@/route-handlers/describe-workflow/describe-workflow';
 import { type RouteParams } from '@/route-handlers/describe-workflow/describe-workflow.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return describeWorkflow(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    describeWorkflow,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/route.ts
@@ -2,17 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { listWorkflows } from '@/route-handlers/list-workflows/list-workflows';
 import type { RouteParams } from '@/route-handlers/list-workflows/list-workflows.types';
-import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
   options: { params: RouteParams }
 ) {
-  return routeHandlersMiddleware(
+  return routeHandlerWithMiddlewares(
+    listWorkflows,
     request,
     options,
-    listWorkflows,
     routeHandlersDefaultMiddlewares
   );
 }

--- a/src/app/api/domains/[domain]/[cluster]/workflows/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/route.ts
@@ -2,10 +2,17 @@ import { type NextRequest } from 'next/server';
 
 import { listWorkflows } from '@/route-handlers/list-workflows/list-workflows';
 import type { RouteParams } from '@/route-handlers/list-workflows/list-workflows.types';
+import routeHandlersMiddleware from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: RouteParams }
+  options: { params: RouteParams }
 ) {
-  return listWorkflows(request, { params });
+  return routeHandlersMiddleware(
+    request,
+    options,
+    listWorkflows,
+    routeHandlersDefaultMiddlewares
+  );
 }

--- a/src/route-handlers/describe-domain/describe-domain.ts
+++ b/src/route-handlers/describe-domain/describe-domain.ts
@@ -1,22 +1,26 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
-import { type RequestParams, type RouteParams } from './describe-domain.types';
+import {
+  type Context,
+  type RequestParams,
+  type RouteParams,
+} from './describe-domain.types';
 
 export async function describeDomain(
   _: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
   try {
-    const res = await grpcClient
-      .getClusterMethods(decodedParams.cluster)
-      .describeDomain({ name: decodedParams.domain });
+    const res = await context.grpcClusterMethods.describeDomain({
+      name: decodedParams.domain,
+    });
 
     return NextResponse.json(res.domain);
   } catch (e) {

--- a/src/route-handlers/describe-domain/describe-domain.ts
+++ b/src/route-handlers/describe-domain/describe-domain.ts
@@ -13,12 +13,12 @@ import {
 export async function describeDomain(
   _: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
   try {
-    const res = await context.grpcClusterMethods.describeDomain({
+    const res = await ctx.grpcClusterMethods.describeDomain({
       name: decodedParams.domain,
     });
 

--- a/src/route-handlers/describe-domain/describe-domain.types.ts
+++ b/src/route-handlers/describe-domain/describe-domain.types.ts
@@ -1,3 +1,4 @@
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 import { type DomainInfo } from '@/views/domain-page/domain-page.types';
 
 export type RouteParams = {
@@ -9,4 +10,5 @@ export type RequestParams = {
   params: RouteParams;
 };
 
+export type Context = DefaultMiddlewaresContext;
 export type DescribeDomainResponse = DomainInfo;

--- a/src/route-handlers/describe-task-list/describe-task-list.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.ts
@@ -1,7 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
@@ -9,35 +8,33 @@ import {
   type TaskList,
   type RequestParams,
   type RouteParams,
+  type Context,
 } from './describe-task-list.types';
 import getWorkersForTaskList from './helpers/get-workers-for-task-list';
 
 export async function describeTaskList(
   _: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
   try {
-    const decisionTaskList = await grpcClient
-      .getClusterMethods(decodedParams.cluster)
-      .describeTaskList({
-        domain: decodedParams.domain,
-        taskList: {
-          name: decodedParams.taskListName,
-        },
-        taskListType: 'TASK_LIST_TYPE_DECISION',
-      });
+    const decisionTaskList = await context.grpcClusterMethods.describeTaskList({
+      domain: decodedParams.domain,
+      taskList: {
+        name: decodedParams.taskListName,
+      },
+      taskListType: 'TASK_LIST_TYPE_DECISION',
+    });
 
-    const activityTaskList = await grpcClient
-      .getClusterMethods(decodedParams.cluster)
-      .describeTaskList({
-        domain: decodedParams.domain,
-        taskList: {
-          name: decodedParams.taskListName,
-        },
-        taskListType: 'TASK_LIST_TYPE_ACTIVITY',
-      });
+    const activityTaskList = await context.grpcClusterMethods.describeTaskList({
+      domain: decodedParams.domain,
+      taskList: {
+        name: decodedParams.taskListName,
+      },
+      taskListType: 'TASK_LIST_TYPE_ACTIVITY',
+    });
 
     const taskList: TaskList = {
       name: decodedParams.taskListName,

--- a/src/route-handlers/describe-task-list/describe-task-list.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.ts
@@ -15,12 +15,12 @@ import getWorkersForTaskList from './helpers/get-workers-for-task-list';
 export async function describeTaskList(
   _: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
   try {
-    const decisionTaskList = await context.grpcClusterMethods.describeTaskList({
+    const decisionTaskList = await ctx.grpcClusterMethods.describeTaskList({
       domain: decodedParams.domain,
       taskList: {
         name: decodedParams.taskListName,
@@ -28,7 +28,7 @@ export async function describeTaskList(
       taskListType: 'TASK_LIST_TYPE_DECISION',
     });
 
-    const activityTaskList = await context.grpcClusterMethods.describeTaskList({
+    const activityTaskList = await ctx.grpcClusterMethods.describeTaskList({
       domain: decodedParams.domain,
       taskList: {
         name: decodedParams.taskListName,

--- a/src/route-handlers/describe-task-list/describe-task-list.types.ts
+++ b/src/route-handlers/describe-task-list/describe-task-list.types.ts
@@ -1,5 +1,6 @@
 import { type PollerInfo } from '@/__generated__/proto-ts/uber/cadence/api/v1/PollerInfo';
 import { type TaskListStatus } from '@/__generated__/proto-ts/uber/cadence/api/v1/TaskListStatus';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 
 export type RouteParams = {
   domain: string;
@@ -27,3 +28,5 @@ export type TaskList = {
 export type DescribeTaskListResponse = {
   taskList: TaskList;
 };
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/describe-workflow/describe-workflow.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.ts
@@ -15,13 +15,13 @@ import {
 export default async function describeWorkflow(
   _: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
     const describeWorkflowResponse =
-      await context.grpcClusterMethods.describeWorkflow({
+      await ctx.grpcClusterMethods.describeWorkflow({
         domain: decodedParams.domain,
         workflowExecution: {
           workflowId: decodedParams.workflowId,
@@ -42,7 +42,7 @@ export default async function describeWorkflow(
       res.workflowExecutionInfo.closeStatus !==
         'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
     ) {
-      const closeEventResponse = await context.grpcClusterMethods.getHistory({
+      const closeEventResponse = await ctx.grpcClusterMethods.getHistory({
         domain: decodedParams.domain,
         workflowExecution: {
           workflowId: decodedParams.workflowId,
@@ -63,15 +63,14 @@ export default async function describeWorkflow(
       if (e instanceof GRPCError && e.httpStatusCode !== 404) {
         throw e;
       }
-      const archivedHistoryResponse =
-        await context.grpcClusterMethods.getHistory({
-          domain: decodedParams.domain,
-          workflowExecution: {
-            workflowId: decodedParams.workflowId,
-            runId: decodedParams.runId,
-          },
-          pageSize: 1,
-        });
+      const archivedHistoryResponse = await ctx.grpcClusterMethods.getHistory({
+        domain: decodedParams.domain,
+        workflowExecution: {
+          workflowId: decodedParams.workflowId,
+          runId: decodedParams.runId,
+        },
+        pageSize: 1,
+      });
       const archivedHistoryEvents =
         archivedHistoryResponse.history?.events || [];
 

--- a/src/route-handlers/describe-workflow/describe-workflow.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.ts
@@ -2,7 +2,6 @@ import merge from 'lodash/merge';
 import { NextResponse, type NextRequest } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
@@ -10,24 +9,25 @@ import {
   type DescribeUnArchivedWorkflowResponse,
   type DescribeArchivedWorkflowResponse,
   type RequestParams,
+  type Context,
 } from './describe-workflow.types';
 
 export default async function describeWorkflow(
   _: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
-    const describeWorkflowResponse = await grpcClient.clusterMethods[
-      decodedParams.cluster
-    ].describeWorkflow({
-      domain: decodedParams.domain,
-      workflowExecution: {
-        workflowId: decodedParams.workflowId,
-        runId: decodedParams.runId,
-      },
-    });
+    const describeWorkflowResponse =
+      await context.grpcClusterMethods.describeWorkflow({
+        domain: decodedParams.domain,
+        workflowExecution: {
+          workflowId: decodedParams.workflowId,
+          runId: decodedParams.runId,
+        },
+      });
 
     const res: DescribeUnArchivedWorkflowResponse = merge(
       {},
@@ -42,9 +42,7 @@ export default async function describeWorkflow(
       res.workflowExecutionInfo.closeStatus !==
         'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
     ) {
-      const closeEventResponse = await grpcClient.clusterMethods[
-        decodedParams.cluster
-      ].getHistory({
+      const closeEventResponse = await context.grpcClusterMethods.getHistory({
         domain: decodedParams.domain,
         workflowExecution: {
           workflowId: decodedParams.workflowId,
@@ -65,16 +63,15 @@ export default async function describeWorkflow(
       if (e instanceof GRPCError && e.httpStatusCode !== 404) {
         throw e;
       }
-      const archivedHistoryResponse = await grpcClient.clusterMethods[
-        decodedParams.cluster
-      ].getHistory({
-        domain: decodedParams.domain,
-        workflowExecution: {
-          workflowId: decodedParams.workflowId,
-          runId: decodedParams.runId,
-        },
-        pageSize: 1,
-      });
+      const archivedHistoryResponse =
+        await context.grpcClusterMethods.getHistory({
+          domain: decodedParams.domain,
+          workflowExecution: {
+            workflowId: decodedParams.workflowId,
+            runId: decodedParams.runId,
+          },
+          pageSize: 1,
+        });
       const archivedHistoryEvents =
         archivedHistoryResponse.history?.events || [];
 

--- a/src/route-handlers/describe-workflow/describe-workflow.types.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.types.ts
@@ -1,6 +1,7 @@
 import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
 import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
 import { type WorkflowExecutionInfo } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionInfo';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 
 export type RouteParams = {
   domain: string;
@@ -45,3 +46,5 @@ export type DescribeArchivedWorkflowResponse = Omit<
     partitionConfig: null;
   };
 };
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.ts
+++ b/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.ts
@@ -1,24 +1,25 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
-import { type RequestParams } from './fetch-workflow-query-types.types';
+import {
+  type Context,
+  type RequestParams,
+} from './fetch-workflow-query-types.types';
 import parseErrorMessageForQueryTypes from './helpers/parse-error-message-for-query-types';
 import { queryTypesDataSchema } from './schemas/query-types-data-schema';
 
 export default async function fetchWorkflowQueryTypes(
   _: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
-    const res = await grpcClient.clusterMethods[
-      decodedParams.cluster
-    ].queryWorkflow({
+    const res = await context.grpcClusterMethods.queryWorkflow({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.ts
+++ b/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.ts
@@ -14,12 +14,12 @@ import { queryTypesDataSchema } from './schemas/query-types-data-schema';
 export default async function fetchWorkflowQueryTypes(
   _: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
-    const res = await context.grpcClusterMethods.queryWorkflow({
+    const res = await ctx.grpcClusterMethods.queryWorkflow({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types.ts
+++ b/src/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types.ts
@@ -1,3 +1,5 @@
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
 export type RouteParams = {
   domain: string;
   cluster: string;
@@ -12,3 +14,5 @@ export type RequestParams = {
 export type FetchWorkflowQueryTypesResponse = {
   queryTypes: Array<string>;
 };
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/get-workflow-history/get-workflow-history.ts
+++ b/src/route-handlers/get-workflow-history/get-workflow-history.ts
@@ -14,7 +14,7 @@ import getWorkflowHistoryQueryParamsSchema from './schemas/get-workflow-history-
 export default async function getWorkflowHistory(
   request: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams<RouteParams>(requestParams.params);
   const { data: queryParams, error } =
@@ -35,7 +35,7 @@ export default async function getWorkflowHistory(
   }
 
   try {
-    const res = await context.grpcClusterMethods.getHistory({
+    const res = await ctx.grpcClusterMethods.getHistory({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/get-workflow-history/get-workflow-history.ts
+++ b/src/route-handlers/get-workflow-history/get-workflow-history.ts
@@ -1,19 +1,20 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import {
   type RouteParams,
   type RequestParams,
+  type Context,
 } from './get-workflow-history.types';
 import getWorkflowHistoryQueryParamsSchema from './schemas/get-workflow-history-query-params-schema';
 
 export default async function getWorkflowHistory(
   request: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams<RouteParams>(requestParams.params);
   const { data: queryParams, error } =
@@ -34,9 +35,7 @@ export default async function getWorkflowHistory(
   }
 
   try {
-    const res = await grpcClient.clusterMethods[
-      decodedParams.cluster
-    ].getHistory({
+    const res = await context.grpcClusterMethods.getHistory({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/get-workflow-history/get-workflow-history.types.ts
+++ b/src/route-handlers/get-workflow-history/get-workflow-history.types.ts
@@ -1,4 +1,5 @@
 import { type GetWorkflowExecutionHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 
 export type RouteParams = {
   domain: string;
@@ -12,3 +13,5 @@ export type RequestParams = {
 };
 
 export type GetWorkflowHistoryResponse = GetWorkflowExecutionHistoryResponse;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -1,13 +1,13 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import getListWorkflowExecutionsQuery from './helpers/get-list-workflow-executions-query';
 import mapExecutionsToWorkflows from './helpers/map-executions-to-workflows';
 import type {
+  Context,
   ListWorkflowsResponse,
   RequestParams,
   RouteParams,
@@ -16,7 +16,8 @@ import listWorkflowsQueryParamSchema from './schemas/list-workflows-query-params
 
 export async function listWorkflows(
   request: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
@@ -36,21 +37,19 @@ export async function listWorkflows(
   }
 
   try {
-    const res = await grpcClient
-      .getClusterMethods(decodedParams.cluster)
-      .listWorkflows({
-        domain: decodedParams.domain,
-        pageSize: queryParams.pageSize,
-        nextPageToken: queryParams.nextPage,
-        query: getListWorkflowExecutionsQuery({
-          search: queryParams.search,
-          workflowStatus: queryParams.status,
-          sortColumn: queryParams.sortColumn,
-          sortOrder: queryParams.sortOrder,
-          timeRangeStart: queryParams.timeRangeStart,
-          timeRangeEnd: queryParams.timeRangeEnd,
-        }),
-      });
+    const res = await context.grpcClusterMethods.listWorkflows({
+      domain: decodedParams.domain,
+      pageSize: queryParams.pageSize,
+      nextPageToken: queryParams.nextPage,
+      query: getListWorkflowExecutionsQuery({
+        search: queryParams.search,
+        workflowStatus: queryParams.status,
+        sortColumn: queryParams.sortColumn,
+        sortOrder: queryParams.sortOrder,
+        timeRangeStart: queryParams.timeRangeStart,
+        timeRangeEnd: queryParams.timeRangeEnd,
+      }),
+    });
 
     const response: ListWorkflowsResponse = {
       workflows: mapExecutionsToWorkflows(res.executions),

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -17,7 +17,7 @@ import listWorkflowsQueryParamSchema from './schemas/list-workflows-query-params
 export async function listWorkflows(
   request: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
@@ -37,7 +37,7 @@ export async function listWorkflows(
   }
 
   try {
-    const res = await context.grpcClusterMethods.listWorkflows({
+    const res = await ctx.grpcClusterMethods.listWorkflows({
       domain: decodedParams.domain,
       pageSize: queryParams.pageSize,
       nextPageToken: queryParams.nextPage,

--- a/src/route-handlers/list-workflows/list-workflows.types.ts
+++ b/src/route-handlers/list-workflows/list-workflows.types.ts
@@ -1,5 +1,6 @@
 import { type ZodIssue, type z } from 'zod';
 
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 import { type DomainWorkflow } from '@/views/domain-page/domain-page.types';
 
 import type listWorkflowsQueryParamSchema from './schemas/list-workflows-query-params-schema';
@@ -27,3 +28,5 @@ export type ListWorkflowsError = {
   validationErrors?: Array<ZodIssue>;
   message?: string;
 };
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/query-workflow/query-workflow.ts
+++ b/src/route-handlers/query-workflow/query-workflow.ts
@@ -14,7 +14,7 @@ import validQueryInputSchema from './schemas/valid-query-input-schema';
 export async function queryWorkflow(
   request: NextRequest,
   requestParams: RequestParams,
-  context: Context
+  ctx: Context
 ) {
   const requestBody = await request.text();
   const { data: queryInput, error } =
@@ -32,7 +32,7 @@ export async function queryWorkflow(
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
-    const res = await context.grpcClusterMethods.queryWorkflow({
+    const res = await ctx.grpcClusterMethods.queryWorkflow({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/query-workflow/query-workflow.ts
+++ b/src/route-handlers/query-workflow/query-workflow.ts
@@ -1,11 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';
-import * as grpcClient from '@/utils/grpc/grpc-client';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import {
+  type Context,
   type QueryWorkflowResponse,
   type RequestParams,
 } from './query-workflow.types';
@@ -13,7 +13,8 @@ import validQueryInputSchema from './schemas/valid-query-input-schema';
 
 export async function queryWorkflow(
   request: NextRequest,
-  requestParams: RequestParams
+  requestParams: RequestParams,
+  context: Context
 ) {
   const requestBody = await request.text();
   const { data: queryInput, error } =
@@ -31,9 +32,7 @@ export async function queryWorkflow(
   const decodedParams = decodeUrlParams(requestParams.params);
 
   try {
-    const res = await grpcClient.clusterMethods[
-      decodedParams.cluster
-    ].queryWorkflow({
+    const res = await context.grpcClusterMethods.queryWorkflow({
       domain: decodedParams.domain,
       workflowExecution: {
         workflowId: decodedParams.workflowId,

--- a/src/route-handlers/query-workflow/query-workflow.types.ts
+++ b/src/route-handlers/query-workflow/query-workflow.types.ts
@@ -1,4 +1,5 @@
 import { type QueryRejected } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryRejected';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 
 export type RouteParams = {
   domain: string;
@@ -16,3 +17,5 @@ export type QueryWorkflowResponse = {
   result: any;
   rejected: QueryRejected | null;
 };
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -131,7 +131,7 @@ const clusterServices = CLUSTERS_CONFIGS.reduce((result, c) => {
   return result;
 }, {} as ClusterServices);
 
-const getCMethods = (
+const getClusterServicesMethods = (
   c: string,
   metadata?: GRPCMetadata
 ): GRPCClusterMethods => {
@@ -251,24 +251,11 @@ const getCMethods = (
   };
 };
 
-const getClustersMethods = (metadata?: GRPCMetadata) => {
-  return CLUSTERS_CONFIGS.reduce(
-    (result, { clusterName }) => {
-      const methods = getCMethods(clusterName, metadata);
-      result[clusterName] = methods;
-      return result;
-    },
-    {} as {
-      [k: string]: GRPCClusterMethods;
-    }
-  );
-};
-export const clustersMethods = getClustersMethods();
 export function getClusterMethods(
   cluster: string,
   requestMetadata?: GRPCMetadata
 ): GRPCClusterMethods {
-  const methods = getCMethods(cluster, requestMetadata);
+  const methods = getClusterServicesMethods(cluster, requestMetadata);
   if (!methods) {
     throw new Error(`Invalid cluster provided: ${cluster}`);
   }

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -32,233 +32,245 @@ import CLUSTERS_CONFIGS from '@/config/clusters/clusters.config';
 
 import grpcServiceConfigurations from '../../config/grpc/grpc-services-config';
 
-import GRPCService, { type GRPCRequestConfig } from './grpc-service';
+import GRPCService, {
+  type GRPCMetadata,
+  type GRPCRequestConfig,
+} from './grpc-service';
 
-const clusterServicesMethods = CLUSTERS_CONFIGS.reduce(
-  (result, c) => {
-    const requestConfig: GRPCRequestConfig = {
-      serviceName: c.grpc.serviceName,
-      metadata: c.grpc.metadata,
-    };
+type ClusterServices = Record<
+  string,
+  Record<
+    'adminService' | 'domainService' | 'visibilityService' | 'workflowService',
+    GRPCService
+  >
+>;
+export type GRPCClusterMethods = {
+  archivedWorkflows: (
+    payload: ListArchivedWorkflowExecutionsRequest__Input
+  ) => Promise<ListArchivedWorkflowExecutionsResponse>;
+  closedWorkflows: (
+    payload: ListClosedWorkflowExecutionsRequest__Input
+  ) => Promise<ListClosedWorkflowExecutionsResponse>;
+  describeCluster: (
+    payload: DescribeClusterRequest__Input
+  ) => Promise<DescribeClusterResponse>;
+  describeDomain: (
+    payload: DescribeDomainRequest__Input
+  ) => Promise<DescribeDomainResponse>;
+  updateDomain: (
+    payload: UpdateDomainRequest__Input
+  ) => Promise<UpdateDomainResponse>;
+  describeTaskList: (
+    paload: DescribeTaskListRequest__Input
+  ) => Promise<DescribeTaskListResponse>;
+  describeWorkflow: (
+    payload: DescribeWorkflowExecutionRequest__Input
+  ) => Promise<DescribeWorkflowExecutionResponse>;
+  exportHistory: (
+    payload: GetWorkflowExecutionHistoryRequest__Input
+  ) => Promise<GetWorkflowExecutionHistoryResponse>;
+  getHistory: (
+    payload: GetWorkflowExecutionHistoryRequest__Input
+  ) => Promise<GetWorkflowExecutionHistoryResponse>;
+  listDomains: (
+    payload: ListDomainsRequest__Input
+  ) => Promise<ListDomainsResponse>;
+  listTaskListPartitions: (
+    payload: ListTaskListPartitionsRequest__Input
+  ) => Promise<ListTaskListPartitionsResponse>;
+  listWorkflows: (
+    payload: ListWorkflowExecutionsRequest__Input
+  ) => Promise<ListWorkflowExecutionsResponse>;
+  openWorkflows: (
+    payload: ListOpenWorkflowExecutionsRequest__Input
+  ) => Promise<ListOpenWorkflowExecutionsResponse>;
+  queryWorkflow: (
+    payload: QueryWorkflowRequest__Input
+  ) => Promise<QueryWorkflowResponse>;
+  signalWorkflow: (
+    payload: SignalWorkflowExecutionRequest__Input
+  ) => Promise<SignalWorkflowExecutionResponse>;
+  terminateWorkflow: (
+    payload: TerminateWorkflowExecutionRequest__Input
+  ) => Promise<TerminateWorkflowExecutionResponse>;
+};
 
-    const adminService = new GRPCService({
-      peer: c.grpc.peer,
-      requestConfig,
-      ...grpcServiceConfigurations.adminServiceConfig,
-    });
-    const domainService = new GRPCService({
-      peer: c.grpc.peer,
-      requestConfig,
-      ...grpcServiceConfigurations.domainServiceConfig,
-    });
-    const visibilityService = new GRPCService({
-      peer: c.grpc.peer,
-      requestConfig,
-      ...grpcServiceConfigurations.visibilityServiceConfig,
-    });
-    const workflowService = new GRPCService({
-      peer: c.grpc.peer,
-      requestConfig,
-      ...grpcServiceConfigurations.workflowServiceConfig,
-    });
+const clusterServices = CLUSTERS_CONFIGS.reduce((result, c) => {
+  const requestConfig: GRPCRequestConfig = {
+    serviceName: c.grpc.serviceName,
+    metadata: c.grpc.metadata,
+  };
 
-    result[c.clusterName] = {
-      archivedWorkflows: visibilityService.request<
-        ListArchivedWorkflowExecutionsRequest__Input,
-        ListArchivedWorkflowExecutionsResponse
-      >({
-        method: 'ListArchivedWorkflowExecutions',
-        //formatResponse: formatResponseWorkflowList,
-        //transform: combine(withDomain(ctx), withPagination(ctx)),
-      }),
-      closedWorkflows: visibilityService.request<
-        ListClosedWorkflowExecutionsRequest__Input,
-        ListClosedWorkflowExecutionsResponse
-      >({
-        method: 'ListClosedWorkflowExecutions',
-        // formatRequest: formatRequestWorkflowList,
-        // formatResponse: formatResponseWorkflowList,
-        // transform: combine(withDomain(ctx), withPagination(ctx)),
-      }),
-      describeCluster: adminService.request<
-        DescribeClusterRequest__Input,
-        DescribeClusterResponse
-      >({
-        method: 'DescribeCluster',
-      }),
-      describeDomain: domainService.request<
-        DescribeDomainRequest__Input,
-        DescribeDomainResponse
-      >({
-        method: 'DescribeDomain',
-        // formatResponse: formatResponseDomain,
-      }),
-      updateDomain: domainService.request<
-        UpdateDomainRequest__Input,
-        UpdateDomainResponse
-      >({ method: 'UpdateDomain' }),
-      describeTaskList: workflowService.request<
-        DescribeTaskListRequest__Input,
-        DescribeTaskListResponse
-      >({
-        // formatRequest: formatRequestDescribeTaskList,
-        // formatResponse: formatResponseDescribeTaskList,
-        method: 'DescribeTaskList',
-      }),
-      describeWorkflow: workflowService.request<
-        DescribeWorkflowExecutionRequest__Input,
-        DescribeWorkflowExecutionResponse
-      >({
-        method: 'DescribeWorkflowExecution',
-        //formatResponse: formatResponseDescribeWorkflow,
-        //transform: combine(withDomain(ctx), withWorkflowExecution(ctx)),
-      }),
-      exportHistory: workflowService.request<
-        GetWorkflowExecutionHistoryRequest__Input,
-        GetWorkflowExecutionHistoryResponse
-      >({
-        method: 'GetWorkflowExecutionHistory',
-        //formatRequest: formatRequestGetHistory,
-        //formatResponse: formatResponseExportHistory,
-        /* transform: combine(
-              withDomain(ctx),
-              withPagination(ctx),
-              withWorkflowExecution(ctx)
-            ), */
-      }),
-      getHistory: workflowService.request<
-        GetWorkflowExecutionHistoryRequest__Input,
-        GetWorkflowExecutionHistoryResponse
-      >({
-        method: 'GetWorkflowExecutionHistory',
-        /* formatRequest: formatRequestGetHistory,
-            formatResponse: formatResponseGetHistory,
-            transform: combine(
-                withDomain(ctx),
-                withPagination(ctx),
-                withWorkflowExecution(ctx)
-            ), */
-      }),
-      listDomains: domainService.request<
-        ListDomainsRequest__Input,
-        ListDomainsResponse
-      >({
-        method: 'ListDomains',
-        //formatResponse: formatResponseListDomains,
-      }),
-      listTaskListPartitions: workflowService.request<
-        ListTaskListPartitionsRequest__Input,
-        ListTaskListPartitionsResponse
-      >({
-        method: 'ListTaskListPartitions',
-      }),
-      listWorkflows: visibilityService.request<
-        ListWorkflowExecutionsRequest__Input,
-        ListWorkflowExecutionsResponse
-      >({
-        method: 'ListWorkflowExecutions',
-        /* formatResponse: formatResponseWorkflowList,
-             transform: combine(withDomain(ctx), withPagination(ctx)), */
-      }),
-      openWorkflows: visibilityService.request<
-        ListOpenWorkflowExecutionsRequest__Input,
-        ListOpenWorkflowExecutionsResponse
-      >({
-        method: 'ListOpenWorkflowExecutions',
-        /* formatRequest: formatRequestWorkflowList,
-            formatResponse: formatResponseWorkflowList,
-            transform: combine(withDomain(ctx), withPagination(ctx)), */
-      }),
-      queryWorkflow: workflowService.request<
-        QueryWorkflowRequest__Input,
-        QueryWorkflowResponse
-      >({
-        method: 'QueryWorkflow',
-        /* formatResponse: formatResponseQueryWorkflow,
-            transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
-      }),
-      signalWorkflow: workflowService.request<
-        SignalWorkflowExecutionRequest__Input,
-        SignalWorkflowExecutionResponse
-      >({
-        method: 'SignalWorkflowExecution',
-        /* formatResponse: formatResponseSignalWorkflowExecution,
-            transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
-      }),
-      terminateWorkflow: workflowService.request<
-        TerminateWorkflowExecutionRequest__Input,
-        TerminateWorkflowExecutionResponse
-      >({
-        method: 'TerminateWorkflowExecution',
-        /* formatResponse: formatResponseTerminateWorkflowExecution,
-            transform: combine(withDomain(ctx), withWorkflowExecution(ctx)), */
-      }),
-    };
-    result[c.clusterName].describeWorkflow;
-    return result;
-  },
-  {} as {
-    [k: string]: {
-      archivedWorkflows: (
-        payload: ListArchivedWorkflowExecutionsRequest__Input
-      ) => Promise<ListArchivedWorkflowExecutionsResponse>;
-      closedWorkflows: (
-        payload: ListClosedWorkflowExecutionsRequest__Input
-      ) => Promise<ListClosedWorkflowExecutionsResponse>;
-      describeCluster: (
-        payload: DescribeClusterRequest__Input
-      ) => Promise<DescribeClusterResponse>;
-      describeDomain: (
-        payload: DescribeDomainRequest__Input
-      ) => Promise<DescribeDomainResponse>;
-      updateDomain: (
-        payload: UpdateDomainRequest__Input
-      ) => Promise<UpdateDomainResponse>;
-      describeTaskList: (
-        paload: DescribeTaskListRequest__Input
-      ) => Promise<DescribeTaskListResponse>;
-      describeWorkflow: (
-        payload: DescribeWorkflowExecutionRequest__Input
-      ) => Promise<DescribeWorkflowExecutionResponse>;
-      exportHistory: (
-        payload: GetWorkflowExecutionHistoryRequest__Input
-      ) => Promise<GetWorkflowExecutionHistoryResponse>;
-      getHistory: (
-        payload: GetWorkflowExecutionHistoryRequest__Input
-      ) => Promise<GetWorkflowExecutionHistoryResponse>;
-      listDomains: (
-        payload: ListDomainsRequest__Input
-      ) => Promise<ListDomainsResponse>;
-      listTaskListPartitions: (
-        payload: ListTaskListPartitionsRequest__Input
-      ) => Promise<ListTaskListPartitionsResponse>;
-      listWorkflows: (
-        payload: ListWorkflowExecutionsRequest__Input
-      ) => Promise<ListWorkflowExecutionsResponse>;
-      openWorkflows: (
-        payload: ListOpenWorkflowExecutionsRequest__Input
-      ) => Promise<ListOpenWorkflowExecutionsResponse>;
-      queryWorkflow: (
-        payload: QueryWorkflowRequest__Input
-      ) => Promise<QueryWorkflowResponse>;
-      signalWorkflow: (
-        payload: SignalWorkflowExecutionRequest__Input
-      ) => Promise<SignalWorkflowExecutionResponse>;
-      terminateWorkflow: (
-        payload: TerminateWorkflowExecutionRequest__Input
-      ) => Promise<TerminateWorkflowExecutionResponse>;
-    };
-  }
-);
+  const adminService = new GRPCService({
+    peer: c.grpc.peer,
+    requestConfig,
+    ...grpcServiceConfigurations.adminServiceConfig,
+  });
+  const domainService = new GRPCService({
+    peer: c.grpc.peer,
+    requestConfig,
+    ...grpcServiceConfigurations.domainServiceConfig,
+  });
+  const visibilityService = new GRPCService({
+    peer: c.grpc.peer,
+    requestConfig,
+    ...grpcServiceConfigurations.visibilityServiceConfig,
+  });
+  const workflowService = new GRPCService({
+    peer: c.grpc.peer,
+    requestConfig,
+    ...grpcServiceConfigurations.workflowServiceConfig,
+  });
 
-export const clusterMethods = clusterServicesMethods;
+  result[c.clusterName] = {
+    adminService,
+    domainService,
+    visibilityService,
+    workflowService,
+  };
+  return result;
+}, {} as ClusterServices);
 
+const getCMethods = (
+  c: string,
+  metadata?: GRPCMetadata
+): GRPCClusterMethods => {
+  const { visibilityService, adminService, domainService, workflowService } =
+    clusterServices[c];
+
+  return {
+    archivedWorkflows: visibilityService.request<
+      ListArchivedWorkflowExecutionsRequest__Input,
+      ListArchivedWorkflowExecutionsResponse
+    >({
+      method: 'ListArchivedWorkflowExecutions',
+      metadata: metadata,
+    }),
+    closedWorkflows: visibilityService.request<
+      ListClosedWorkflowExecutionsRequest__Input,
+      ListClosedWorkflowExecutionsResponse
+    >({
+      method: 'ListClosedWorkflowExecutions',
+      metadata: metadata,
+    }),
+    describeCluster: adminService.request<
+      DescribeClusterRequest__Input,
+      DescribeClusterResponse
+    >({
+      method: 'DescribeCluster',
+      metadata: metadata,
+    }),
+    describeDomain: domainService.request<
+      DescribeDomainRequest__Input,
+      DescribeDomainResponse
+    >({
+      method: 'DescribeDomain',
+      metadata: metadata,
+    }),
+    updateDomain: domainService.request<
+      UpdateDomainRequest__Input,
+      UpdateDomainResponse
+    >({ method: 'UpdateDomain', metadata: metadata }),
+    describeTaskList: workflowService.request<
+      DescribeTaskListRequest__Input,
+      DescribeTaskListResponse
+    >({
+      method: 'DescribeTaskList',
+      metadata: metadata,
+    }),
+    describeWorkflow: workflowService.request<
+      DescribeWorkflowExecutionRequest__Input,
+      DescribeWorkflowExecutionResponse
+    >({
+      method: 'DescribeWorkflowExecution',
+      metadata: metadata,
+    }),
+    exportHistory: workflowService.request<
+      GetWorkflowExecutionHistoryRequest__Input,
+      GetWorkflowExecutionHistoryResponse
+    >({
+      method: 'GetWorkflowExecutionHistory',
+      metadata: metadata,
+    }),
+    getHistory: workflowService.request<
+      GetWorkflowExecutionHistoryRequest__Input,
+      GetWorkflowExecutionHistoryResponse
+    >({
+      method: 'GetWorkflowExecutionHistory',
+      metadata: metadata,
+    }),
+    listDomains: domainService.request<
+      ListDomainsRequest__Input,
+      ListDomainsResponse
+    >({
+      method: 'ListDomains',
+      metadata: metadata,
+    }),
+    listTaskListPartitions: workflowService.request<
+      ListTaskListPartitionsRequest__Input,
+      ListTaskListPartitionsResponse
+    >({
+      method: 'ListTaskListPartitions',
+      metadata: metadata,
+    }),
+    listWorkflows: visibilityService.request<
+      ListWorkflowExecutionsRequest__Input,
+      ListWorkflowExecutionsResponse
+    >({
+      method: 'ListWorkflowExecutions',
+      metadata: metadata,
+    }),
+    openWorkflows: visibilityService.request<
+      ListOpenWorkflowExecutionsRequest__Input,
+      ListOpenWorkflowExecutionsResponse
+    >({
+      method: 'ListOpenWorkflowExecutions',
+      metadata: metadata,
+    }),
+    queryWorkflow: workflowService.request<
+      QueryWorkflowRequest__Input,
+      QueryWorkflowResponse
+    >({
+      method: 'QueryWorkflow',
+      metadata: metadata,
+    }),
+    signalWorkflow: workflowService.request<
+      SignalWorkflowExecutionRequest__Input,
+      SignalWorkflowExecutionResponse
+    >({
+      method: 'SignalWorkflowExecution',
+      metadata: metadata,
+    }),
+    terminateWorkflow: workflowService.request<
+      TerminateWorkflowExecutionRequest__Input,
+      TerminateWorkflowExecutionResponse
+    >({
+      method: 'TerminateWorkflowExecution',
+      metadata: metadata,
+    }),
+  };
+};
+
+const getClustersMethods = (metadata?: GRPCMetadata) => {
+  return CLUSTERS_CONFIGS.reduce(
+    (result, { clusterName }) => {
+      const methods = getCMethods(clusterName, metadata);
+      result[clusterName] = methods;
+      return result;
+    },
+    {} as {
+      [k: string]: GRPCClusterMethods;
+    }
+  );
+};
+export const clustersMethods = getClustersMethods();
 export function getClusterMethods(
-  cluster: string
-): (typeof clusterMethods)[string] {
-  const methods = clusterMethods[cluster];
+  cluster: string,
+  requestMetadata?: GRPCMetadata
+): GRPCClusterMethods {
+  const methods = getCMethods(cluster, requestMetadata);
   if (!methods) {
-    throw new Error('Invalid cluster provided');
+    throw new Error(`Invalid cluster provided: ${cluster}`);
   }
   return methods;
 }

--- a/src/utils/grpc/grpc-service.ts
+++ b/src/utils/grpc/grpc-service.ts
@@ -35,7 +35,8 @@ const GRPC_OPTIONS = {
   'grpc.max_receive_message_length': MAX_MESSAGE_SIZE,
 };
 
-export type GRPCMetadata = Record<string, string>;
+export type GRPCMetadata = Record<string, string | never>;
+
 export type GRPCRequestConfig = {
   serviceName: string;
   metadata?: GRPCMetadata;

--- a/src/utils/route-handlers-middleware/__tests__/handle-route-request.test.ts
+++ b/src/utils/route-handlers-middleware/__tests__/handle-route-request.test.ts
@@ -1,0 +1,98 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import logger from '../../logger';
+import handleRouteRequest from '../handle-route-request';
+import type {
+  MiddlewareFunction,
+  RequestHandlerFunction,
+} from '../route-handlers-middleware.types';
+
+jest.mock('@/utils/logger');
+
+const mockRequest = {} as NextRequest;
+const mockOptions = { params: {} };
+const mockResponse = NextResponse.json({ message: 'Success' });
+
+const mockRequestHandler: RequestHandlerFunction<any, any> = jest
+  .fn()
+  .mockResolvedValue(mockResponse);
+
+describe('handleRouteRequest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return response from middleware if it returns NextResponse', async () => {
+    const mockMiddleware: MiddlewareFunction<any>[] = [
+      jest.fn().mockResolvedValue(mockResponse),
+    ];
+
+    const result = await handleRouteRequest(
+      mockRequest,
+      mockOptions,
+      mockRequestHandler,
+      mockMiddleware
+    );
+
+    expect(result).toBe(mockResponse);
+    expect(mockRequestHandler).not.toHaveBeenCalled();
+  });
+
+  it('should call request handler if no middleware returns NextResponse', async () => {
+    const mockMiddleware: MiddlewareFunction<any>[] = [
+      jest.fn().mockResolvedValue(['key', 'value']),
+    ];
+
+    const result = await handleRouteRequest(
+      mockRequest,
+      mockOptions,
+      mockRequestHandler,
+      mockMiddleware
+    );
+
+    expect(result).toBe(mockResponse);
+    expect(mockRequestHandler).toHaveBeenCalledWith(mockRequest, mockOptions, {
+      key: 'value',
+    });
+  });
+
+  it('should log error and return error response if middleware throws', async () => {
+    const mockError = new Error('Test error');
+    const mockMiddleware: MiddlewareFunction<any>[] = [
+      jest.fn().mockRejectedValue(mockError),
+    ];
+
+    const result = await handleRouteRequest(
+      mockRequest,
+      mockOptions,
+      mockRequestHandler,
+      mockMiddleware
+    );
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result.status).toBe(500);
+    expect(logger.error).toHaveBeenCalledWith(
+      { cause: mockError },
+      `Error in Middlewares: ${mockRequest.url}`
+    );
+    expect(mockRequestHandler).not.toHaveBeenCalled();
+  });
+
+  it('should call request handler with context if middleware returns context', async () => {
+    const mockMiddleware: MiddlewareFunction<any>[] = [
+      jest.fn().mockResolvedValue(['grpcClusterMethods', {}]),
+    ];
+
+    const result = await handleRouteRequest(
+      mockRequest,
+      mockOptions,
+      mockRequestHandler,
+      mockMiddleware
+    );
+
+    expect(result).toBe(mockResponse);
+    expect(mockRequestHandler).toHaveBeenCalledWith(mockRequest, mockOptions, {
+      grpcClusterMethods: {},
+    });
+  });
+});

--- a/src/utils/route-handlers-middleware/__tests__/route-handler-with-middlewares.test.ts
+++ b/src/utils/route-handlers-middleware/__tests__/route-handler-with-middlewares.test.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
 import logger from '../../logger';
-import handleRouteRequest from '../handle-route-request';
+import routeHandlerWithMiddlewares from '../route-handler-with-middlewares';
 import type {
   MiddlewareFunction,
   RequestHandlerFunction,
@@ -17,7 +17,7 @@ const mockRequestHandler: RequestHandlerFunction<any, any> = jest
   .fn()
   .mockResolvedValue(mockResponse);
 
-describe('handleRouteRequest', () => {
+describe('routeHandlerWithMiddlewares', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -27,10 +27,10 @@ describe('handleRouteRequest', () => {
       jest.fn().mockResolvedValue(mockResponse),
     ];
 
-    const result = await handleRouteRequest(
+    const result = await routeHandlerWithMiddlewares(
+      mockRequestHandler,
       mockRequest,
       mockOptions,
-      mockRequestHandler,
       mockMiddleware
     );
 
@@ -43,10 +43,10 @@ describe('handleRouteRequest', () => {
       jest.fn().mockResolvedValue(['key', 'value']),
     ];
 
-    const result = await handleRouteRequest(
+    const result = await routeHandlerWithMiddlewares(
+      mockRequestHandler,
       mockRequest,
       mockOptions,
-      mockRequestHandler,
       mockMiddleware
     );
 
@@ -62,10 +62,10 @@ describe('handleRouteRequest', () => {
       jest.fn().mockRejectedValue(mockError),
     ];
 
-    const result = await handleRouteRequest(
+    const result = await routeHandlerWithMiddlewares(
+      mockRequestHandler,
       mockRequest,
       mockOptions,
-      mockRequestHandler,
       mockMiddleware
     );
 
@@ -83,10 +83,10 @@ describe('handleRouteRequest', () => {
       jest.fn().mockResolvedValue(['grpcClusterMethods', {}]),
     ];
 
-    const result = await handleRouteRequest(
+    const result = await routeHandlerWithMiddlewares(
+      mockRequestHandler,
       mockRequest,
       mockOptions,
-      mockRequestHandler,
       mockMiddleware
     );
 

--- a/src/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config.ts
+++ b/src/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config.ts
@@ -1,0 +1,10 @@
+import { type GRPCClusterMethods } from '@/utils/grpc/grpc-client';
+
+import grpcClusterMethods from '../middlewares/grpc-cluster-methods';
+import { type MiddlewareFunction } from '../route-handlers-middleware.types';
+
+const routeHandlersDefaultMiddlewares: [
+  MiddlewareFunction<['grpcClusterMethods', GRPCClusterMethods]>,
+] = [grpcClusterMethods];
+
+export default routeHandlersDefaultMiddlewares;

--- a/src/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config.ts
+++ b/src/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config.ts
@@ -1,10 +1,10 @@
 import { type GRPCClusterMethods } from '@/utils/grpc/grpc-client';
 
-import grpcClusterMethods from '../middlewares/grpc-cluster-methods';
+import grpcClusterMethodsMiddleware from '../middlewares/grpc-cluster-methods';
 import { type MiddlewareFunction } from '../route-handlers-middleware.types';
 
 const routeHandlersDefaultMiddlewares: [
   MiddlewareFunction<['grpcClusterMethods', GRPCClusterMethods]>,
-] = [grpcClusterMethods];
+] = [grpcClusterMethodsMiddleware];
 
 export default routeHandlersDefaultMiddlewares;

--- a/src/utils/route-handlers-middleware/handle-route-request.ts
+++ b/src/utils/route-handlers-middleware/handle-route-request.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { GRPCError, getHTTPStatusCode } from '../grpc/grpc-error';
+import logger from '../logger';
+
+import type {
+  CombineMiddlewareContextType,
+  GetAllMiddlewaresReturnTypes,
+  MiddlewareFunction,
+  RequestHandlerFunction,
+} from './route-handlers-middleware.types';
+
+async function handleRouteRequest<
+  M extends MiddlewareFunction[],
+  Options extends { params: Record<string, string> },
+>(
+  request: NextRequest,
+  options: Options,
+  requestHandler: RequestHandlerFunction<M, Options>,
+  middlewares: M
+) {
+  let context: Partial<
+    CombineMiddlewareContextType<GetAllMiddlewaresReturnTypes<M>>
+  > = {};
+  for (const middlewareFunction of middlewares) {
+    try {
+      const result = await middlewareFunction(request, options, context);
+      if (result instanceof NextResponse) {
+        return result;
+      } else if (Array.isArray(result) && typeof result[0] === 'string') {
+        const [key, value] = result;
+        context = {
+          ...context,
+          [key]: value,
+        };
+      }
+    } catch (e) {
+      logger.error({ cause: e }, `Error in Middlewares: ${request.url}`);
+
+      return NextResponse.json(
+        {
+          message:
+            e instanceof GRPCError ? e.message : 'Failed to handle request',
+          cause: e,
+        },
+        { status: getHTTPStatusCode(e) }
+      );
+    }
+  }
+  return requestHandler(
+    request,
+    options,
+    context as CombineMiddlewareContextType<GetAllMiddlewaresReturnTypes<M>>
+  );
+}
+
+export default handleRouteRequest;

--- a/src/utils/route-handlers-middleware/helpers/__tests__/is-object-of-string-key-value.test.ts
+++ b/src/utils/route-handlers-middleware/helpers/__tests__/is-object-of-string-key-value.test.ts
@@ -1,0 +1,31 @@
+import isObjectOfStringKeyValue from '../is-object-of-string-key-value';
+
+describe('isObjectOfStringKeyValue', () => {
+  it('should return true for an object with string keys and string values', () => {
+    const obj = { key1: 'value1', key2: 'value2' };
+    expect(isObjectOfStringKeyValue(obj)).toBe(true);
+  });
+
+  it('should return false for an object with non-string values', () => {
+    const obj = { key1: 1, key2: 'value2' };
+    expect(isObjectOfStringKeyValue(obj)).toBe(false);
+  });
+
+  it('should return false for a non-object value', () => {
+    expect(isObjectOfStringKeyValue(null)).toBe(false);
+    expect(isObjectOfStringKeyValue(undefined)).toBe(false);
+    expect(isObjectOfStringKeyValue(123)).toBe(false);
+    expect(isObjectOfStringKeyValue('string')).toBe(false);
+    expect(isObjectOfStringKeyValue([])).toBe(false);
+  });
+
+  it('should return true for an empty object', () => {
+    expect(isObjectOfStringKeyValue({})).toBe(true);
+  });
+
+  it('should return false for an object with symbol keys', () => {
+    const symbolKey = Symbol('key');
+    const obj = { [symbolKey]: 'value1', key2: 'value2' };
+    expect(isObjectOfStringKeyValue(obj)).toBe(false);
+  });
+});

--- a/src/utils/route-handlers-middleware/helpers/is-object-of-string-key-value.ts
+++ b/src/utils/route-handlers-middleware/helpers/is-object-of-string-key-value.ts
@@ -1,0 +1,11 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+export default function isObjectOfStringKeyValue(
+  v: any
+): v is Record<string, string> {
+  return (
+    isPlainObject(v) &&
+    Reflect.ownKeys(v).every((k) => typeof k === 'string') &&
+    Object.values(v).every((v) => typeof v === 'string')
+  );
+}

--- a/src/utils/route-handlers-middleware/index.ts
+++ b/src/utils/route-handlers-middleware/index.ts
@@ -1,3 +1,3 @@
-export { default } from './handle-route-request';
+export { default as routeHandlerWithMiddlewares } from './route-handler-with-middlewares';
 
 export { type DefaultMiddlewaresContext } from './route-handlers-middleware.types';

--- a/src/utils/route-handlers-middleware/index.ts
+++ b/src/utils/route-handlers-middleware/index.ts
@@ -1,0 +1,3 @@
+export { default } from './handle-route-request';
+
+export { type DefaultMiddlewaresContext } from './route-handlers-middleware.types';

--- a/src/utils/route-handlers-middleware/middlewares/__tests__/grpc-cluster-methods.test.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__tests__/grpc-cluster-methods.test.ts
@@ -1,4 +1,3 @@
-import { isObjectLike } from 'lodash';
 import { type NextRequest } from 'next/server';
 
 import decodeUrlParams from '@/utils/decode-url-params';

--- a/src/utils/route-handlers-middleware/middlewares/__tests__/grpc-cluster-methods.test.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__tests__/grpc-cluster-methods.test.ts
@@ -1,0 +1,86 @@
+import { isObjectLike } from 'lodash';
+import { type NextRequest } from 'next/server';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import { getClusterMethods } from '@/utils/grpc/grpc-client';
+
+import grpcClusterMethods from '../grpc-cluster-methods';
+
+jest.mock('@/utils/decode-url-params', () => jest.fn());
+jest.mock('@/utils/grpc/grpc-client', () => ({
+  getClusterMethods: jest.fn(),
+}));
+
+const mockContext = {
+  grpcMetadata: undefined,
+};
+
+const mockParams = {
+  cluster: 'test-cluster',
+};
+
+const mockDecodedParams = {
+  cluster: 'decoded-cluster',
+};
+
+const mockRequest = {
+  cookies: {},
+  geo: {},
+  ip: '',
+  nextUrl: new URL('http://localhost'),
+} as NextRequest;
+
+describe('grpcClusterMethods middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if params.cluster is not provided', () => {
+    expect(() =>
+      grpcClusterMethods(mockRequest, { params: {} }, mockContext)
+    ).toThrow('Cluster not found: undefined');
+  });
+
+  it('should decode URL params and call getClusterMethods with correct arguments', () => {
+    (decodeUrlParams as jest.Mock).mockReturnValue(mockDecodedParams);
+
+    grpcClusterMethods(mockRequest, { params: mockParams }, mockContext);
+
+    expect(decodeUrlParams).toHaveBeenCalledWith(mockParams);
+    expect(getClusterMethods).toHaveBeenCalledWith(
+      mockDecodedParams.cluster,
+      undefined
+    );
+  });
+
+  it('should return the correct middleware result', () => {
+    const mockGRPCClusterMethods = {};
+    (decodeUrlParams as jest.Mock).mockReturnValue(mockDecodedParams);
+    (getClusterMethods as jest.Mock).mockReturnValue(mockGRPCClusterMethods);
+
+    const result = grpcClusterMethods(
+      mockRequest,
+      { params: mockParams },
+      mockContext
+    );
+
+    expect(result).toEqual(['grpcClusterMethods', mockGRPCClusterMethods]);
+  });
+
+  it('should handle grpcMetadata correctly', () => {
+    const mockGRPCMetadata = { key: 'value' };
+    const contextWithMetadata = { grpcMetadata: mockGRPCMetadata };
+    (decodeUrlParams as jest.Mock).mockReturnValue(mockDecodedParams);
+
+    grpcClusterMethods(
+      mockRequest,
+      { params: mockParams },
+      contextWithMetadata
+    );
+
+    expect(getClusterMethods).toHaveBeenCalledWith(
+      mockDecodedParams.cluster,
+      mockGRPCMetadata
+    );
+  });
+});

--- a/src/utils/route-handlers-middleware/middlewares/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/grpc-cluster-methods.ts
@@ -1,0 +1,41 @@
+import { isObjectLike } from 'lodash';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import {
+  type GRPCClusterMethods,
+  getClusterMethods,
+} from '@/utils/grpc/grpc-client';
+import { type GRPCMetadata } from '@/utils/grpc/grpc-service';
+
+import { type MiddlewareFunction } from '../route-handlers-middleware.types';
+
+const keyValuesAreStrings = (v: any): v is Record<string, string> => {
+  return (
+    isObjectLike(v) &&
+    Object.entries(v).every(
+      ([key, value]) => typeof key === 'string' && typeof value === 'string'
+    )
+  );
+};
+
+const grpcClusterMethods: MiddlewareFunction<
+  ['grpcClusterMethods', GRPCClusterMethods]
+> = (_, { params }, context) => {
+  let grpcMetadata: GRPCMetadata | undefined;
+  if (keyValuesAreStrings(context.grpcMetadata)) {
+    grpcMetadata = context.grpcMetadata;
+  }
+
+  if (!params.cluster) {
+    throw new Error(`Cluster not found: ${params.cluster}`);
+  }
+
+  const decodedParams = decodeUrlParams(params);
+
+  return [
+    'grpcClusterMethods',
+    getClusterMethods(decodedParams.cluster, grpcMetadata),
+  ];
+};
+
+export default grpcClusterMethods;

--- a/src/utils/route-handlers-middleware/middlewares/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/grpc-cluster-methods.ts
@@ -1,5 +1,3 @@
-import { isObjectLike } from 'lodash';
-
 import decodeUrlParams from '@/utils/decode-url-params';
 import {
   type GRPCClusterMethods,
@@ -7,23 +5,15 @@ import {
 } from '@/utils/grpc/grpc-client';
 import { type GRPCMetadata } from '@/utils/grpc/grpc-service';
 
+import isObjectOfStringKeyValue from '../helpers/is-object-of-string-key-value';
 import { type MiddlewareFunction } from '../route-handlers-middleware.types';
-
-const keyValuesAreStrings = (v: any): v is Record<string, string> => {
-  return (
-    isObjectLike(v) &&
-    Object.entries(v).every(
-      ([key, value]) => typeof key === 'string' && typeof value === 'string'
-    )
-  );
-};
 
 const grpcClusterMethods: MiddlewareFunction<
   ['grpcClusterMethods', GRPCClusterMethods]
-> = (_, { params }, context) => {
+> = (_, { params }, ctx) => {
   let grpcMetadata: GRPCMetadata | undefined;
-  if (keyValuesAreStrings(context.grpcMetadata)) {
-    grpcMetadata = context.grpcMetadata;
+  if (isObjectOfStringKeyValue(ctx.grpcMetadata)) {
+    grpcMetadata = ctx.grpcMetadata;
   }
 
   if (!params.cluster) {

--- a/src/utils/route-handlers-middleware/route-handler-with-middlewares.ts
+++ b/src/utils/route-handlers-middleware/route-handler-with-middlewares.ts
@@ -10,27 +10,27 @@ import type {
   RequestHandlerFunction,
 } from './route-handlers-middleware.types';
 
-async function handleRouteRequest<
+export default async function routeHandlersWithMiddlewares<
   M extends MiddlewareFunction[],
   Options extends { params: Record<string, string> },
 >(
+  requestHandler: RequestHandlerFunction<M, Options>,
   request: NextRequest,
   options: Options,
-  requestHandler: RequestHandlerFunction<M, Options>,
   middlewares: M
 ) {
-  let context: Partial<
+  let ctx: Partial<
     CombineMiddlewareContextType<GetAllMiddlewaresReturnTypes<M>>
   > = {};
   for (const middlewareFunction of middlewares) {
     try {
-      const result = await middlewareFunction(request, options, context);
+      const result = await middlewareFunction(request, options, ctx);
       if (result instanceof NextResponse) {
         return result;
       } else if (Array.isArray(result) && typeof result[0] === 'string') {
         const [key, value] = result;
-        context = {
-          ...context,
+        ctx = {
+          ...ctx,
           [key]: value,
         };
       }
@@ -50,8 +50,6 @@ async function handleRouteRequest<
   return requestHandler(
     request,
     options,
-    context as CombineMiddlewareContextType<GetAllMiddlewaresReturnTypes<M>>
+    ctx as CombineMiddlewareContextType<GetAllMiddlewaresReturnTypes<M>>
   );
 }
-
-export default handleRouteRequest;

--- a/src/utils/route-handlers-middleware/route-handlers-middleware.types.ts
+++ b/src/utils/route-handlers-middleware/route-handlers-middleware.types.ts
@@ -11,7 +11,7 @@ export type MiddlewareFunction<
 > = (
   request: NextRequest,
   options: { params: Record<string, string> },
-  context: Record<string, unknown>
+  ctx: Record<string, unknown>
 ) => ReturnT;
 
 export type GetAllMiddlewaresReturnTypes<M extends MiddlewareFunction[]> = {
@@ -28,7 +28,7 @@ export type RequestHandlerFunction<
 > = (
   request: NextRequest,
   options: O,
-  context: CombineMiddlewareContextType<
+  ctx: CombineMiddlewareContextType<
     GetAllMiddlewaresReturnTypes<MiddlewareFunctionsT>
   >
 ) => any;

--- a/src/utils/route-handlers-middleware/route-handlers-middleware.types.ts
+++ b/src/utils/route-handlers-middleware/route-handlers-middleware.types.ts
@@ -1,0 +1,55 @@
+import { type NextRequest, type NextResponse } from 'next/server';
+
+import type routeHandlersDefaultMiddlewares from './config/route-handlers-default-middlewares.config';
+
+export type MiddlewareContextReturn<K extends string = any, T = any> = [K, T];
+
+export type MiddlewareReturn = NextResponse | [any, any] | null | undefined;
+
+export type MiddlewareFunction<
+  ReturnT extends MiddlewareReturn = MiddlewareReturn,
+> = (
+  request: NextRequest,
+  options: { params: Record<string, string> },
+  context: Record<string, unknown>
+) => ReturnT;
+
+export type GetAllMiddlewaresReturnTypes<M extends MiddlewareFunction[]> = {
+  [K in keyof M]: M[K] extends MiddlewareFunction<infer ReturnT>
+    ? ReturnT extends MiddlewareReturn
+      ? ReturnT
+      : never
+    : never;
+};
+
+export type RequestHandlerFunction<
+  MiddlewareFunctionsT extends MiddlewareFunction[],
+  O extends { params: Record<string, string> },
+> = (
+  request: NextRequest,
+  options: O,
+  context: CombineMiddlewareContextType<
+    GetAllMiddlewaresReturnTypes<MiddlewareFunctionsT>
+  >
+) => any;
+
+type FilterValidMiddlewareContextTypes<M> = M extends [infer K, infer T]
+  ? { [key in K & string]: T }
+  : Record<string, never>; // Empty object if not valid
+
+// Recursively combine the return values of middlewares into a single object
+export type CombineMiddlewareContextType<
+  M extends
+    | readonly MiddlewareReturn[]
+    | typeof routeHandlersDefaultMiddlewares,
+> = M extends readonly [
+  infer First,
+  ...infer Rest extends readonly MiddlewareReturn[],
+]
+  ? FilterValidMiddlewareContextTypes<First> &
+      CombineMiddlewareContextType<Rest>
+  : Record<string, never>;
+
+export type DefaultMiddlewaresContext = CombineMiddlewareContextType<
+  GetAllMiddlewaresReturnTypes<typeof routeHandlersDefaultMiddlewares>
+>;


### PR DESCRIPTION
### Summary
Create middleware utility to encapsulate reusable logic before rest apis.

### Middlewares design
- Each middleware can return either a `NextResponse`, `null`, `undefined` or a tuple representing `[key,value]` to add to the context.
- If a middleware returned a NextResponse remaining middlewares wont execute and the value is returned.
- If a context tuple is returned it will be added to the current context object and passed to the next middleware. 
- After all middlewares are executed an non of them return `NextResponse` the handler would be invoked with the computed context.

### Changes
- Create middlewares util
- Create `grpc methods` middleware
- grpc methods middleware can accept `grpcMetadata` from the context
- refactor `grpc-client`