### PR TITLE
Disable prefetch by default

### DIFF
--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -5,7 +5,12 @@ import NextLink from 'next/link';
 import { styled } from './link.styles';
 import { type Props } from './link.types';
 
-export default function Link({ href, children, prefetch = false, ...restProps }: Props) {
+export default function Link({
+  href,
+  children,
+  prefetch = false,
+  ...restProps
+}: Props) {
   return (
     <styled.LinkBase {...restProps} $as={NextLink} href={href} disabled={!href}>
       {children}

--- a/src/components/link/link.tsx
+++ b/src/components/link/link.tsx
@@ -5,7 +5,7 @@ import NextLink from 'next/link';
 import { styled } from './link.styles';
 import { type Props } from './link.types';
 
-export default function Link({ href, children, ...restProps }: Props) {
+export default function Link({ href, children, prefetch = false, ...restProps }: Props) {
   return (
     <styled.LinkBase {...restProps} $as={NextLink} href={href} disabled={!href}>
       {children}


### PR DESCRIPTION
### Summary
On Lists loading we prefetch all visible rows links which can be unnecessary in most cases. So we change the default prefetch to be disabled and it can be enabled case by case.

### Future plans
We can prefetch by default on hover to decrease waiting time