### PR TITLE
Fix result json for non completed workflows

### DIFF
--- a/src/views/workflow-summary-tab/helpers/__tests__/get-workflow-result-json.test.ts
+++ b/src/views/workflow-summary-tab/helpers/__tests__/get-workflow-result-json.test.ts
@@ -1,0 +1,73 @@
+import {
+  type FormattedWorkflowExecutionCanceledEvent,
+  type FormattedWorkflowExecutionCompletedEvent,
+  type FormattedWorkflowExecutionFailedEvent,
+  type FormattedWorkflowExecutionTerminatedEvent,
+  type FormattedWorkflowExecutionTimedOutEvent,
+} from '@/utils/data-formatters/schema/format-history-event-schema';
+
+import getWorkflowResultJson from '../get-workflow-result-json';
+
+describe('getWorkflowResultJson', () => {
+  it('should return details for WorkflowExecutionCanceled event', () => {
+    const formattedEvent: FormattedWorkflowExecutionCanceledEvent = {
+      eventType: 'WorkflowExecutionCanceled',
+      details: 'canceled details',
+      decisionTaskCompletedEventId: '1',
+      eventId: 2,
+      timestamp: null,
+    };
+    expect(getWorkflowResultJson(formattedEvent)).toBe('canceled details');
+  });
+
+  it('should return details for WorkflowExecutionFailed event', () => {
+    const formattedEvent: FormattedWorkflowExecutionFailedEvent = {
+      eventType: 'WorkflowExecutionFailed',
+      reason: 'cadenceInternal:Generic',
+      details: 'failed details',
+      eventId: 2,
+      timestamp: null,
+      decisionTaskCompletedEventId: '1',
+    };
+    expect(getWorkflowResultJson(formattedEvent)).toBe('failed details');
+  });
+
+  it('should return details for WorkflowExecutionTerminated event', () => {
+    const formattedEvent: FormattedWorkflowExecutionTerminatedEvent = {
+      eventType: 'WorkflowExecutionTerminated',
+      details: 'terminated details',
+      reason: 'cadenceInternal:Generic',
+      eventId: 2,
+      timestamp: null,
+      identity: '1111',
+    };
+    expect(getWorkflowResultJson(formattedEvent)).toBe('terminated details');
+  });
+
+  it('should return result for WorkflowExecutionCompleted event', () => {
+    const formattedEvent: FormattedWorkflowExecutionCompletedEvent = {
+      eventType: 'WorkflowExecutionCompleted',
+      result: 'completed result',
+      decisionTaskCompletedEventId: '1',
+      eventId: 1,
+      timestamp: null,
+    };
+    expect(getWorkflowResultJson(formattedEvent)).toBe('completed result');
+  });
+
+  it('should return undefined for other eventType', () => {
+    const formattedEvent: FormattedWorkflowExecutionTimedOutEvent = {
+      eventType: 'WorkflowExecutionTimedOut',
+      eventId: 1,
+      timeoutType: 'TIMEOUT_TYPE_HEARTBEAT',
+      timestamp: null,
+    };
+    expect(getWorkflowResultJson(formattedEvent)).toBeUndefined();
+  });
+
+  it('should return undefined if eventType is undefined', () => {
+    const formattedEvent = {};
+    // @ts-expect-error empty eventType
+    expect(getWorkflowResultJson(formattedEvent)).toBeUndefined();
+  });
+});

--- a/src/views/workflow-summary-tab/helpers/get-workflow-result-json.ts
+++ b/src/views/workflow-summary-tab/helpers/get-workflow-result-json.ts
@@ -1,0 +1,17 @@
+import { type FormattedHistoryEvent } from '@/utils/data-formatters/schema/format-history-event-schema';
+
+export default function getWorkflowResultJson(
+  formattedEvent: FormattedHistoryEvent
+) {
+  const eventType = formattedEvent.eventType;
+  if (
+    eventType === 'WorkflowExecutionCanceled' ||
+    eventType === 'WorkflowExecutionFailed' ||
+    eventType === 'WorkflowExecutionTerminated'
+  )
+    return formattedEvent.details;
+
+  if (eventType === 'WorkflowExecutionCompleted') return formattedEvent.result;
+
+  return undefined;
+}

--- a/src/views/workflow-summary-tab/workflow-summary-tab.tsx
+++ b/src/views/workflow-summary-tab/workflow-summary-tab.tsx
@@ -18,6 +18,7 @@ import type { WorkflowPageTabContentProps } from '@/views/workflow-page/workflow
 import getWorkflowIsCompleted from '../workflow-page/helpers/get-workflow-is-completed';
 import useDescribeWorkflow from '../workflow-page/hooks/use-describe-workflow';
 
+import getWorkflowResultJson from './helpers/get-workflow-result-json';
 import WorkflowSummaryTabDetails from './workflow-summary-tab-details/workflow-summary-tab-details';
 import WorkflowSummaryTabJsonView from './workflow-summary-tab-json-view/workflow-summary-tab-json-view';
 import { cssStyles } from './workflow-summary-tab.styles';
@@ -58,10 +59,9 @@ export default function WorkflowSummaryTab({
     ? formatWorkflowHistoryEvent(closeEvent)
     : null;
 
-  const resultJson =
-    formattedCloseEvent && 'result' in formattedCloseEvent
-      ? formattedCloseEvent.result
-      : undefined;
+  const resultJson = formattedCloseEvent
+    ? getWorkflowResultJson(formattedCloseEvent)
+    : undefined;
 
   const isWorkflowRunning =
     !closeEvent ||


### PR DESCRIPTION
### Summary
Result json used to depend on showing the `result` property of closed event. This doesn't work for close events that have `details` property instead of `result`


### Changes
Create a utility to get the result json from close events

### Screenshots
![Screenshot 2024-11-01 at 17 21 41](https://github.com/user-attachments/assets/8cf30f3e-4793-4f11-8990-a1b112ab47c5)
