### PR TITLE
Add partitionConfig to task list fixtures

### DIFF
--- a/src/route-handlers/describe-task-list/__fixtures__/mock-task-list-response.ts
+++ b/src/route-handlers/describe-task-list/__fixtures__/mock-task-list-response.ts
@@ -20,6 +20,7 @@ export const mockDecisionTaskListResponse: DescribeTaskListResponse = {
     },
   ],
   taskListStatus: null,
+  partitionConfig: null,
 };
 
 export const mockActivityTaskListResponse: DescribeTaskListResponse = {
@@ -42,4 +43,5 @@ export const mockActivityTaskListResponse: DescribeTaskListResponse = {
     },
   ],
   taskListStatus: null,
+  partitionConfig: null,
 };


### PR DESCRIPTION
## Summary 
Add null partitionConfig (added [here](https://github.com/uber/cadence-idl/commit/b527eebaaeaa3cfbdc491f84040e5a27603222d8)) to task list fixtures to fix failing type checks 

## Test plan
Ran typecheck locally.