### PR TITLE
Coerce fork event version

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts
@@ -1,11 +1,28 @@
+import { ZodError } from 'zod';
+
+import logger from '@/utils/logger';
 import { allWorkflowEvents } from '@/views/workflow-history/__fixtures__/all-workflow-event-types';
 
 import formatWorkflowHistoryEvent from '..';
+
+jest.mock('@/utils/logger');
 
 describe('formatWorkflowHistoryEvent', () => {
   allWorkflowEvents.forEach((event) => {
     it(`should format workflow ${event.attributes} to match snapshot`, () => {
       expect(formatWorkflowHistoryEvent(event)).toMatchSnapshot();
     });
+  });
+  it(`should log error if parsing failed`, () => {
+    //@ts-expect-error pass event with missing fields
+    expect(
+      formatWorkflowHistoryEvent({
+        attributes: 'workflowExecutionStartedEventAttributes',
+      })
+    ).toBe(null);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { cause: expect.any(ZodError) },
+      'Failed to format workflow event'
+    );
   });
 });

--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts
@@ -14,8 +14,8 @@ describe('formatWorkflowHistoryEvent', () => {
     });
   });
   it(`should log error if parsing failed`, () => {
-    //@ts-expect-error pass event with missing fields
     expect(
+      //@ts-expect-error pass event with missing fields
       formatWorkflowHistoryEvent({
         attributes: 'workflowExecutionStartedEventAttributes',
       })

--- a/src/utils/data-formatters/format-workflow-history-event/index.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/index.ts
@@ -1,4 +1,5 @@
 import type { HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+import logger from '@/utils/logger';
 
 import {
   type FormattedHistoryEvent,
@@ -10,7 +11,11 @@ export default function formatWorkflowHistoryEvent(
 ): FormattedHistoryEvent | null {
   const schema = getFormatHistoryEventSchema(event);
   if (schema) {
-    const { data } = schema.safeParse(event);
+    const { data, error } = schema.safeParse(event);
+    if (error) {
+      logger.warn({ cause: error }, 'Failed to format workflow event');
+      return null;
+    }
     return data ?? null;
   }
   return null;

--- a/src/utils/data-formatters/schema/history-event-schema.ts
+++ b/src/utils/data-formatters/schema/history-event-schema.ts
@@ -315,7 +315,7 @@ export const decisionTaskFailedEventSchema = historyEventBaseSchema.extend({
     identity: z.string(),
     baseRunId: z.string(),
     newRunId: z.string(),
-    forkEventVersion: z.string(),
+    forkEventVersion: z.coerce.string(),
     binaryChecksum: z.string(),
     requestId: z.string(),
   }),


### PR DESCRIPTION
### Summary
Grpc returns `forkEventVersion` as a number in case the value is `0`. So we need to use `coerce` to make sure it is parsed into a string