### PR TITLE
Rename stack trace url path to kebab case

### DIFF
--- a/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
@@ -6,9 +6,9 @@ import WorkflowSummaryTab from '@/views/workflow-summary-tab/workflow-summary-ta
 import type { WorkflowPageTabsContentsMap } from '../workflow-page-tab-content/workflow-page-tab-content.types';
 
 const workflowPageTabsContentsMapConfig = {
-  'summary': WorkflowSummaryTab,
-  'history': WorkflowHistory,
-  'queries': WorkflowQueries,
+  summary: WorkflowSummaryTab,
+  history: WorkflowHistory,
+  queries: WorkflowQueries,
   'stack-trace': WorkflowStackTrace,
 } as const satisfies WorkflowPageTabsContentsMap;
 

--- a/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-contents-map.config.ts
@@ -6,10 +6,10 @@ import WorkflowSummaryTab from '@/views/workflow-summary-tab/workflow-summary-ta
 import type { WorkflowPageTabsContentsMap } from '../workflow-page-tab-content/workflow-page-tab-content.types';
 
 const workflowPageTabsContentsMapConfig = {
-  summary: WorkflowSummaryTab,
-  history: WorkflowHistory,
-  queries: WorkflowQueries,
-  stackTrace: WorkflowStackTrace,
+  'summary': WorkflowSummaryTab,
+  'history': WorkflowHistory,
+  'queries': WorkflowQueries,
+  'stack-trace': WorkflowStackTrace,
 } as const satisfies WorkflowPageTabsContentsMap;
 
 export default workflowPageTabsContentsMapConfig;

--- a/src/views/workflow-page/config/workflow-page-tabs-error.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-error.config.ts
@@ -2,13 +2,13 @@ import getWorkflowPageErrorConfig from '../helpers/get-workflow-page-error-confi
 import { type WorkflowPageTabsErrorConfig } from '../workflow-page-tabs-error/workflow-page-tabs-error.types';
 
 const workflowPageTabsErrorConfig: WorkflowPageTabsErrorConfig = {
-  summary: (err) =>
+  'summary': (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow summary'),
-  history: (err) =>
+  'history': (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow history'),
-  queries: (err) =>
+  'queries': (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow queries'),
-  stackTrace: (err) =>
+  'stack-trace': (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow stack trace'),
 } as const;
 

--- a/src/views/workflow-page/config/workflow-page-tabs-error.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs-error.config.ts
@@ -2,11 +2,11 @@ import getWorkflowPageErrorConfig from '../helpers/get-workflow-page-error-confi
 import { type WorkflowPageTabsErrorConfig } from '../workflow-page-tabs-error/workflow-page-tabs-error.types';
 
 const workflowPageTabsErrorConfig: WorkflowPageTabsErrorConfig = {
-  'summary': (err) =>
+  summary: (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow summary'),
-  'history': (err) =>
+  history: (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow history'),
-  'queries': (err) =>
+  queries: (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow queries'),
   'stack-trace': (err) =>
     getWorkflowPageErrorConfig(err, 'Failed to load workflow stack trace'),

--- a/src/views/workflow-page/config/workflow-page-tabs.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs.config.ts
@@ -26,7 +26,7 @@ const workflowPageTabsConfig = [
     artwork: MdOutlineManageSearch,
   },
   {
-    key: 'stackTrace',
+    key: 'stack-trace',
     title: 'Stack Trace',
     artwork: MdOutlineTerminal,
   },

--- a/src/views/workflow-page/workflow-page-tabs-error/__tests__/workflow-page-tabs-error.test.tsx
+++ b/src/views/workflow-page/workflow-page-tabs-error/__tests__/workflow-page-tabs-error.test.tsx
@@ -24,13 +24,13 @@ jest.mock(
   '../../config/workflow-page-tabs-error.config',
   () =>
     ({
-      'summary': () => ({
+      summary: () => ({
         message: 'summary error',
       }),
-      'history': () => ({
+      history: () => ({
         message: 'history error',
       }),
-      'queries': () => ({
+      queries: () => ({
         message: 'queries error',
       }),
       'stack-trace': () => ({

--- a/src/views/workflow-page/workflow-page-tabs-error/__tests__/workflow-page-tabs-error.test.tsx
+++ b/src/views/workflow-page/workflow-page-tabs-error/__tests__/workflow-page-tabs-error.test.tsx
@@ -24,17 +24,17 @@ jest.mock(
   '../../config/workflow-page-tabs-error.config',
   () =>
     ({
-      summary: () => ({
+      'summary': () => ({
         message: 'summary error',
       }),
-      history: () => ({
+      'history': () => ({
         message: 'history error',
       }),
-      queries: () => ({
+      'queries': () => ({
         message: 'queries error',
       }),
-      stackTrace: () => ({
-        message: 'stackTrace error',
+      'stack-trace': () => ({
+        message: 'stack trace error',
       }),
     }) as const satisfies WorkflowPageTabsErrorConfig
 );

--- a/src/views/workflow-stack-trace/__tests__/workflow-stack-trace.test.tsx
+++ b/src/views/workflow-stack-trace/__tests__/workflow-stack-trace.test.tsx
@@ -119,7 +119,7 @@ async function setup({
           cluster: 'test-cluster',
           runId: 'test-runid',
           workflowId: 'test-workflowId',
-          workflowTab: 'stackTrace',
+          workflowTab: 'stack-trace',
         }}
       />
     </Suspense>,


### PR DESCRIPTION
### Summary
Change url for stack trace page into kebab case to follow conventions. 

 
### Extra Thoughts
Since we depend on the tab key both in the url and code, making the key kebab case to fix the url forces us to use string object keys for tabs with kebab case keys.

This looks unusual.. My attempts to fix this was to add another tab config representing `urlFormattedKey` but this turned out to be more ugly solution as whenever we need to access tab configs using the current selected `urlTab` we need to translate that into actual tab key. This can get redundant and i preferred the current approach as it is more convenient.